### PR TITLE
Engine API: replace terminal block error with INVALID_TERMINAL_BLOCK status

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -271,7 +271,7 @@ The payload build process is specified as follows:
 
 1. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` doesn't reference a leaf of the block tree. That is, the block referenced by `forkchoiceState.headBlockHash` is neither the head of the canonical chain nor a block at the tip of any other chain.
 
-1. If `forkchoiceState.headBlockHash` references a PoW block, client software **MUST** validate this block with respect to terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#transition-block-validity). This check maps to the transition block validity section of the EIP. Additionally, if this validation fails, client software **MUST NOT** update the forkchoice state and **MUST NOT** begin a paylod build process.
+1. If `forkchoiceState.headBlockHash` references a PoW block, client software **MUST** validate this block with respect to terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#transition-block-validity). This check maps to the transition block validity section of the EIP. Additionally, if this validation fails, client software **MUST NOT** update the forkchoice state and **MUST NOT** begin a payload build process.
 
 1. Before updating the forkchoice state, client software **MUST** ensure the validity of the payload referenced by `forkchoiceState.headBlockHash`, and **MAY** validate the payload while processing the call. The validation process is specified in the [Payload validation](#payload-validation) section.
 


### PR DESCRIPTION
Replaces `-32002: Invalid terminal block` error with `INVALID_TERMINAL_BLOCK` status value.

The motivation behind this change is to have terminal block conditions check handled in a way similar to other block validity conditions in terms of response to CL.

Additionally, this PR does also contain an explicit requirement on invalidating all descendants of the last PoW block in the chain if this PoW block is not a valid terminal block.

Alternatively, we could use an `INVALID` status to signal terminal block conditions violations. But this status is accompanied with `latestValidHash` which in the case of invalid terminal block can't be clearly defined, and moreover doesn't exist on CL. Thus, having a separate status tells that entire block tree starting from a transition block must be invalidated by CL, if this transition block is built upon invalid terminal block.