### PR TITLE
Corrected eth_getWork schema to use prefixItems instead of items for the result

### DIFF
--- a/src/eth/mining.json
+++ b/src/eth/mining.json
@@ -31,7 +31,7 @@
 			"name": "Current work",
 			"schema": {
 				"type": "array",
-				"items": [
+				"prefixItems": [
 					{
 						"title": "Proof-of-work hash",
 						"$ref": "#/components/schemas/bytes32"


### PR DESCRIPTION
I wrote something to parse `openrpc.json` and it failed to parse because `items` is an array, when it should be an object

`prefixItems` is an array of schemas, in order of the expected items in the array
vs
`items` is a single schema to apply to all elements of the array beyond `prefixItems`

from the [spec](https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.1)