### PR TITLE
Improve definition of log filter topic JSON type

### DIFF
--- a/src/schemas/filter.json
+++ b/src/schemas/filter.json
@@ -52,19 +52,31 @@
 			},
 			"topics": {
 				"title": "Topics",
-				"$ref": "#/components/schemas/Topics"
+				"$ref": "#/components/schemas/FilterTopics"
 			}
 		}
 	},
-	"Topic": {
-		"title": "Topic",
-		"$ref": "#/components/schemas/uint256"
-	},
-	"Topics": {
-		"title": "Topics",
+	"FilterTopics": {
+		"title": "Filter Topics",
 		"type": "array",
 		"items": {
-			"$ref": "#/components/schemas/Topic"
+			"$ref": "#/components/schemas/FilterTopic"
 		}
+	},
+	"FilterTopic": {
+		"title": "Filter Topic List Entry",
+		"oneOf": [
+			{
+				"title": "Single Topic Match",
+				"$ref": "#/components/schemas/bytes32"
+			},
+			{
+				"title": "Multiple Topic Match",
+				"type": "array",
+				"items": {
+					"$ref": "#/components/schemas/bytes32"
+				}
+			}
+		]
 	}
 }


### PR DESCRIPTION
This fixes two issues in the type definition of the log filter "topics" field.

- Topics must be encoded as bytes32 instead of uint256. Implementations reject hex topics with less than 32 bytes.
- Items of the topic list can be given as a single topic or as an array of multiple topics. In the latter case, the filter returns logs with any of the given topics.

Example: the filter below matches logs with

- any topic in the first position
- topic 0xd783efa4... in the second position
- topic 0x1ddcc4de... OR 0x77d14ee1... in the third position.

```
{
  "topics": [
    [],
	"0xd783efa4d392943503f28438ad5830b2d5964696ffc285f338585e9fe0a37a05",
	["0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347", "0x77d14e10470b5850332524f8cd6f69ad21f070ce92dca33ab2858300242ef2f1"]
  ]
}  
```

