### PR TITLE
Add QoS for transition config endpoint

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -343,3 +343,7 @@ The payload build process is specified as follows:
 2. Execution Layer client software **SHOULD** surface an error to the user if local configuration settings mismatch corresponding values received in the call of this method, with exception for `terminalBlockNumber` value.
 
 3. Consensus Layer client software **SHOULD** surface an error to the user if local configuration settings mismatch corresponding values obtained from the response to the call of this method.
+
+4. Consensus Layer client software **SHOULD** poll this endpoint every 60 seconds.
+
+5. Execution Layer client software **SHOULD** surface an error to the user if it does not recieve a request on this endpoint at least once every 120 seconds.


### PR DESCRIPTION
This follows from a [Discord conversation](https://discord.com/channels/595666850260713488/692062809701482577/947845183414861826) about using the `engine_exchangeTransitionConfigurationV1` endpoint as a "ping" to allow an EL to be aware when it's CL is offline. (cc @djrtwo @mkalinin)

I imagine this to be particularly helpful in the space between:

1. Beacon chain Bellatrix fork
2. Terminal PoW block

During this period all ELs must be paired with a CL, but there's presently no way for them to know that the CL is connected and live.
