### PR TITLE
Engine API: define a subset of exposing eth methods

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -134,9 +134,9 @@ $ curl https://localhost:8550 \
 
 ## Structures
 
-Encoding of values which have `DATA` type **MUST** be encoded as a hexadecimal string with a `0x` prefix matching the regular expression `^0x(?:[a-fA-F0-9]{2})*$`.
+Values of a field of `DATA` type **MUST** be encoded as a hexadecimal string with a `0x` prefix matching the regular expression `^0x(?:[a-fA-F0-9]{2})*$`.
 
-Encoding of values which have `QUANTITY` type **MUST** be encoded as a hexadecimal string with a `0x` prefix and the leading 0s stripped (except for the case of encoding the value `0`) matching the regular expression `^0x(?:0|(?:[a-fA-F1-9][a-fA-F0-9]*))$`.
+Values of a field of `QUANTITY` type **MUST** be encoded as a hexadecimal string with a `0x` prefix and the leading 0s stripped (except for the case of encoding the value `0`) matching the regular expression `^0x(?:0|(?:[a-fA-F1-9][a-fA-F0-9]*))$`.
 
 *Note:* Byte order of encoded value having `QUANTITY` type is big-endian.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -45,7 +45,7 @@ This document specifies the Engine API methods that the Consensus Layer uses to 
 ## Underlying protocol
 
 Message format and encoding notation used by this specification are inherited
-from [Ethereum JSON-RPC Specification](https://github.com/ethereum/execution-apis/tree/main/src/).
+from [Ethereum JSON-RPC Specification][json-rpc-spec].
 
 Client software **MUST** expose Engine API at a port independent from JSON-RPC API.
 The default port for the Engine API is 8550.
@@ -63,7 +63,7 @@ the client **MUST** also expose the following subset of `eth` methods:
 * `eth_sendRawTransaction`
 * `eth_syncing`
 
-Specification of these methods may be found in [`eth`](https://github.com/ethereum/execution-apis/tree/main/src/eth) folder of this repository.
+These methods are described in [Ethereum JSON-RPC Specification][json-rpc-spec].
 
 ## Versioning
 
@@ -351,3 +351,5 @@ The payload build process is specified as follows:
 2. Execution Layer client software **SHOULD** surface an error to the user if local configuration settings mismatch corresponding values received in the call of this method, with exception for `terminalBlockNumber` value.
 
 3. Consensus Layer client software **SHOULD** surface an error to the user if local configuration settings mismatch corresponding values obtained from the response to the call of this method.
+
+[json-rpc-spec]: https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/eth1.0-apis/assembled-spec/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -44,18 +44,26 @@ This document specifies the Engine API methods that the Consensus Layer uses to 
 
 ## Underlying protocol
 
-This specification is based on [Ethereum JSON-RPC API](https://eth.wiki/json-rpc/API) and inherits the following properties of this standard:
-
-* Supported communication protocols (HTTP and WebSocket)
-* Message format and encoding notation
-* [Error codes improvement proposal](https://eth.wiki/json-rpc/json-rpc-error-codes-improvement-proposal)
+Message format and encoding notation used by this specification are inherited
+from [Ethereum JSON-RPC Specification](https://github.com/ethereum/execution-apis/tree/main/src/).
 
 Client software **MUST** expose Engine API at a port independent from JSON-RPC API.
 The default port for the Engine API is 8550.
 The Engine API is exposed under the `engine` namespace.
 
 To facilitate an Engine API consumer to access state and logs (e.g. proof-of-stake deposits) through the same connection,
-the client **MUST** also expose the `eth` namespace. 
+the client **MUST** also expose the following subset of `eth` methods:
+* `eth_blockNumber`
+* `eth_call`
+* `eth_chainId`
+* `eth_getCode`
+* `eth_getBlockByHash`
+* `eth_getBlockByNumber`
+* `eth_getLogs`
+* `eth_sendRawTransaction`
+* `eth_syncing`
+
+Specification of these methods may be found in [`eth`](https://github.com/ethereum/execution-apis/tree/main/src/eth) folder of this repository.
 
 ## Versioning
 
@@ -126,7 +134,7 @@ $ curl https://localhost:8550 \
 
 ## Structures
 
-Fields having `DATA` and `QUANTITY` types **MUST** be encoded according to the [HEX value encoding](https://eth.wiki/json-rpc/API#hex-value-encoding) section of Ethereum JSON-RPC API.
+Encoding of values which have `DATA` and `QUANTITY` types **MUST** follow `bytes` and `uint` schemas from [`base-types.json`](https://github.com/ethereum/execution-apis/blob/main/src/schemas/base-types.json) respectively. Description of encoding notation of these two types may also be found in [HEX value encoding](https://eth.wiki/json-rpc/API#hex-value-encoding) section of Ethereum JSON-RPC API on eth.wiki.
 
 *Note:* Byte order of encoded value having `QUANTITY` type is big-endian.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -134,7 +134,9 @@ $ curl https://localhost:8550 \
 
 ## Structures
 
-Encoding of values which have `DATA` and `QUANTITY` types **MUST** follow `bytes` and `uint` schemas from [`base-types.json`](https://github.com/ethereum/execution-apis/blob/main/src/schemas/base-types.json) respectively. Description of encoding notation of these two types may also be found in [HEX value encoding](https://eth.wiki/json-rpc/API#hex-value-encoding) section of Ethereum JSON-RPC API on eth.wiki.
+Encoding of values which have `DATA` type **MUST** be encoded as a hexadecimal string with a `0x` prefix matching the regular expression `^0x(?:[a-fA-F0-9]{2})*$`.
+
+Encoding of values which have `QUANTITY` type **MUST** be encoded as a hexadecimal string with a `0x` prefix and the leading 0s stripped (except for the case of encoding the value `0`) matching the regular expression `^0x(?:0|(?:[a-fA-F1-9][a-fA-F0-9]*))$`.
 
 *Note:* Byte order of encoded value having `QUANTITY` type is big-endian.
 


### PR DESCRIPTION
This PR is based on the feedback received from CL client teams on a subset of `eth` methods their clients are relying on. The table with the list of methods can be found [here](https://hackmd.io/E9VKRcmRSc2Imo8RBtqxlw?view).

Additionally, it attempts to get rid of https://eth.wiki/json-rpc/API as a source of JSON-RPC spec and replace it with this repository. Though, eth.wiki is still used in one place as auxiliary resource.

Note `eth_chainId` isn't specified in [`eth`](https://github.com/ethereum/execution-apis/tree/main/src/eth) but is supported by all EL clients. Considering wide support of this method and state of Ethereum JSON-RPC Specification which is still in active development stage, including `eth_chainId` into this list seems to be fine.