### PR TITLE
Fix eth_submitWork parameters, allow 0x0 uint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "eth1.0-apis",
       "version": "0.0.0",
       "license": "CC0-1.0",
       "dependencies": {

--- a/src/eth/mining.json
+++ b/src/eth/mining.json
@@ -53,21 +53,21 @@
 		"summary": "Used for submitting a proof-of-work solution.",
 		"params": [
 			{
-				"name": "Proof-of-work hash",
+				"name": "nonce",
+				"required": true,
+				"schema": {
+					"$ref": "#/components/schemas/bytes8"
+				}
+			},
+			{
+				"name": "hash",
 				"required": true,
 				"schema": {
 					"$ref": "#/components/schemas/bytes32"
 				}
 			},
 			{
-				"name": "seed hash",
-				"required": true,
-				"schema": {
-					"$ref": "#/components/schemas/bytes32"
-				}
-			},
-			{
-				"name": "difficulty",
+				"name": "digest",
 				"required": true,
 				"schema": {
 					"$ref": "#/components/schemas/bytes32"

--- a/src/schemas/base-types.json
+++ b/src/schemas/base-types.json
@@ -42,7 +42,7 @@
 	"uint": {
 		"title": "hex encoded unsigned integer",
 		"type": "string",
-		"pattern": "^0x[1-9a-f]+[0-9a-f]*$"
+		"pattern": "^0x([1-9a-f]+[0-9a-f]*|0)$"
 	},
 	"uint256": {
 		"title": "hex encoded unsigned integer",

--- a/src/schemas/base-types.json
+++ b/src/schemas/base-types.json
@@ -19,6 +19,11 @@
 		"type": "string",
 		"pattern": "^0x[0-9a-f]*$"
 	},
+	"bytes8": {
+		"title": "8 hex encoded bytes",
+		"type": "string",
+		"pattern": "^0x[0-9a-f]{16}$"
+	},
 	"bytes32": {
 		"title": "32 hex encoded bytes",
 		"type": "string",


### PR DESCRIPTION
addresses #119 by correcting the parameters, based on https://github.com/ethereum/go-ethereum/blob/d8ff53dfb8a516f47db37dbc7fd7ad18a1e8a125/consensus/ethash/api.go#L66-L84

also addresses #106 by making the pattern for `uint` match `0x0`