### PR TITLE
Add output of ref'd openrpc document for other consumers

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -29,8 +29,7 @@ schemaFiles.forEach(file => {
     ...parsed,
   };
 });
-
-let spec = await dereferenceDocument({
+const doc = {
   openrpc: "1.2.4",
   info: {
     title: "Ethereum JSON-RPC Specification",
@@ -45,7 +44,11 @@ let spec = await dereferenceDocument({
   components: {
     schemas: schemas
   }
-})
+}
+let spec = await dereferenceDocument(doc);
+
+fs.writeFileSync('refs-openrpc.json', data);
+
 spec.components = {};
 
 function recursiveMerge(schema) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -47,7 +47,7 @@ const doc = {
 }
 let spec = await dereferenceDocument(doc);
 
-fs.writeFileSync('refs-openrpc.json', doc);
+fs.writeFileSync('refs-openrpc.json', JSON.stringify(doc, null, '\t'););
 
 spec.components = {};
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -47,7 +47,7 @@ const doc = {
 }
 let spec = await dereferenceDocument(doc);
 
-fs.writeFileSync('refs-openrpc.json', JSON.stringify(doc, null, '\t'););
+fs.writeFileSync('refs-openrpc.json', JSON.stringify(doc, null, '\t'));
 
 spec.components = {};
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -47,7 +47,7 @@ const doc = {
 }
 let spec = await dereferenceDocument(doc);
 
-fs.writeFileSync('refs-openrpc.json', data);
+fs.writeFileSync('refs-openrpc.json', doc);
 
 spec.components = {};
 


### PR DESCRIPTION
This adds a new file to the assembled spec deploy `refs-openrpc.json` which lets other projects ref parts of it like [here](https://github.com/MetaMask/api-specs/blob/main/methods/eth_sendTransaction.json#L8).

fixes #70 