### PR TITLE
Engine API: expose eth namespace to reduce to single connection

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -9,7 +9,12 @@ This specification is based on [Ethereum JSON-RPC API](https://eth.wiki/json-rpc
 * Message format and encoding notation
 * [Error codes improvement proposal](https://eth.wiki/json-rpc/json-rpc-error-codes-improvement-proposal)
 
-Client software **MUST** expose Engine API at a port independent from JSON-RPC API. The default port for the Engine API is 8550 for HTTP and 8551 for WebSocket.
+Client software **MUST** expose Engine API at a port independent from JSON-RPC API.
+The default port for the Engine API is 8550 for HTTP and 8551 for WebSocket.
+The Engine API is exposed under the `engine` namespace.
+
+To facilitate an Engine API consumer to access state and logs (e.g. proof-of-stake deposits) through the same connection,
+the client **MAY** also expose the `eth` namespace. 
 
 ## Versioning
 


### PR DESCRIPTION
Currently beacon-nodes use the `eth` namespace to read state and event-logs, to track beacon-chain deposits (see [deposit contract consensus specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/deposit-contract.md)), as well as "eth1-data-votes" (legacy, but this voting process will still be present in the merge, until later cleanup fork).

During the merge-interop event I think @holiman (iirc?) proposed to expose the `eth` namespace under this same new secured engine-specific port, so beacon-nodes do not have to open two different connections to the same execution node.

All execution-layer clients already support these namespaces as "modules" of some kind, and this modularity means the `eth` namespace can be exposed on this endpoint with minimal changes in the EL, and reduces changes on the CL (would otherwise need to support two different connections for engine and deposits work).

Assuming this reduction in setup complexity/work is desired, I am not sure if it should be a `MAY` or `MUST` in the spec. Is there any case where we do not like to expose `eth` under this endpoint?
