### PR TITLE
Add justified block to Ethereum JSON-RPC

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -165,7 +165,8 @@ This structure encapsulates the fork choice state. The fields are encoded as fol
 
 - `headBlockHash`: `DATA`, 32 Bytes - block hash of the head of the canonical chain
 - `safeBlockHash`: `DATA`, 32 Bytes - the "safe" block hash of the canonical chain under certain synchrony and honesty assumptions. This value **MUST** be either equal to or an ancestor of `headBlockHash`
-- `finalizedBlockHash`: `DATA`, 32 Bytes - block hash of the most recent finalized block
+- `justifiedBlockHash`: `DATA`, 32 Bytes - hash of the most recent justified block
+- `finalizedBlockHash`: `DATA`, 32 Bytes - hash of the most recent finalized block
 
 ### PayloadAttributesV1
 

--- a/src/schemas/block.json
+++ b/src/schemas/block.json
@@ -125,7 +125,8 @@
 	"BlockTag": {
 		"title": "Block tag",
 		"type": "string",
-		"enum": ["earliest", "latest", "pending", "finalized", "safe", "unsafe"]
+		"enum": ["earliest", "latest", "pending", "finalized", "safe", "unsafe"],
+		"description": "Tags \"finalized\" and \"safe\" refer to the corresponding blocks defined by the most recent fork choice state. Tag \"unsafe\" is an alias to the \"latest\"."
 	},
 	"BlockNumberOrTag": {
 		"title": "Block number or tag",

--- a/src/schemas/block.json
+++ b/src/schemas/block.json
@@ -125,7 +125,7 @@
 	"BlockTag": {
 		"title": "Block tag",
 		"type": "string",
-		"enum": ["earliest", "latest", "pending"]
+		"enum": ["earliest", "latest", "pending", "finalized"]
 	},
 	"BlockNumberOrTag": {
 		"title": "Block number or tag",

--- a/src/schemas/block.json
+++ b/src/schemas/block.json
@@ -125,7 +125,7 @@
 	"BlockTag": {
 		"title": "Block tag",
 		"type": "string",
-		"enum": ["earliest", "latest", "pending", "finalized"]
+		"enum": ["earliest", "latest", "pending", "finalized", "safe", "unsafe"]
 	},
 	"BlockNumberOrTag": {
 		"title": "Block number or tag",

--- a/src/schemas/block.json
+++ b/src/schemas/block.json
@@ -125,8 +125,8 @@
 	"BlockTag": {
 		"title": "Block tag",
 		"type": "string",
-		"enum": ["earliest", "latest", "pending", "finalized", "safe", "unsafe"],
-		"description": "Tags \"finalized\" and \"safe\" refer to the corresponding blocks defined by the most recent fork choice state. Tag \"unsafe\" is an alias to the \"latest\"."
+		"enum": ["earliest", "latest", "pending", "finalized", "justified", "safe", "unsafe"],
+		"description": "Tags \"finalized\", \"justified\" and \"safe\" refer to the corresponding blocks defined by the most recent fork choice state. Tag \"unsafe\" is an alias to the \"latest\"."
 	},
 	"BlockNumberOrTag": {
 		"title": "Block number or tag",


### PR DESCRIPTION
* Adds `justifiedBlockHash` as additional parameter to the `ForkchoiceStateV1` data structure in Engine API
* Adds `justified` tag to block tags available in JSON-RPC

Depends on https://github.com/ethereum/execution-apis/pull/200

TODO
- [x] corresponding change to consensus specs
  - https://github.com/ethereum/consensus-specs/pull/2859