### PR TITLE
Engine API: add validAncestorHash to engine_executePayload

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -113,7 +113,7 @@ This structure contains the attributes required to initiate a payload build proc
 
 2. Client software **MUST** discard the payload if it's deemed invalid.
 
-3. Client software **MUST** return `{status: SYNCING, lastestValidHash: null}` if the client software does not have the requisite data available locally to validate the payload and cannot retrieve this required data in less than `SLOTS_PER_SECOND / 30` (0.4s in the Mainnet configuration) or if the sync process is already in progress. In the event that requisite data to validate the payload is missing (e.g. does not have payload identified by `parentHash`), the client software **SHOULD** initiate the sync process.
+3. Client software **MUST** return `{status: SYNCING, lastestValidHash: null}` if the sync process is already in progress or if requisite data for payload validation is missing. In the event that requisite data to validate the payload is missing (e.g. does not have payload identified by `parentHash`), the client software **SHOULD** initiate the sync process.
 
 ### engine_forkchoiceUpdated
 


### PR DESCRIPTION
*NOTE: Currently based on #83 and pointed to that PR as the base. Trying to keep the diff legible while continuing to be able to work. Will rebase and point this PR to `main` once #83 is merged*

`INVALID` is insufficient to parse the validity of ancestor blocks that previously returned `SYNCING`. As per discussions at interop, add `validAncestorHash` in the return value to point to the latest (by block number) valid ancestor to the payload that is being processed. In the event of `INVALID`, this can thus invalidate an arbitrary number of blocks in the chain starting with the payload.

Did discuss this with @holiman to ensure that this is feasible in geth.

Additionally:
* Provide guidance on how long to try to resolve a payload's dependencies before responding with `SYNCING` -- `SLOTS_PER_SECOND / 30` (0.4s)
* Do not make PoW vs PoS an exceptional case wrt `SYNCING` return value. Enforcing finding of dependencies of blocks with PoW ancestors rather than returning `SYNCING` could result in deadlocks.

