### PR TITLE
Engine API: refine message ordering section

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -9,6 +9,7 @@ This document specifies the Engine API methods that the Consensus Layer uses to 
 
 - [Underlying protocol](#underlying-protocol)
 - [Versioning](#versioning)
+- [Constants](#constants)
 - [Message ordering](#message-ordering)
 - [Load-balancing and advanced configurations](#load-balancing-and-advanced-configurations)
 - [Errors](#errors)
@@ -59,6 +60,12 @@ The versioning of the Engine API is defined as follows:
   * a set of structure fields
 * The specification **MAY** reference a method or a structure without the version suffix e.g. `engine_executePayload`. These statements should be read as related to all versions of the referenced method or structure.
 
+## Constants
+
+| Name | Value |
+| - | - |
+| `MESSAGE_ORDER_RESET_ID` | `0` |
+
 ## Message ordering
 
 Consensus Layer client software **MUST** utilize JSON-RPC request IDs that are strictly increasing.
@@ -67,6 +74,11 @@ the corresponding fork choice update events occurring in the system.
 
 Execution Layer client software **MUST NOT** process `engine_forkchoiceUpdated` method call
 if its JSON-RPC request ID is lower than the ID assigned to the previous call of this method.
+
+Consensus Layer client software **SHOULD** use `MESSAGE_ORDER_RESET_ID` as initial value of request ID
+to reset the ID cached by Execution Layer client software.
+If the ID of a request equals to `MESSAGE_ORDER_RESET_ID`, Execution Layer client software **MUST** process this request
+disregarding the ID of the previous one; it implies caching `MESSAGE_ORDER_RESET_ID` value as the previous request ID.
 
 ## Load-balancing and advanced configurations
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -78,7 +78,7 @@ if its JSON-RPC request ID is lower than the ID assigned to the previous call of
 Consensus Layer client software **SHOULD** use `MESSAGE_ORDER_RESET_ID` as initial value of request ID
 to reset the ID cached by Execution Layer client software.
 If the ID of a request equals to `MESSAGE_ORDER_RESET_ID`, Execution Layer client software **MUST** process this request
-disregarding the ID of the previous one; it implies caching `MESSAGE_ORDER_RESET_ID` value as the previous request ID.
+disregarding the ID of the previous one and use `MESSAGE_ORDER_RESET_ID` value as the latest previous request ID.
 
 ## Load-balancing and advanced configurations
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -78,7 +78,7 @@ if its JSON-RPC request ID is lower than the ID assigned to the previous call of
 Consensus Layer client software **SHOULD** use `MESSAGE_ORDER_RESET_ID` as initial value of request ID
 to reset the ID cached by Execution Layer client software.
 If the ID of a request equals to `MESSAGE_ORDER_RESET_ID`, Execution Layer client software **MUST** process this request
-disregarding the ID of the previous one and use `MESSAGE_ORDER_RESET_ID` value as the latest previous request ID.
+disregarding the ID of the previous one and use `MESSAGE_ORDER_RESET_ID` value as the latest previous request ID, effectively resetting the request ID event ordering.
 
 ## Load-balancing and advanced configurations
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -61,11 +61,12 @@ The versioning of the Engine API is defined as follows:
 
 ## Message ordering
 
-Consensus Layer client software **MUST** utilize JSON-RPC request IDs that are strictly
-increasing.
+Consensus Layer client software **MUST** utilize JSON-RPC request IDs that are strictly increasing.
+Request IDs assigned to `engine_forkchoiceUpdated` method calls **MUST** respect the order of
+the corresponding fork choice update events occurring in the system.
 
-Execution Layer client software **MUST** execute calls strictly in the order of request IDs
-to avoid degenerate race conditions.
+Execution Layer client software **MUST NOT** process `engine_forkchoiceUpdated` method call
+if its JSON-RPC request ID is lower than the ID assigned to the previous call of this method.
 
 ## Load-balancing and advanced configurations
 


### PR DESCRIPTION
Refines the Message ordering section of the Engine API.

The previous version of the spec had the following overlooks:
* CL could flip two `forkchoiceUpdated` messages *before* the IDs were assigned which could result in inconsistency of the head of the chain between the layers
* The restrictions on EL side were too strong. EL couldn't process two different messages in parallel which e.g. locks the client until `executePayload` processing is finished

Proposed changes:
* CL: add the requirement to respect the order of occurrence of fork choice updated event
* EL: restrict enforcement of processing order to `forkchoiceUpdated` calls only