### PR TITLE
add feeRecipientDiff as return value

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -169,13 +169,13 @@ This structure contains the attributes required to initiate a payload build proc
     - `status`: `enum` - `"VALID" | "INVALID" | "SYNCING"`
     - `latestValidHash`: `DATA|null`, 32 Bytes - the hash of the most recent *valid* block in the branch defined by payload and its ancestors
     - `validationError`: `String|null` - a message providing additional details on the validation error if the payload is deemed `INVALID`
-    - `feeRecipientDiff`: `Quantity`, 256 Bits - the change in balance of the feeRecipient address
+    - `feeRecipientDiff`: `Quantity|null`, 256 Bits - the change in balance of the feeRecipient address
 * error: code and message set in case an exception happens while executing the payload.
 
 #### Specification
 
 1. Client software **MUST** validate the payload according to the execution environment rule set with modifications to this rule set defined in the [Block Validity](https://eips.ethereum.org/EIPS/eip-3675#block-validity) section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification) and return the validation result.
-    * If validation succeeds, return `{status: VALID, latestValidHash: payload.blockHash}`
+    * If validation succeeds, return `{status: VALID, latestValidHash: payload.blockHash, feeRecipientDiff: <value>}`
     * If validation fails, return `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the most recent *valid* ancestor of the invalid payload. That is, the valid ancestor of the payload with the highest `blockNumber`.
 
 2. Client software **MUST** discard the payload if it's deemed invalid.

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -169,6 +169,7 @@ This structure contains the attributes required to initiate a payload build proc
     - `status`: `enum` - `"VALID" | "INVALID" | "SYNCING"`
     - `latestValidHash`: `DATA|null`, 32 Bytes - the hash of the most recent *valid* block in the branch defined by payload and its ancestors
     - `validationError`: `String|null` - a message providing additional details on the validation error if the payload is deemed `INVALID`
+    - `feeRecipientDiff`: `Quantity`, 256 Bits - the change in balance of the feeRecipient address
 * error: code and message set in case an exception happens while executing the payload.
 
 #### Specification
@@ -184,6 +185,8 @@ This structure contains the attributes required to initiate a payload build proc
 4. Client software **MAY** provide additional details on the validation error if the payload is deemed `INVALID` by assigning the corresponding message to the `validationError` field.
 
 5. Client software **MUST** return `-32002: Invalid terminal block` error if the parent block is a PoW block that doesn't satisfy terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions). This check maps on the Transition block validity section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#transition-block-validity).
+
+6. Client software **MUST** calculate and return `feeRecipientDiff` as the difference in ETH balance of the `feeRecipient` address specified in [`ExecutionPayloadV1`](#ExecutionPayloadV1).
 
 ### engine_forkchoiceUpdatedV1
 
@@ -234,7 +237,9 @@ The payload build process is specified as follows:
 
 #### Response
 
-* result: [`ExecutionPayloadV1`](#ExecutionPayloadV1)
+* result: `object`
+    - [`ExecutionPayloadV1`](#ExecutionPayloadV1)
+    - `feeRecipientDiff`: `Quantity`, 256 Bits - the change in balance of the feeRecipient address
 * error: code and message set in case an exception happens while getting the payload.
 
 #### Specification
@@ -244,3 +249,5 @@ The payload build process is specified as follows:
 2. The call **MUST** return `-32001: Unknown payload` error if the build process identified by the `payloadId` does not exist.
 
 3. Client software **MAY** stop the corresponding build process after serving this call.
+
+4. Client software **MUST** calculate and return `feeRecipientDiff` as the difference in ETH balance of the `feeRecipient` address specified in [`ExecutionPayloadV1`](#ExecutionPayloadV1).


### PR DESCRIPTION
In order to perform profit switching between payloads constructed from multiple sources, the profit switcher needs to be made aware of the value of a payload produced locally and be able to measure the value of a payload produced by a third party.

For this, we need to define a standard way to measure the value of a payload and include it in the engine API.

I propose we define a new value called `feeRecipientDiff` which represents a signed integer denominating the change in balance of the `feeRecipient` address defined in the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/beacon-chain.md#executionpayload) object.

I avoided adding `feeRecipientDiff` directly to the [`ExecutionPayload`](dev/specs/merge/beacon-chain.md#executionpayload) object as it seemed to introduce unnecessary complexity with sending the value around the network and handling it as part of block validity.

Instead, `feeRecipientDiff` can be added as a return value to the [`engine_executePayloadV1`](https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.5/src/engine/specification.md#engine_executepayloadv1) and [`engine_getPayloadV1`](https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.5/src/engine/specification.md#engine_getpayloadv1) functions.

This is currently spec'ed as a mandatory return value as I expect making it optional will cause setup confusion when users configure their nodes.