### PR TITLE
Change `input` for Unsigned Transactions Schemas to `data`

### DIFF
--- a/src/schemas/transaction.json
+++ b/src/schemas/transaction.json
@@ -40,7 +40,7 @@
 	"Transaction1559Unsigned": {
 		"type": "object",
 		"title": "EIP-1559 transaction.",
-		"required": [ "type", "nonce", "gas", "value", "input", "maxFeePerGas", "maxPriorityFeePerGas", "chainId", "accessList" ],
+		"required": [ "type", "nonce", "gas", "value", "data", "maxFeePerGas", "maxPriorityFeePerGas", "chainId", "accessList" ],
 		"properties": {
 			"type": {
 				"title": "type",
@@ -62,8 +62,9 @@
 				"title": "value",
 				"$ref": "#/components/schemas/uint"
 			},
-			"input": {
+			"data": {
 				"title": "input data",
+				"description": "The compiled code of a contract OR the hash of the invoked method signature and encoded parameters",
 				"$ref": "#/components/schemas/bytes"
 			},
 			"maxPriorityFeePerGas": {
@@ -91,7 +92,7 @@
 	"Transaction2930Unsigned": {
 		"type": "object",
 		"title": "EIP-2930 transaction.",
-		"required": [ "type", "nonce", "gas", "value", "input", "gasPrice", "chainId", "accessList" ],
+		"required": [ "type", "nonce", "gas", "value", "data", "gasPrice", "chainId", "accessList" ],
 		"properties": {
 			"type": {
 				"title": "type",
@@ -113,8 +114,9 @@
 				"title": "value",
 				"$ref": "#/components/schemas/uint"
 			},
-			"input": {
+			"data": {
 				"title": "input data",
+				"description": "The compiled code of a contract OR the hash of the invoked method signature and encoded parameters",
 				"$ref": "#/components/schemas/bytes"
 			},
 			"gasPrice": {
@@ -137,7 +139,7 @@
 	"TransactionLegacyUnsigned": {
 		"type": "object",
 		"title": "Legacy transaction.",
-		"required": [ "type", "nonce", "gas", "value", "input", "gasPrice" ],
+		"required": [ "type", "nonce", "gas", "value", "data", "gasPrice" ],
 		"properties": {
 			"type": {
 				"title": "type",
@@ -159,8 +161,9 @@
 				"title": "value",
 				"$ref": "#/components/schemas/uint"
 			},
-			"input": {
+			"data": {
 				"title": "input data",
+				"description": "The compiled code of a contract OR the hash of the invoked method signature and encoded parameters",
 				"$ref": "#/components/schemas/bytes"
 			},
 			"gasPrice": {


### PR DESCRIPTION
Original JSON-RPC spec:

![image](https://user-images.githubusercontent.com/20375610/159108828-9370a1ee-eaeb-49be-8e21-db7a9ec5f763.png)

Unfortunately, the original spec also defines that the transaction returned from calls such as `eth_getTransactionByHash` return `input` instead of data:

![image](https://user-images.githubusercontent.com/20375610/159108932-1b9d1578-d620-4397-b5c5-ed34ed8a3d9f.png)

So the reuse of `Transaction1559Unsigned`, `Transaction2930Unsigned`, and `TransactionLegacyUnsigned` would not be valid for [Transaction1559Signed](https://github.com/ethereum/execution-apis/blob/43e2e2c22ee2930389f9455a7f81f20955a88731/src/schemas/transaction.json#L189),  [Transaction2930Signed](https://github.com/ethereum/execution-apis/blob/43e2e2c22ee2930389f9455a7f81f20955a88731/src/schemas/transaction.json#L215), and [TransactionLegacySigned](https://github.com/ethereum/execution-apis/blob/43e2e2c22ee2930389f9455a7f81f20955a88731/src/schemas/transaction.json#L241) if `input` is changed to `data` as this PR proposes