### PR TITLE
Fixed build where refs were still dereffed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 openrpc.json
+refs-openrpc.json
 data.json
 schema.json
 *.dic

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -45,9 +45,10 @@ const doc = {
     schemas: schemas
   }
 }
-let spec = await dereferenceDocument(doc);
 
 fs.writeFileSync('refs-openrpc.json', JSON.stringify(doc, null, '\t'));
+
+let spec = await dereferenceDocument(doc);
 
 spec.components = {};
 


### PR DESCRIPTION
This moves `writeFile` to before deref, looks like it mutates it.