### PR TITLE
Engine API: Refine message ordering. Take 2

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -60,25 +60,13 @@ The versioning of the Engine API is defined as follows:
   * a set of structure fields
 * The specification **MAY** reference a method or a structure without the version suffix e.g. `engine_executePayload`. These statements should be read as related to all versions of the referenced method or structure.
 
-## Constants
-
-| Name | Value |
-| - | - |
-| `MESSAGE_ORDER_RESET_ID` | `0` |
-
 ## Message ordering
 
-Consensus Layer client software **MUST** utilize JSON-RPC request IDs that are strictly increasing.
-Request IDs assigned to `engine_forkchoiceUpdated` method calls **MUST** respect the order of
-the corresponding fork choice update events occurring in the system.
+Consensus Layer client software **MUST** respect the order of the corresponding fork choice update events
+when making calls to the `engine_forkchoiceUpdated` method.
 
-Execution Layer client software **MUST NOT** process `engine_forkchoiceUpdated` method call
-if its JSON-RPC request ID is lower than the ID assigned to the previous call of this method.
-
-Consensus Layer client software **SHOULD** use `MESSAGE_ORDER_RESET_ID` as initial value of request ID
-to reset the ID cached by Execution Layer client software.
-If the ID of a request equals to `MESSAGE_ORDER_RESET_ID`, Execution Layer client software **MUST** process this request
-disregarding the ID of the previous one and use `MESSAGE_ORDER_RESET_ID` value as the latest previous request ID, effectively resetting the request ID event ordering.
+Execution Layer client software **MUST** process `engine_forkchoiceUpdated` method calls
+in the same order as they have been received.
 
 ## Load-balancing and advanced configurations
 


### PR DESCRIPTION
Removes Message ordering mechanism based on request IDs. JSON-RPC request IDs might be difficult to get parsed depending on the JSON-RPC library. The new proposal doesn't rely on request IDs at all and removes the logic that is required to reset this ID, which in its turn introduces inconvenience for setups with multiple EL clients behind a load balancer.

The proposed approach doesn't require CL client software to send `forkchoiceUpdated` calls in a lock-step fashion. But it's based on the assumption that the underlying protocol doesn't mess up with the order of messages, i.e. if CL sends the following sequence of calls: `[fcU(A), fcU(B)]` then EL client will always receive `fcU(A)` before `fcU(B)`. This assumption gets broken if HTTP over multiple TCP sessions is used as the underlying communication protocol.