### PR TITLE
Engine API: remove separate port for WebSocket protocol

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -41,7 +41,7 @@ This specification is based on [Ethereum JSON-RPC API](https://eth.wiki/json-rpc
 * [Error codes improvement proposal](https://eth.wiki/json-rpc/json-rpc-error-codes-improvement-proposal)
 
 Client software **MUST** expose Engine API at a port independent from JSON-RPC API.
-The default port for the Engine API is 8550 for HTTP and 8551 for WebSocket.
+The default port for the Engine API is 8550.
 The Engine API is exposed under the `engine` namespace.
 
 To facilitate an Engine API consumer to access state and logs (e.g. proof-of-stake deposits) through the same connection,


### PR DESCRIPTION
Removes a port for WebSocket protocol as the same port can be used by both, HTTP and WebSocket, protocols (and others):
* https://localhost:8550
* wss://localhost:8550

cc @holiman @MicahZoltu 