### PR TITLE
Engine API: extend semantics of `executePayload` and `forkchoiceUpdated` methods

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -226,7 +226,7 @@ The payload build process is specified as follows:
 
 #### Specification
 
-1. Client software **MUST** validate `blockHash` value as being equivalent to `Keccak256(RLP(ExecutionBlockHeader))`, where `ExecutionBlockHeader` is an object having a PoW block header structure. Fields of this object are set to the corresponding payload values and constant values according to the Block structure section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#block-structure), extended with the corresponding section of [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399#block-structure). Client software **MUST** run this validation in all cases even if this branch or any other branches of the block tree are in an active sync process.
+1. Client software **MUST** validate `blockHash` value as being equivalent to `Keccak256(RLP(ExecutionBlockHeader))`, where `ExecutionBlockHeader` is the execution layer block header (the former PoW block header structure). Fields of this object are set to the corresponding payload values and constant values according to the Block structure section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#block-structure), extended with the corresponding section of [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399#block-structure). Client software **MUST** run this validation in all cases even if this branch or any other branches of the block tree are in an active sync process.
 
 1. Client software **MAY** initiate a sync process if requisite data for payload validation is missing. Sync process is specified in the [Sync](#sync) section.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -16,18 +16,20 @@ This document specifies the Engine API methods that the Consensus Layer uses to 
   - [ExecutionPayloadV1](#executionpayloadv1)
   - [ForkchoiceStateV1](#forkchoicestatev1)
   - [PayloadAttributesV1](#payloadattributesv1)
+  - [PayloadStatusV1](#payloadstatusv1)
+- [Routines](#routines)
+  - [Payload validation](#payload-validation)
+  - [Sync](#sync)
+  - [Payload building](#payload-building)
 - [Core](#core)
   - [engine_newPayloadV1](#engine_newpayloadv1)
     - [Request](#request)
     - [Response](#response)
     - [Specification](#specification)
-      - [Payload validation process](#payload-validation-process)
-      - [Sync process](#sync-process)
   - [engine_forkchoiceUpdatedV1](#engine_forkchoiceupdatedv1)
     - [Request](#request-1)
     - [Response](#response-1)
     - [Specification](#specification-1)
-      - [Payload build process](#payload-build-process)
   - [engine_getPayloadV1](#engine_getpayloadv1)
     - [Request](#request-2)
     - [Response](#response-2)
@@ -38,6 +40,7 @@ This document specifies the Engine API methods that the Consensus Layer uses to 
 ## Underlying protocol
 
 This specification is based on [Ethereum JSON-RPC API](https://eth.wiki/json-rpc/API) and inherits the following properties of this standard:
+
 * Supported communication protocols (HTTP and WebSocket)
 * Message format and encoding notation
 * [Error codes improvement proposal](https://eth.wiki/json-rpc/json-rpc-error-codes-improvement-proposal)
@@ -52,6 +55,7 @@ the client **MUST** also expose the `eth` namespace.
 ## Versioning
 
 The versioning of the Engine API is defined as follows:
+
 * The version of each method and structure is independent from versions of other methods and structures.
 * The `VX`, where the `X` is the number of the version, is suffixed to the name of each method and structure.
 * The version of a method or a structure **MUST** be incremented by one if any of the following is changed:
@@ -125,6 +129,7 @@ Fields having `DATA` and `QUANTITY` types **MUST** be encoded according to the [
 ### ExecutionPayloadV1
 
 This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#ExecutionPayload) structure of the beacon chain spec. The fields are encoded as follows:
+
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
 - `stateRoot`: `DATA`, 32 Bytes
@@ -143,6 +148,7 @@ This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/cons
 ### ForkchoiceStateV1
 
 This structure encapsulates the fork choice state. The fields are encoded as follows:
+
 - `headBlockHash`: `DATA`, 32 Bytes - block hash of the head of the canonical chain
 - `safeBlockHash`: `DATA`, 32 Bytes - the "safe" block hash of the canonical chain under certain synchrony and honesty assumptions. This value **MUST** be either equal to or an ancestor of `headBlockHash`
 - `finalizedBlockHash`: `DATA`, 32 Bytes - block hash of the most recent finalized block
@@ -150,9 +156,56 @@ This structure encapsulates the fork choice state. The fields are encoded as fol
 ### PayloadAttributesV1
 
 This structure contains the attributes required to initiate a payload build process in the context of an `engine_forkchoiceUpdated` call. The fields are encoded as follows:
+
 - `timestamp`: `QUANTITY`, 64 Bits - value for the `timestamp` field of the new payload
 - `random`: `DATA`, 32 Bytes - value for the `random` field of the new payload
 - `suggestedFeeRecipient`: `DATA`, 20 Bytes - suggested value for the `feeRecipient` field of the new payload
+
+### PayloadStatusV1
+
+This structure contains the result of processing a payload. The fields are encoded as follows:
+
+- `status`: `enum` - `"VALID" | "INVALID" | "SYNCING" | "ACCEPTED" | "INVALID_BLOCK_HASH"`
+- `latestValidHash`: `DATA|null`, 32 Bytes - the hash of the most recent *valid* block in the branch defined by payload and its ancestors
+- `validationError`: `String|null` - a message providing additional details on the validation error if the payload is deemed `INVALID`
+
+## Routines
+
+### Payload validation
+
+Payload validation process consists of validating a payload with respect to the block header and execution environment rule sets. The process is specified as follows:
+
+1. Client software **MUST** validate the payload according to the block header and execution environment rule set with modifications to these rule sets defined in the [Block Validity](https://eips.ethereum.org/EIPS/eip-3675#block-validity) section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification):
+  * If validation succeeds, the response **MUST** contain `{status: VALID, latestValidHash: payload.blockHash}`
+  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the most recent *valid* ancestor of the invalid payload. That is, the valid ancestor of the payload with the highest `blockNumber`
+  * Client software **MUST** discard the payload if it's deemed `INVALID`.
+
+1. Client software **MUST** return `-32002: Invalid terminal block` error if the parent block is locally available and is a PoW block that doesn't satisfy terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions). This check maps on the Transition block validity section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#transition-block-validity).
+
+1. Client software **MAY** provide additional details on the validation error if the payload is deemed `INVALID` by assigning the corresponding message to the `validationError` field.
+
+1. The process of validating a payload on the canonical chain **MUST NOT** be affected by an active sync process on a side branch of the block tree. For example, if side branch `B` is `SYNCING` but the requisite data for validating a payload from canonical branch `A` is available, client software **MUST** run full validation of the payload and respond accordingly.
+
+### Sync
+
+In the context of this specification, the sync process is understood as the process of obtaining data required to validate the payload. The sync process may consist of the following stages:
+
+1. Pulling data from remote peers in the network.
+1. Validating ancestors of the payload and obtaining the parent state.
+
+Each of these stages is optional. Exact behavior of a client software during the sync process is implementation dependent.
+
+### Payload building
+
+The payload build process is specified as follows:
+
+1. Client software **MUST** set the payload field values according to the set of parameters passed into this method with exception of the `suggestedFeeRecipient`. The built `ExecutionPayload` **MAY** deviate the `feeRecipient` field value from what is specified by the `suggestedFeeRecipient` parameter.
+
+1. Client software **SHOULD** build the initial version of the payload which has an empty transaction set.
+
+1. Client software **SHOULD** start the process of updating the payload. The strategy of this process is implementation dependent. The default strategy is to keep the transaction set up-to-date with the state of local mempool.
+
+1. Client software **SHOULD** stop the updating process when either a call to `engine_getPayload` with the build process's `payloadId` is made or [`SECONDS_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#time-parameters-1) (12s in the Mainnet configuration) have passed since the point in time identified by the `timestamp` parameter.
 
 ## Core
 
@@ -166,50 +219,29 @@ This structure contains the attributes required to initiate a payload build proc
 
 #### Response
 
-* result: `object`
-    - `status`: `enum` - `"VALID" | "INVALID" | "SYNCING" | "ACCEPTED" | "INVALID_BLOCK_HASH"`
-    - `latestValidHash`: `DATA|null`, 32 Bytes - the hash of the most recent *valid* block in the branch defined by payload and its ancestors
-    - `validationError`: `String|null` - a message providing additional details on the validation error if the payload is deemed `INVALID`
+* result: [`PayloadStatusV1`](#PayloadStatusV1)
 * error: code and message set in case an exception happens while processing the payload.
 
 #### Specification
 
-1. Client software **MUST** validate `blockHash` value as being equivalent to `Keccak256(RLP(ExecutionBlockHeader))`, where `ExecutionBlockHeader` object is composed of the payload field values and constant values described in the [Block structure](https://eips.ethereum.org/EIPS/eip-3675#block-structure) section of the [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification). Additionally:
-    * Client software **MUST** return `{status: INVALID_BLOCK_HASH, latestValidHash: null, validationError: null}` and discard the payload if this validation fails
-    * Client software **MUST** run this validation in all cases even if this branch or any other branches of the block tree are in an active sync process.
+1. Client software **MUST** validate `blockHash` value as being equivalent to `Keccak256(RLP(ExecutionBlockHeader))`, where `ExecutionBlockHeader` object is composed of the payload field values and constant values described in the [Block structure](https://eips.ethereum.org/EIPS/eip-3675#block-structure) section of the [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification). Client software **MUST** run this validation in all cases even if this branch or any other branches of the block tree are in an active sync process.
 
-1. Client software **SHOULD** initiate the sync process if requisite data for payload validation is missing. The sync process is specified in the [Sync process](#sync-process) section. Additionally:
-    * Client software **MUST** return `{status: SYNCING, latestValidHash: null, validationError: null}` if the sync process has been initiated.
+1. Client software **MAY** initiate the sync process if requisite data for payload validation is missing. The sync process is specified in the [Sync](#sync) section.
 
-1. Client software **SHOULD** validate the payload if requisite data for payload validation is locally available. The validation process is specified in the [Payload validation process](#payload-validation-process) section. Additionally:
-    * Client software **MUST** return the result of the payload validation if the validation has been initiated.
+1. Client software **MUST** validate the payload if it extends the canonical chain and requisite data for the validation is locally available. The validation process is specified in the [Payload validation](#payload-validation) section.
 
-1. Client software **MUST** return `{status: ACCEPTED, latestValidHash: null, validationError: null}` if neither payload validation nor sync process has been initiated.
+1. Client software **MAY NOT** validate the payload if the payload doesn't belong to the canonical chain.
+
+1. Client software **MUST** respond to this method call in the following way:
+  * `{status: INVALID_BLOCK_HASH, latestValidHash: null, validationError: null}` if the `blockHash` validation has failed
+  * `{status: SYNCING, latestValidHash: null, validationError: null}` if the payload extends the canonical chain and requisite data for its validation is missing
+  * with the payload status obtained from the [Payload validation](#payload-validation) process if the payload has been fully validated while processing the call
+  * `{status: ACCEPTED, latestValidHash: null, validationError: null}` if the following conditions are met:
+    - the `blockHash` of the payload is valid
+    - the payload doesn't extend the canonical chain
+    - the payload hasn't been fully validated.
 
 1. If any of the above fails due to errors unrelated to the normal processing flow of the method, the client software **MUST** return an error.
-
-##### Payload validation process
-
-Payload validation process consists of validating a payload with respect to the block header and execution environment rule sets. The process is specified as follows:
-
-1. Client software **MUST** validate the payload according to the block header and execution environment rule set with modifications to these rule sets defined in the [Block Validity](https://eips.ethereum.org/EIPS/eip-3675#block-validity) section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification). Additionally:
-    * If validation succeeds, the response **MUST** contain `{status: VALID, latestValidHash: payload.blockHash}`
-    * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the most recent *valid* ancestor of the invalid payload. That is, the valid ancestor of the payload with the highest `blockNumber`
-    * Client software **MUST** discard the payload if it's deemed invalid.
-
-1. Client software **MUST** return `-32002: Invalid terminal block` error if the parent block is locally available and is a PoW block that doesn't satisfy terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions). This check maps on the Transition block validity section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#transition-block-validity).
-
-1. Client software **MAY** provide additional details on the validation error if the payload is deemed `INVALID` by assigning the corresponding message to the `validationError` field.
-
-1. The process of validating a payload on the canonical chain **MUST NOT** be affected by an active sync process on a side branch of the block tree. For example, if side branch `B` is `SYNCING` but the requisite data for validating a payload from canonical branch `A` is available, client software **MUST** initiate the validation process.
-
-##### Sync process
-
-In the context of this specification, the sync process is understood as the process of obtaining data required to validate the payload. The sync process may consist of the following stages:
-1. Pulling data from remote peers in the network.
-1. Validating ancestors of the payload and obtaining the parent state.
-
-Each of these stages is optional. Exact behavior of a client software during the sync process is implementation dependent.
 
 ### engine_forkchoiceUpdatedV1
 
@@ -223,42 +255,34 @@ Each of these stages is optional. Exact behavior of a client software during the
 #### Response
 
 * result: `object`
-    - `status`: `enum` - `"VALID" | "INVALID" | "SYNCING" | "ACCEPTED"`
-    - `latestValidHash`: `DATA|null`, 32 Bytes - the hash of the most recent *valid* block in the branch defined by payload and its ancestors
-    - `validationError`: `String|null` - a message providing additional details on the validation error if the payload is deemed `INVALID`
-    - `payloadId`: `DATA|null`, 8 Bytes - identifier of the payload build process or `null`
-* error: code and message set in case an exception happens while validating payload, updating the forkchoice or initiating the payload build process.
+  - `payloadStatus`: [`PayloadStatusV1`](#PayloadStatusV1); values of the `status` field in the context of this method are restricted to the following subset:
+    * `"VALID"`
+    * `"INVALID"`
+    * `"SYNCING"`
+  - `payloadId`: `DATA|null`, 8 Bytes - identifier of the payload build process or `null`
+* error: code and message set in case an exception happens while the validating payload, updating the forkchoice or initiating the payload build process.
 
 #### Specification
 
-1. Client software **SHOULD** initiate the sync process if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because requisite data is missing. The sync process is specified in the [Sync process](#sync-process) section. Additionally:
-    * Client software **MUST** return `{status: SYNCING, latestValidHash: null, validationError: null, payloadId: null}` if the sync process has been initiated.
+1. Client software **MAY** initiate the sync process if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because requisite data is missing. The sync process is specified in the [Sync](#sync) section.
 
-1. Client software **MAY** skip an update of the forkchoice state and **MAY NOT** begin a payload build process if the payload identified by `forkchoiceState.headBlockHash` hasn't been validated yet. Additionally:
-    * Client software **MUST** return `{status: ACCEPTED, latestValidHash: null, validationError: null, payloadId: null}` in this case.
+1. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` references an ancestor of the head of the canonical chain.
 
-1. Client software **MAY** skip an update of the forkchoice state and **MAY NOT** begin a payload build process if `forkchoiceState.headBlockHash` references an ancestor of the head of the canonical chain. Additionally:
-    * Client software **MUST** return `{status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null, payloadId: null}` in this case.
+1. Before updating the forkchoice state, client software **MUST** ensure the validity of the payload identified by `forkchoiceState.headBlockHash`, and **MAY** validate the payload while processing the call. The validation process is specified in the [Payload validation](#payload-validation) section.
 
-1. Before updating the forkchoice state, client software **MUST** ensure the validity of the payload identified by `forkchoiceState.headBlockHash`, and **MAY** initiate payload validation process if that need be. The validation process is specified in the [Payload validation process](#payload-validation-process) section. Additionally:
-    * Client software **MUST NOT** update the forkchoice state and immediately respond to the method call with the corresponding result if the payload or any of its ancestors is deemed `INVALID`.
+1. Client software **MUST** update its forkchoice state if payloads identified by `forkchoiceState.headBlockHash` and `forkchoiceState.finalizedBlockHash` are `VALID`. The update is specified as follows:
+  * The values `(forkchoiceState.headBlockHash, forkchoiceState.finalizedBlockHash)` of this method call map on the `POS_FORKCHOICE_UPDATED` event of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification) and **MUST** be processed according to the specification defined in the EIP
+  * All updates to the forkchoice state resulting from this call **MUST** be made atomically.
 
-1. Client software **MUST** update its forkchoice state if payloads identified by `forkchoiceState.headBlockHash` and `forkchoiceState.finalizedBlockHash` are deemed valid. The update is specified as follows:
-    * The values `(forkchoiceState.headBlockHash, forkchoiceState.finalizedBlockHash)` of this method call map on the `POS_FORKCHOICE_UPDATED` event of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification) and **MUST** be processed according to the specification defined in the EIP
-    * All updates to the forkchoice state resulting from this call **MUST** be made atomically
-    * Client software **MUST** return `{status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null, payloadId: null}` if `payloadAttributes` is `null`.
+1. Client software **MUST** begin a payload build process building on top of `forkchoiceState.headBlockHash` and identified via `buildProcessId` value if `payloadAttributes` is not `null` and the forkchoice state has been updated successfully. The build process is specified in the [Payload building](#payload-building) section.
 
-1. Client software **MUST** begin a payload build process building on top of `forkchoiceState.headBlockHash` and identified via `buildProcessId` value if `payloadAttributes` is not `null` and the forkchoice state has been updated successfully. The build process is specified in the [Payload build process](#payload-build-process) section. Additionally:
-    * Client software **MUST** return `{status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null, payloadId: buildProcessId}`.
+1. Client software **MUST** respond to this method call in the following way:
+  * `{payloadStatus: {status: SYNCING, latestValidHash: null, validationError: null}, payloadId: null}` if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because requisite data is missing
+  * `{payloadStatus: {status: INVALID, latestValidHash: null, validationError: errorMessage | null}, payloadId: null}` obtained from the [Payload validation](#payload-validation) process if the payload is deemed `INVALID`
+  * `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}` if the payload is deemed `VALID` and the build process hasn't been started
+  * `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId}` if the payload is deemed `VALID` and the build process has begun.
 
 1. If any of the above fails due to errors unrelated to the normal processing flow of the method, the client software **MUST** return an error.
-
-##### Payload build process
-The payload build process is specified as follows:
-* Client software **MUST** set the payload field values according to the set of parameters passed into this method with exception of the `suggestedFeeRecipient`. The built `ExecutionPayload` **MAY** deviate the `feeRecipient` field value from what is specified by the `suggestedFeeRecipient` parameter.
-* Client software **SHOULD** build the initial version of the payload which has an empty transaction set.
-* Client software **SHOULD** start the process of updating the payload. The strategy of this process is implementation dependent. The default strategy is to keep the transaction set up-to-date with the state of local mempool.
-* Client software **SHOULD** stop the updating process when either a call to `engine_getPayload` with the build process's `payloadId` is made or [`SECONDS_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#time-parameters-1) (12s in the Mainnet configuration) have passed since the point in time identified by the `timestamp` parameter.
 
 ### engine_getPayloadV1
 
@@ -277,6 +301,6 @@ The payload build process is specified as follows:
 
 1. Given the `payloadId` client software **MUST** return the most recent version of the payload that is available in the corresponding build process at the time of receiving the call.
 
-2. The call **MUST** return `-32001: Unknown payload` error if the build process identified by the `payloadId` does not exist.
+1. The call **MUST** return `-32001: Unknown payload` error if the build process identified by the `payloadId` does not exist.
 
-3. Client software **MAY** stop the corresponding build process after serving this call.
+1. Client software **MAY** stop the corresponding build process after serving this call.

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -195,7 +195,7 @@ In the context of this specification, the sync is understood as the process of o
 1. Pulling data from remote peers in the network.
 1. Passing ancestors of a payload through the [Payload validation](#payload-validation) and obtaining a parent state.
 
-*Note:* Each of these stages is optional. Exact behavior of a client software during the sync process is implementation dependent.
+*Note:* Each of these stages is optional. Exact behavior of client software during the sync process is implementation dependent.
 
 ### Payload building
 
@@ -244,7 +244,7 @@ The payload build process is specified as follows:
     - the payload hasn't been fully validated
   * with `-32002: Invalid terminal block` error if terminal block conditions aren't met.
 
-1. If any of the above fails due to errors unrelated to the normal processing flow of the method, a client software **MUST** respond with an error object.
+1. If any of the above fails due to errors unrelated to the normal processing flow of the method, client software **MUST** respond with an error object.
 
 ### engine_forkchoiceUpdatedV1
 
@@ -271,7 +271,7 @@ The payload build process is specified as follows:
 
 1. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` doesn't reference a leaf of the block tree. That is, the block referenced by `forkchoiceState.headBlockHash` is neither the head of the canonical chain nor a block at the tip of any other chain.
 
-1. Client software **MUST** return `-32002: Invalid terminal block` error if `forkchoiceState.headBlockHash` references a PoW block that doesn't satisfy terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions). This check maps on the Transition block validity section of the EIP.
+1. Client software **MUST** return `-32002: Invalid terminal block` error if `forkchoiceState.headBlockHash` references a PoW block that doesn't satisfy terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#definitions). This check maps to the transition block validity section of the EIP.
 
 1. Before updating the forkchoice state, client software **MUST** ensure the validity of the payload referenced by `forkchoiceState.headBlockHash`, and **MAY** validate the payload while processing the call. The validation process is specified in the [Payload validation](#payload-validation) section.
 
@@ -282,13 +282,13 @@ The payload build process is specified as follows:
 1. Client software **MUST** begin a payload build process building on top of `forkchoiceState.headBlockHash` and identified via `buildProcessId` value if `payloadAttributes` is not `null` and the forkchoice state has been updated successfully. The build process is specified in the [Payload building](#payload-building) section.
 
 1. Client software **MUST** respond to this method call in the following way:
-  * `{payloadStatus: {status: SYNCING, latestValidHash: null, validationError: null}, payloadId: null}` if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because data that are requisite for the validation is missing
+  * `{payloadStatus: {status: SYNCING, latestValidHash: null, validationError: null}, payloadId: null}` if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because requisite data for the validation is missing
   * `{payloadStatus: {status: INVALID, latestValidHash: null, validationError: errorMessage | null}, payloadId: null}` obtained from the [Payload validation](#payload-validation) process if the payload is deemed `INVALID`
   * `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}` if the payload is deemed `VALID` and a build process hasn't been started
   * `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId}` if the payload is deemed `VALID` and the build process has begun
-  * with `-32002: Invalid terminal block` error if terminal block conditions aren't met.
+  * with `-32002: Invalid terminal block` error if terminal block conditions aren't met
 
-1. If any of the above fails due to errors unrelated to the normal processing flow of the method, a client software **MUST** respond with an error object.
+1. If any of the above fails due to errors unrelated to the normal processing flow of the method, client software **MUST** respond with an error object.
 
 ### engine_getPayloadV1
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -21,7 +21,7 @@ rpc
 schemas
 secp
 statev
-stateusv
+statusv
 sha
 uint
 updatedv

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -21,6 +21,7 @@ rpc
 schemas
 secp
 statev
+stateusv
 sha
 uint
 updatedv


### PR DESCRIPTION
The following changes to `executePayload` and `forkchoiceUpdated` methods are proposed:
* Makes execution semantics optional for `executePayload`, and renames this method to `newPayload` to make the name sound
* Adds an option to execute payload on receiving `forkchoiceUpdated` before updating the forkchoice state
* Allows for EL client to skip updating the forkchoice state if `forkchoiceUpdated` references a historical block from the canonical chain that has been validating a while ago, i.e. forkchoice state may never go backwards if an update to the same chain is requested
* Introduces `ACCEPTED` status. It may be sent in the response in the following cases:
    * If CL sends a payload from a side fork and the parent block is missing, EL client software may just store this payload locally and no sync or payload validation process won't be initiated until this payload (or its descendant) will be designated as the head of the canonical chain
    * If CL sends `forkchoiceUpdated` to make set the head to the payload that does exist and can be validated (parent block and state are available locally), but validation is not yet done and client software implementation doesn't induce validation process on `forkchoiceUpdated`. Probably, in this case it is better for EL client software to respond with `IGNORED` to better reflect the semantics of this response
* Requires payload execution on the canonical chain to be unaffected by an active sync process if it is happening on a side branch of the block tree, and data required to validate the payload (the parent block and state) is locally available. This requirement disallows EL client software to respond `SYNCING` if `newPayload` sends a child of the head of the canonical chain when the software is catching up with the head of a side fork, it prevents node to turn optimistic (as per [optimistic sync spec](http://github.com/ethereum/consensus-specs/pull/2770)) for no reason
* Introduces the `blockHash` check as the first step of `newPayload` processing flow; this validation must run disregarding the state of EL client, whether it's syncing or not

Additionally:
* Moves Payload validation process to a separate section for the sake of modularity.
* Introduces Sync process section to give a notion of the sync process to the spec. It may be removed if deemed superfluous, but could be useful in some sense

A separate `EXECUTING`/`VALIDATING` status has been previously considered to denote the state of EL client software in which it executes multiple blocks in a row in order to obtain the parent state to be able to validate a payload. But this operation has been kept under `SYNCING` status with the reflection in the Sync process description. Distinguishing these two different states is not that useful from the CL client software perspective as both doesn't give an understanding of how much time the operation will take to inform the CL behaviour.