### PR TITLE
Version payload id computation and collision-resistant payload IDs

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -175,14 +175,14 @@ This structure contains the attributes required to initiate a payload build proc
 
 ##### Hashing to `payloadId`
 
-The `payloadId` is the first `8` bytes of the `sha256` hash of the concatenation of version byte and inputs:
+The `payloadId` is the `sha256` hash of the concatenation of version byte and inputs:
 ```python
 PAYLOAD_ID_VERSION_BYTE = b"\x00"
-sha256(PAYLOAD_ID_VERSION_BYTE + headBlockHash + payloadAttributes.timestamp.to_bytes(8, "big") + payloadAttributes.random + payloadAttributes.feeRecipient)[0:8]
+sha256(PAYLOAD_ID_VERSION_BYTE + headBlockHash + payloadAttributes.timestamp.to_bytes(8, "big") + payloadAttributes.random + payloadAttributes.feeRecipient)
 ```
 Note that the timestamp is encoded as big-endian and padded fully to 8 bytes.
 
-This ID is versioned and may change over time, opaque to the engine API user, and **MUST** always be consistent between `engine_forkchoiceUpdated` and `engine_getPayload`. 
+This ID-computation is versioned and may change over time, opaque to the engine API user, and **MUST** always be consistent between `engine_forkchoiceUpdated` and `engine_getPayload`. 
 
 
 ### engine_getPayloadV1

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -191,7 +191,7 @@ This ID-computation is versioned and may change over time, opaque to the engine 
 
 * method: `engine_getPayloadV1`
 * params:
-  1. `payloadId`: `DATA`, 8 bytes - Identifier of the payload build process
+  1. `payloadId`: `DATA`, 32 bytes - Identifier of the payload build process
 
 #### Response
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -186,7 +186,6 @@ This ID-computation is versioned and may change over time, opaque to the engine 
 The `PAYLOAD_ID_VERSION_BYTE` **SHOULD** be updated if the intent or typing of the payload production inputs changes,
 such that a payload cache can be safely shared between current and later versions of `engine_forkchoiceUpdated`. 
 
-
 ### engine_getPayloadV1
 
 #### Request

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -165,13 +165,25 @@ This structure contains the attributes required to initiate a payload build proc
 3. Client software **MUST** return `SYNCING` status if the payload identified by either the `headBlockHash` or the `finalizedBlockHash` is unknown or if the sync process is in progress. In the event that either the `headBlockHash` or the `finalizedBlockHash` is unknown, the client software **SHOULD** initiate the sync process.
 
 4. Client software **MUST** begin a payload build process building on top of `headBlockHash` if `payloadAttributes` is not `null` and the client is not `SYNCING`. The build process is specified as:
-  * The payload build process **MUST** be identifid via `payloadId` where `payloadId` is defined as the first `8` bytes of the `sha256` hash of concatenation of `headBlockHash`, `payloadAttributes.timestamp`, `payloadAttributes.random`, and `payloadAttributes.feeRecipient` where `payloadAttributes.timestamp` is encoded as big-endian and padded fully to 8 bytes -- i.e. `sha256(headBlockHash + timestamp + random + feeRecipient)[0:8]`.
+  * The payload build process **MUST** be identified via `payloadId` where `payloadId` is defined as the hash of the block-production inputs, see [Hashing to `payloadId`](#hashing-to-payloadid).
   * Client software **MUST** set the payload field values according to the set of parameters passed into this method with exception of the `feeRecipient`. The prepared `ExecutionPayload` **MAY** deviate the `coinbase` field value from what is specified by the `feeRecipient` parameter.
   * Client software **SHOULD** build the initial version of the payload which has an empty transaction set.
   * Client software **SHOULD** start the process of updating the payload. The strategy of this process is implementation dependent. The default strategy is to keep the transaction set up-to-date with the state of local mempool.
   * Client software **SHOULD** stop the updating process when either a call to `engine_getPayload` with the build process's `payloadId` is made or [`SECONDS_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#time-parameters-1) (currently set to 12 in the Mainnet configuration) seconds have passed since the point in time identified by the `timestamp` parameter.
 
 5. If any of the above fails due to errors unrelated to the client software's normal `SYNCING` status, the client software **MUST** return an error.
+
+##### Hashing to `payloadId`
+
+The `payloadId` is the first `8` bytes of the `sha256` hash of the concatenation of version byte and inputs:
+```python
+PAYLOAD_ID_VERSION_BYTE = b"\x00"
+sha256(PAYLOAD_ID_VERSION_BYTE + headBlockHash + payloadAttributes.timestamp.to_bytes(8, "big") + payloadAttributes.random + payloadAttributes.feeRecipient)[0:8]
+```
+Note that the timestamp is encoded as big-endian and padded fully to 8 bytes.
+
+This ID is versioned and may change over time, opaque to the engine API user, and **MUST** always be consistent between `engine_forkchoiceUpdated` and `engine_getPayload`. 
+
 
 ### engine_getPayloadV1
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -182,7 +182,9 @@ sha256(PAYLOAD_ID_VERSION_BYTE + headBlockHash + payloadAttributes.timestamp.to_
 ```
 Note that the timestamp is encoded as big-endian and padded fully to 8 bytes.
 
-This ID-computation is versioned and may change over time, opaque to the engine API user, and **MUST** always be consistent between `engine_forkchoiceUpdated` and `engine_getPayload`. 
+This ID-computation is versioned and may change over time, opaque to the engine API user, and **MUST** always be consistent between `engine_forkchoiceUpdated` and `engine_getPayload`.
+The `PAYLOAD_ID_VERSION_BYTE` **SHOULD** be updated if the intent or typing of the payload production inputs changes,
+such that a payload cache can be safely shared between current and later versions of `engine_forkchoiceUpdated`. 
 
 
 ### engine_getPayloadV1


### PR DESCRIPTION
- Define `PAYLOAD_ID_VERSION_BYTE`: if we ever change the input types, but they happen to look the same when concatenated, the hash will be different.
- Move payload id computation to its own sub-section
- Fix previous typo in same line

Also, since the payload ID is `DATA`, not an integer, I see no reason to not just use a 32-byte identifier that is more resistant against collisions. **Can/should we change it to a 32 byte ID?**

If the actual intention is that collisions can happen, then we could change it to a `QUANTITY` and clarify that the engine-API user should check that the returned payload actually matches their original request (i.e. verify parent hash, timestamp, randomness attributes match expectation, and feeRecipient depending on trust).
