### PR TITLE
Create main version of specifiation.md for engineAPI

### DIFF
--- a/src/engine/README.md
+++ b/src/engine/README.md
@@ -3,8 +3,12 @@
 The Engine JSON-RPC API is a collection of methods that all execution clients implement.
 This interface allows the communication between consensus and execution layers of the two-component post-Merge Ethereum Client.
 
+This API is in *active development* and currently [specified as a markdown document](./specification.md).
+A schema will follow once the specification stabilizes.
+
 ## Merge Interop
 
-Documentation of the subset of the Engine API methods for the Merge Interop:
+Documentation of the subset of the Engine API methods for the [Merge Interop](http://interop.merge.wiki/):
 - [Specification](./interop/specification.md)
-- Schema *in progress*
+
+*Note*: This interop specification is to be soon deprecated for the [mainnet target](./specification.md).

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -1,10 +1,6 @@
-# Engine API. Interop edition
+# Engine API
 
-***WARNING***: This document will soon be deprecated in favor of the [mainnet target](../specification.md).
-
-This document specifies a subset of the Engine API methods that are required to be implemented for the Merge interop.
-
-*Note*: Sync API design is yet a draft and considered optional for the interop.
+This document specifies the Engine API methods that the Consensus Layer uses to interact with the Execution Layer.
 
 ## Underlying protocol
 


### PR DESCRIPTION
Create a "mainnet" copy of the engine specs to begin work on changes. Doing this in an isolated PR so subsequent feature change PRs are sane to review.

* copy over specification.md to `src/engine`. 
* note impending deprecation of interop engine spec in `src/engine/interop/specification.md` and in `src/engine/README.md`