### PR TITLE
Engine API: make preparePayload return an object

### DIFF
--- a/src/engine/interop/specification.md
+++ b/src/engine/interop/specification.md
@@ -58,7 +58,8 @@ This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/cons
 - `feeRecipient`: `DATA`, 20 Bytes - suggested value for the `coinbase` field of the new payload
 
 #### Returns
-1. `payloadId|Error`: `QUANTITY`, 64 Bits - Identifier of the payload building process
+`Object|Error` - Either instance of response object or an error. Response object:
+1. `payloadId`: `QUANTITY`, 64 Bits - Identifier of the payload building process
 
 #### Specification
 


### PR DESCRIPTION
### What's done?

The `engine_preparePayload` return type is changed from `payloadId|Error` to `Object|Error` for the sake of the future compatibility, i.e. this change allows for adding more data to the response of this method preserving backward compatibility.