### PR TITLE
Transaction refactor.

### DIFF
--- a/src/schemas/block.json
+++ b/src/schemas/block.json
@@ -108,7 +108,7 @@
 						"title": "Full transactions",
 						"type": "array",
 						"items": {
-							"$ref": "#/components/schemas/SignedTransaction"
+							"$ref": "#/components/schemas/TransactionSigned"
 						}
 					}
 				]

--- a/src/schemas/transaction.json
+++ b/src/schemas/transaction.json
@@ -296,7 +296,7 @@
 					}
 				}
 			},
-			{ "$ref": "#/components/schemas/SignedTransaction"}
+			{ "$ref": "#/components/schemas/TransactionSigned"}
 		]
 	}
 }

--- a/src/schemas/transaction.json
+++ b/src/schemas/transaction.json
@@ -241,7 +241,7 @@
 			{ "$ref": "#/components/schemas/TransactionLegacyUnsigned"},
 			{
 				"title": "Legacy transaction signature properties.",
-				"required": [ "yParity", "r", "s" ],
+				"required": [ "v", "r", "s" ],
 				"properties": {
 					"v": {
 						"title": "v",

--- a/src/schemas/transaction.json
+++ b/src/schemas/transaction.json
@@ -21,13 +21,227 @@
 			"$ref": "#/components/schemas/AccessListEntry"
 		}
 	},
-	"SignedTransaction": {
-		"title": "Signed transaction object",
+	"TransactionWithSender": {
+		"title": "Transaction object with sender",
 		"type": "object",
 		"allOf": [
-			{ "$ref": "#/components/schemas/Transaction" },
 			{
-				"required": ["v", "r", "s"],
+				"required": ["from"],
+				"properties": {
+					"from": {
+						"title": "from",
+						"$ref": "#/components/schemas/address"
+					}
+				}
+			},
+			{ "$ref": "#/components/schemas/TransactionUnsigned" }
+		]
+	},
+	"Transaction1559Unsigned": {
+		"type": "object",
+		"title": "EIP-1559 transaction.",
+		"required": [ "type", "nonce", "gas", "value", "input", "maxFeePerGas", "maxPriorityFeePerGas", "chainId", "accessList" ],
+		"properties": {
+			"type": {
+				"title": "type",
+				"$ref": "#/components/schemas/byte"
+			},
+			"nonce": {
+				"title": "nonce",
+				"$ref": "#/components/schemas/uint"
+			},
+			"to": {
+				"title": "to address",
+				"$ref": "#/components/schemas/address"
+			},
+			"gas": {
+				"title": "gas limit",
+				"$ref": "#/components/schemas/uint"
+			},
+			"value": {
+				"title": "value",
+				"$ref": "#/components/schemas/uint"
+			},
+			"input": {
+				"title": "input data",
+				"$ref": "#/components/schemas/bytes"
+			},
+			"maxPriorityFeePerGas": {
+				"title": "max priority fee per gas",
+				"description": "Maximum fee per gas the sender is willing to pay to miners in wei",
+				"$ref": "#/components/schemas/uint"
+			},
+			"maxFeePerGas": {
+				"title": "max fee per gas",
+				"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei",
+				"$ref": "#/components/schemas/uint"
+			},
+			"accessList": {
+				"title": "accessList",
+				"description": "EIP-2930 access list",
+				"$ref": "#/components/schemas/AccessList"
+			},
+			"chainId": {
+				"title": "chainId",
+				"description": "Chain ID that this transaction is valid on.",
+				"$ref": "#/components/schemas/uint"
+			}
+		}
+	},
+	"Transaction2930Unsigned": {
+		"type": "object",
+		"title": "EIP-2930 transaction.",
+		"required": [ "type", "nonce", "gas", "value", "input", "gasPrice", "chainId", "accessList" ],
+		"properties": {
+			"type": {
+				"title": "type",
+				"$ref": "#/components/schemas/byte"
+			},
+			"nonce": {
+				"title": "nonce",
+				"$ref": "#/components/schemas/uint"
+			},
+			"to": {
+				"title": "to address",
+				"$ref": "#/components/schemas/address"
+			},
+			"gas": {
+				"title": "gas limit",
+				"$ref": "#/components/schemas/uint"
+			},
+			"value": {
+				"title": "value",
+				"$ref": "#/components/schemas/uint"
+			},
+			"input": {
+				"title": "input data",
+				"$ref": "#/components/schemas/bytes"
+			},
+			"gasPrice": {
+				"title": "gas price",
+				"description": "The gas price willing to be paid by the sender in wei",
+				"$ref": "#/components/schemas/uint"
+			},
+			"accessList": {
+				"title": "accessList",
+				"description": "EIP-2930 access list",
+				"$ref": "#/components/schemas/AccessList"
+			},
+			"chainId": {
+				"title": "chainId",
+				"description": "Chain ID that this transaction is valid on.",
+				"$ref": "#/components/schemas/uint"
+			}
+		}
+	},
+	"TransactionLegacyUnsigned": {
+		"type": "object",
+		"title": "Legacy transaction.",
+		"required": [ "type", "nonce", "gas", "value", "input", "gasPrice" ],
+		"properties": {
+			"type": {
+				"title": "type",
+				"$ref": "#/components/schemas/byte"
+			},
+			"nonce": {
+				"title": "nonce",
+				"$ref": "#/components/schemas/uint"
+			},
+			"to": {
+				"title": "to address",
+				"$ref": "#/components/schemas/address"
+			},
+			"gas": {
+				"title": "gas limit",
+				"$ref": "#/components/schemas/uint"
+			},
+			"value": {
+				"title": "value",
+				"$ref": "#/components/schemas/uint"
+			},
+			"input": {
+				"title": "input data",
+				"$ref": "#/components/schemas/bytes"
+			},
+			"gasPrice": {
+				"title": "gas price",
+				"description": "The gas price willing to be paid by the sender in wei",
+				"$ref": "#/components/schemas/uint"
+			},
+			"chainId": {
+				"title": "chainId",
+				"description": "Chain ID that this transaction is valid on.",
+				"$ref": "#/components/schemas/uint"
+			}
+		}
+	},
+	"TransactionUnsigned": {
+		"oneOf": [
+			{ "$ref": "#/components/schemas/Transaction1559Unsigned"},
+			{ "$ref": "#/components/schemas/Transaction2930Unsigned"},
+			{ "$ref": "#/components/schemas/TransactionLegacyUnsigned"}
+		]
+	},
+	"Transaction1559Signed": {
+		"title": "Signed 1559 Transaction",
+		"type": "object",
+		"allOf": [
+			{ "$ref": "#/components/schemas/Transaction1559Unsigned"},
+			{
+				"title": "EIP-1559 transaction signature properties.",
+				"required": [ "yParity", "r", "s" ],
+				"properties": {
+					"yParity": {
+						"title": "yParity",
+						"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.",
+						"$ref": "#/components/schemas/uint"
+					},
+					"r": {
+						"title": "r",
+						"$ref": "#/components/schemas/uint"
+					},
+					"s": {
+						"title": "s",
+						"$ref": "#/components/schemas/uint"
+					}
+				}
+			}
+		]
+	},
+	"Transaction2930Signed": {
+		"title": "Signed 2930 Transaction",
+		"type": "object",
+		"allOf": [
+			{ "$ref": "#/components/schemas/Transaction2930Unsigned"},
+			{
+				"title": "EIP-2930 transaction signature properties.",
+				"required": [ "yParity", "r", "s" ],
+				"properties": {
+					"yParity": {
+						"title": "yParity",
+						"description": "The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.",
+						"$ref": "#/components/schemas/uint"
+					},
+					"r": {
+						"title": "r",
+						"$ref": "#/components/schemas/uint"
+					},
+					"s": {
+						"title": "s",
+						"$ref": "#/components/schemas/uint"
+					}
+				}
+			}
+		]
+	},
+	"TransactionLegacySigned": {
+		"title": "Signed Legacy Transaction",
+		"type": "object",
+		"allOf": [
+			{ "$ref": "#/components/schemas/TransactionLegacyUnsigned"},
+			{
+				"title": "Legacy transaction signature properties.",
+				"required": [ "yParity", "r", "s" ],
 				"properties": {
 					"v": {
 						"title": "v",
@@ -45,98 +259,11 @@
 			}
 		]
 	},
-	"TransactionWithSender": {
-		"title": "Transaction object with sender",
-		"type": "object",
-		"allOf": [
-			{
-				"required": ["from"],
-				"properties": {
-					"from": {
-						"title": "from",
-						"$ref": "#/components/schemas/address"
-					}
-				}
-			},
-			{ "$ref": "#/components/schemas/Transaction" }
-		]
-	},
-	"Transaction": {
-		"type": "object",
-		"title": "Transaction object",
-		"allOf": [
-			{
-				"required": ["nonce", "gas", "value", "input"],
-				"properties": {
-					"type": {
-						"title": "type",
-						"$ref": "#/components/schemas/byte"
-					},
-					"nonce": {
-						"title": "nonce",
-						"$ref": "#/components/schemas/uint"
-					},
-					"to": {
-						"title": "to address",
-						"$ref": "#/components/schemas/address"
-					},
-					"gas": {
-						"title": "gas limit",
-						"$ref": "#/components/schemas/uint"
-					},
-					"value": {
-						"title": "value",
-						"$ref": "#/components/schemas/uint"
-					},
-					"input": {
-						"title": "input data",
-						"$ref": "#/components/schemas/bytes"
-					},
-					"accessList": {
-						"title": "accessList",
-						"description": "EIP-2930 access list",
-						"$ref": "#/components/schemas/AccessList"
-					}
-				}
-			},
-			{
-				"oneOf": [
-					{
-						"title": "EIP-1559 fee market parameters",
-						"type": "object",
-						"description": "EIP-1559 dynamic fee transactions have two fee parameters.",
-						"required": [
-							"maxFeePerGas",
-							"maxPriorityFeePerGas"
-						],
-						"properties": {
-							"maxPriorityFeePerGas": {
-								"title": "max priority fee per gas",
-								"description": "Maximum fee per gas the sender is willing to pay to miners in wei",
-								"$ref": "#/components/schemas/uint"
-							},
-							"maxFeePerGas": {
-								"title": "max fee per gas",
-								"description": "The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei",
-								"$ref": "#/components/schemas/uint"
-							}
-						}
-					},
-					{
-						"title": "Legacy fee market parameters",
-						"type": "object",
-						"description": "Legacy transactions and EIP-2930 access list transaction include this parameter.",
-						"required": ["gasPrice"],
-						"properties": {
-							"gasPrice": {
-								"title": "gas price",
-								"description": "The gas price willing to be paid by the sender in wei",
-								"$ref": "#/components/schemas/uint"
-							}
-						}
-					}
-				]
-			}
+	"TransactionSigned": {
+		"oneOf": [
+			{ "$ref": "#/components/schemas/Transaction1559Signed"},
+			{ "$ref": "#/components/schemas/Transaction2930Signed"},
+			{ "$ref": "#/components/schemas/TransactionLegacySigned"}
 		]
 	},
 	"TransactionInfo": {


### PR DESCRIPTION
An EIP-1559 signature is only valid on an EIP-1559 transaction, you cannot have a 1559 signature on a legacy transaction.  Because of this, I have broken things out so that there are separate concrete base types that then are specifically inherited by the signature types.  I also added rollup types for use in places like the TransactionInfo and TransactionWithSender.

I also renamed things so everything starts with `Transaction` and follows a fairly uniform naming scheme.  This will hopefully help with sorting and auto-complete tools.

Someone should double-check my work, I think I correctly set everything up, but a lot of copy/pasting happened and it is definitely possible I screwed something up.