### PR TITLE
Auth spec shouldn't specify which methods are provided over it

### DIFF
--- a/src/engine/authentication.md
+++ b/src/engine/authentication.md
@@ -25,7 +25,6 @@ parameters for the WS-handshake are carried in the http headers.
 
 - Client software MUST expose the authenticated Engine API at a port independent from existing JSON-RPC API.
   - The default port for the authenticated Engine API is `8551`. The Engine API is exposed under the `engine` namespace.
-- On the authenticated endpoint, the legacy API **MUST** also be available.
 - The EL **MUST** support at least the following `alg` `HMAC + SHA256` (`HS256`)
 - The EL **MUST** reject the `alg` `none`. 
 


### PR DESCRIPTION
Slightly confused by this statement in the authentication spec. It appears the current state of the authentication spec (all legacy method should be provided) is contradicting the PR #183 (only a subset should be provided). Unless I misinterpret and the "legacy api" is the non-authenticated engine api? In which case believe the idea was to still remove that?