### PR TITLE
added BlockNumberOrTagOrHash to eth_estimateGas

### DIFF
--- a/src/eth/execute.json
+++ b/src/eth/execute.json
@@ -28,6 +28,12 @@
 				"schema": {
 					"$ref": "#/components/schemas/TransactionWithSender"
 				}
+			},
+			{
+				"name": "Block number, tag, or hash",
+				"schema": {
+					"$ref": "#/components/schemas/BlockNumberOrTagOrHash"
+				}
 			}
 		],
 		"result": {

--- a/src/schemas/block.json
+++ b/src/schemas/block.json
@@ -139,5 +139,22 @@
 				"$ref": "#/components/schemas/BlockTag"
 			}
 		]
+	},
+	"BlockNumberOrTagOrHash": {
+		"title": "Block number or tag",
+		"oneOf": [
+			{
+				"title": "Block number",
+				"$ref": "#/components/schemas/uint"
+			},
+			{
+				"title": "Block tag",
+				"$ref": "#/components/schemas/BlockTag"
+			},
+			{
+				"title":"Block hash",
+				"$ref": "#/components/schemas/hash32"
+			}
+		]
 	}
 }


### PR DESCRIPTION
added missing parameters to eth_estimateGas referenced in #99.
Found that TransactionWithSender schema doesn't render `from`  parameter. 
I will make an issue for this and hopefully fix it tomorrow.