### PR TITLE
Clarify that `latestValidHash` must be set for invalid payloads

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -246,10 +246,11 @@ The payload build process is specified as follows:
 4. Client software **MAY NOT** validate the payload if the payload doesn't belong to the canonical chain.
 
 5. Client software **MUST** respond to this method call in the following way:
-  * `{status: INVALID_BLOCK_HASH, latestValidHash: null, validationError: errorMessage | null}` if the `blockHash` validation has failed
-  * `{status: INVALID_TERMINAL_BLOCK, latestValidHash: null, validationError: errorMessage | null}` if terminal block conditions are not satisfied
+  * with a payload status obtained from the [Payload validation](#payload-validation) process, i.e.
+    - `{status: INVALID_TERMINAL_BLOCK, latestValidHash: null, validationError: errorMessage | null}` if the terminal block conditions are not satisfied
+    - `{status: INVALID, latestValidHash: validHash, validationError: errorMessage | null}` if the validation for `payload.blockHash` failed
+    - `{status: VALID, latestValidHash: payload.blockHash}` if the validation for `payload.blockHash` succeeded
   * `{status: SYNCING, latestValidHash: null, validationError: null}` if the payload extends the canonical chain and requisite data for its validation is missing
-  * with the payload status obtained from the [Payload validation](#payload-validation) process if the payload has been fully validated while processing the call
   * `{status: ACCEPTED, latestValidHash: null, validationError: null}` if the following conditions are met:
     - the `blockHash` of the payload is valid
     - the payload doesn't extend the canonical chain


### PR DESCRIPTION
The spec currently describes the `INVALID_BLOCK_HASH` response for `engine_newPayloadV1` with a `null` `latestValidHash`, yet the [Payload validation](https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.7/src/engine/specification.md#payload-validation) section requires that the `latestValidHash` be set:

> If validation fails, the response MUST contain {status: INVALID, latestValidHash: validHash} where validHash is the block hash of the most recent valid ancestor of the invalid payload. That is, the valid ancestor of the payload with the highest blockNumber

This is my first execution engine PR, so please let me know if the formatting is not appropriate or you'd prefer to specify this differently.

