### PR TITLE
add engine api timeouts

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -12,6 +12,7 @@ This document specifies the Engine API methods that the Consensus Layer uses to 
 - [Message ordering](#message-ordering)
 - [Load-balancing and advanced configurations](#load-balancing-and-advanced-configurations)
 - [Errors](#errors)
+- [Timeouts](#timeouts)
 - [Structures](#structures)
   - [ExecutionPayloadV1](#executionpayloadv1)
   - [ForkchoiceStateV1](#forkchoicestatev1)
@@ -132,6 +133,12 @@ $ curl https://localhost:8550 \
 }
 ```
 
+## Timeouts
+
+After the specified `timeout` for a given call transpires without a response, Consensus Layer software **MUST** abort and consider the call as failed.
+
+In such an event, the Consensus Layer software **MAY** retry the call.
+
 ## Structures
 
 Values of a field of `DATA` type **MUST** be encoded as a hexadecimal string with a `0x` prefix matching the regular expression `^0x(?:[a-fA-F0-9]{2})*$`.
@@ -239,6 +246,7 @@ The payload build process is specified as follows:
 * method: `engine_newPayloadV1`
 * params: 
   1. [`ExecutionPayloadV1`](#ExecutionPayloadV1)
+* timeout: 120s
 
 #### Response
 
@@ -275,6 +283,7 @@ The payload build process is specified as follows:
 * params: 
   1. `forkchoiceState`: `Object` - instance of [`ForkchoiceStateV1`](#ForkchoiceStateV1)
   2. `payloadAttributes`: `Object|null` - instance of [`PayloadAttributesV1`](#PayloadAttributesV1) or `null`
+* timeout: 120s
 
 #### Response
 
@@ -319,6 +328,7 @@ The payload build process is specified as follows:
 * method: `engine_getPayloadV1`
 * params:
   1. `payloadId`: `DATA`, 8 Bytes - Identifier of the payload build process
+* timeout: 12s
 
 #### Response
 
@@ -340,6 +350,7 @@ The payload build process is specified as follows:
 * method: `engine_exchangeTransitionConfigurationV1`
 * params:
   1. `transitionConfiguration`: `Object` - instance of [`TransitionConfigurationV1`](#TransitionConfigurationV1)
+* timeout: 12s
 
 #### Response
 


### PR DESCRIPTION
## Proposal

* 120s timeout for engine endpoints **with** block execution semantics
* 12s timeout for engine endpoints **without** execution semantics

## Why a timeout

There are a couple of reasons a block may take longer than expected to process when inserting via engine API into EL
* A DoS block -- that is a block that will finish but takes unexpectedly and disproportionately long to process
* A bug -- Some sort of infinite loop, crash, or hang may cause the EL to never respond (or take a very very long time to)

In the event of a DoS block, it is dangerous to naively dismiss these as purely "invalid" at certain time thresholds. If a DoS block can be crafted such that some hardware/clint takes just less than a specified timeout and other hardware/client takes just longer, then an attacker can split the network on such a block.

It is particularly dangerous to have such timeouts be on the order of a slot's length of time (12s) because in this range of time, decisions on what to propose on top of and to attest to happen. So if a DoS block is in the range of sub-slot to 2x slot time (and different depending on hardware!), then an attacker (assuming they found a DoS in block construction) can likely perform such split-network view attacks with timeouts in this range.

Once timeouts are firmly beyond a slot-length, then we have fewer issues with split views. This is because targeting network split attacks that rely on many-slot-length timeouts (e.g. 120s) are likely to just get passed up by subsequnt normal, non-DoS blocks. That is -- if a DoS block at slot N relies on ~120s of execution time to create a network split, it is likely that in that time, a few honest blocks will come in and the canonical chain will just pass up this DoS block.

But what a timeout at all? At a certain point, a block is not valuable to execute and include. That is, if a block is taking more than a slot for any machine to execute, it is almost certain that it will just be orphaned and at some point the client needs to be able to move on and abort the work. More importantly, a block might have a deeper bug -- e.g. infinite loop -- and might never succeed. In such an event, the client needs to be able to call it quits and might have no indication to do so other than the lapse of time.

## The case for 120s for block execution endpoints

Assuming that in the normal case, an honest block follows in the slot after a DoS block, a 120s timeout allows for a 10x difference in fastest hardware/client vs slowest hardware/client for that given block. There are thus two scenarios -- when the fastest executor is < 12s and when the fastest executor is >= 12s. Assuming the 10x min/max executor bound:
* *When the fastest executor is < 12s*, an honest proposer of next slot *might* build on the DoS block (if they were the fastest executor). In such a reality, the slowest executor would be < 120s (less than the timeout) so would eventually be able to follow what might be a canonical chain including the block
* *When the fastest executor is >= 12s*, an honest proposer of next slot would *not* be built on top of this DoS block because the next slot producer (even if the fastest executor on the network) would not have be able to incorporate the block locally in time. Thus the canonical chain would move on *without* the DoS block. Some nodes would include the block locally (< 120s execution), but the slowest on the network (> 120s) would just throw out the block at the timeout but not be at risk of chain split due to the DoS block not making it into the canonical chain

*Note, I wouldn't suggest going less than my 10x assumption. I think it is conservative and safe.  But if we think this is not conservative enough, let me know with some justification and we can change it higher.*

## What about re-orgs with FCU

The FCU endpoint might take a long time not just because of one block execution but might be many blocks. Additioanlly it might just be expensive to re-org for other reasons.

I'd like to hear more input here but we might consider either 
* EL responds with SYNCING if doing a deep re-org that will take time
* FCU timeout is dynamic wrt the depth of the re-org -- 120s in the normal case, but longer if CL knows a depth is happening.

## The case for 12s for non-execution endpoints

For endpoints without block execution I suggest 12s timeout (slot-length).

If EL cannot respond within a slot for non-execution endpoints, either these are no longer valuable (e.g. getPayloadV1 and th proposal slot passed) or there is just clearly a bug (e.g. exchangeTransitionConfigurationV1)