### PR TITLE
Engine API: Make SYNCING response and according actions fork specific

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -215,7 +215,7 @@ This structure contains the attributes required to initiate a payload build proc
 
 1. Client software **MUST** return `{status: SUCCESS, payloadId: buildProcessId}` if `payloadAttributes` is not `null`, and **MUST** begin a payload build process building on top of `forkchoiceState.headBlockHash` and identified via `buildProcessId` value. The build process is specified in the [Payload build process](#payload-build-process) section.
 
-1. Client software **MUST** update the fork choice state and initiate a payload build process, and respond accordingly despite of the sync process being in progress if payloads identified by the `forkchoiceState.headBlockHash` and the `forkchoiceState.finalizedBlockHash` are known.
+1. Client software **MUST** update the fork choice state and initiate a payload build process, and respond accordingly even if the sync process is in progress on some branch if payloads identified by the `forkchoiceState.headBlockHash` and the `forkchoiceState.finalizedBlockHash` are known.
 
 1. Client software **MUST** return `-32002: Invalid terminal block` error if a block referenced by `forkchoiceState.headBlockHash` is a PoW block that doesn't satisfy terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions).
 


### PR DESCRIPTION
It is required by an optimistic sync https://github.com/ethereum/consensus-specs/pull/2770 that EL sync process and according responses are fork specific. It means that despite of the sync process that is catching up with the head of any fork an EL client software must still verify payloads, update fork choice state and initiate payload build processes on another fork if data that are requisite for these operations are available for a client software.

An example:
```
A -> B -> C <= canonical
\
  -> B' -> C' <= SYNCING
```
In this example `executePayload(D)`, where `C -> D` **MUST NOT** be affected by sync process that is catching up with `C'`. Also, `forkchoiceUpdated(finalized: A', head: D)` assuming that `A'` is finalized ancestor of `A` **MUST NOT** be affected by the aforementioned sync process, and it **MUST** initiate a payload build process if requested.

Also, tired of updating numbers in the list when changing the order of items, thus, utilizing Markdown to maintain ordered lists.