### PR TITLE
Add Builder API

### DIFF
--- a/src/builder/README.md
+++ b/src/builder/README.md
@@ -1,0 +1,7 @@
+# Builder JSON-RPC API
+
+The Builder JSON-RPC API is a collection of methods that all execution clients implement.
+This interface allows the communication between the consensus layer and external builders.
+
+This API is in *active development* and currently [specified as a markdown document](./specification.md).
+A schema will follow once the specification stabilizes.

--- a/src/builder/README.md
+++ b/src/builder/README.md
@@ -1,7 +1,7 @@
 # Builder JSON-RPC API
 
-The Builder JSON-RPC API is a collection of methods that all execution clients implement.
-This interface allows the communication between the consensus layer and external builders.
+The Builder JSON-RPC API is a collection of methods that external block building software must 
+implement. This interface allows the communication between the consensus layer and external builders.
 
 This API is in *active development* and currently [specified as a markdown document](./specification.md).
 A schema will follow once the specification stabilizes.

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -135,7 +135,7 @@ The list of error codes introduced by this specification can be found below.
 All signature operations should follow the [standard BLS operations][bls] interface defined in `consensus-specs`.
 
 There are two types of data to sign over in the Builder API:
-* In-protocol messages, e.g. [`BlindBeaconBlock`](#blindbeaconblock), which should compute the signing root using [`computer_signing_root`][compute-signing-root] and use the domain specified for beacon block proposals.
+* In-protocol messages, e.g. [`BlindBeaconBlock`](#blindbeaconblock), which should compute the signing root using [`compute_signing_root`][compute-signing-root] and use the domain specified for beacon block proposals.
 * Builder API messages, e.g. [`builder_setFeeRecipientV1`](#builder_setFeeRecipientV1) and the response to [`builder_getHeader`](#response-2), which should compute the signing root using [`compute_signing_root`][compute-signing-root] and the domain `DomainType('0xXXXXXXXX')` (TODO: get a proper domain).
 
 As `compute_signing_root` takes `SSZObject` as input, client software should convert in-protocol messages to their SSZ representation to compute the signing root and Builder API messages to the SSZ representations defined [above](#sszobjects).

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -161,16 +161,6 @@ class BuilderReceiptV1(Container):
     pubkey: BLSPubkey
 ```
 
-##### `SignedBlindBeaconBlock`
-
-###### `SignedBlindBeaconBlock`
-
-```python
-class SignedBlindBeaconBlock(Container):
-    message: BlindBeaconBlock
-    signature: BLSSignature
-```
-
 ###### `BlindBeaconBlock`
 
 ```python

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -42,7 +42,7 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `deposits`: `Array`, [`DespositV1`](#depositv1)
 - `voluntaryExits`: `Array`, [`SignedVoluntaryExitV1`](#signedvoluntaryexitv1)
 - `syncAggregate`: `object`, [`SyncAggregateV1`](#syncaggregatev1)
-- `executionPayload`: `object`, [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1)
+- `executionPayloadHeader`: `object`, [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1)
 
 ### `Eth1DataV1`
 - `depositRoot`: `DATA`, 32 Bytes

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -325,8 +325,8 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 
 - method: `builder_getPayloadV1`
 - params:
-  1. `message`: [`SignedBlindBeaconBlock`](#signedblindbeaconblockv1).
-  2. `signature`: `DATA`, 96 Bytes - BLS signature over [`SignedBlindBeaconBlock`](#signedblindbeaconblockv1).
+  1. `message`: [`BlindBeaconBlock`](#blindbeaconblockv1).
+  2. `signature`: `DATA`, 96 Bytes - BLS signature over [`BlindBeaconBlock`](#blindbeaconblockv1).
 
 #### Response
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -217,6 +217,28 @@ The list of error codes introduced by this specification can be found below.
 | -32603 | Internal error | Internal JSON-RPC error. |
 | -32700 | Parse error | Invalid JSON was received by the server. |
 
+Each error returns a `null` `data` value, except `-32000` which returns the `data` object with a `err` member that explains the error encountered.
+
+For example:
+
+```
+$ curl https://localhost:8550 \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"engine_getPayloadV1","params": ["0x1"],"id":1}'
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32000,
+    "message": "Server error",
+    "data": {
+        "err": "Database corrupted"
+    }
+  }
+}
+```
+
 ## Routines
 
 ### Signing
@@ -230,6 +252,22 @@ There are two types of data to sign over in the Builder API:
 As `compute_signing_root` takes `SSZObject` as input, client software should convert in-protocol messages to their SSZ representation to compute the signing root and Builder API messages to the SSZ representations defined [above](#sszobjects).
 
 ## Methods
+
+### `builder_status`
+
+#### Request
+
+- method: `builder_status`
+- params: `null`
+
+#### Response
+
+- result: `null`
+- error: code and message set in case the builder is not operating normally.
+
+#### Specification
+
+1. Builder software **SHOULD** return `-32000: Server error` if it is unable to respond to requests. `err` **MUST** be set explaining the issue.
 
 ### `builder_registerValidatorV1`
 
@@ -246,7 +284,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 #### Response
 
 - result: `null`
-- error: code and message set in case an exception happens while getting the payload.
+- error: code and message set in case an exception happens while registering the validator.
 
 #### Specification
 1. Builder software **MUST** verify `signature` is valid under `pubkey`, otherwise return error `-32005: Invalid Signature`.
@@ -271,7 +309,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
         - `value`: `DATA`, 32 Bytes - the payment in wei that will be paid to the `feeRecipient` account.
         - `pubkey`: `DATA`, 48 Bytes - the public key associated with the builder.
     - `signature`: `DATA`, 96 Bytes - BLS signature of the builder over `message`.
-- error: code and message set in case an exception happens while getting the payload.
+- error: code and message set in case an exception happens while getting the header.
 
 #### Specification
 1. Builder software **SHOULD** respond immediately with the `header` that increases the `feeRecipient`'s balance by the most.

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -1,4 +1,4 @@
-# Version 0.2.1
+# Builder API
 
 This document specifies the Builder API methods that the Consensus Layer uses to interact with external block builders.
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -155,8 +155,8 @@ class ValidatorRegistrationV1(Container):
 ##### `BuilderReceiptV1`
 
 ```python
-class BuilderReceiptV1(Container):
-    payload: ExecutionPayloadHeader
+class BuilderBidV1(Container):
+    header: ExecutionPayloadHeader
     value: uint256
     pubkey: BLSPubkey
 ```
@@ -185,7 +185,7 @@ class BlindBeaconBlockBody(Container):
     deposits: List[Deposit, MAX_DEPOSITS]
     voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
     sync_aggregate: SyncAggregate
-    execution_payload: ExecutionPayloadHeader
+    execution_payload_header: ExecutionPayloadHeader
 ```
 
 ## Errors
@@ -324,7 +324,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - error: code and message set in case an exception happens while proposing the payload.
 
 #### Specification
-1. Builder software **MUST** verify that the beacon block's exeuction payload is a matching [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1) provided from [`builder_getHeaderV1`](#buildergetheaderv1), otherwise the return `-32004: Unknown block`.
+1. Builder software **MUST** verify that the beacon block's execution payload is a matching [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1) provided from [`builder_getHeaderV1`](#buildergetheaderv1), otherwise the return `-32004: Unknown block`.
 2. Builder software **MUST** verify that `signature` is a BLS signature over `block` using [`verify_block_signature`][verify-block-signature] from the validator that is expected to propose in the slot. If the signature is determined to be invalid or from a different validator than expected, the builder **MUST** return `-32005: Invalid signature`.
 
 [consensus-specs]: https://github.com/ethereum/consensus-specs

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -289,7 +289,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - method: `builder_getHeaderV1`
 - params:
   1. `slot`: `QUANTITY`, 64 Bits - Slot number of the block proposal.
-  2. `pubkey`: `QUANTITY`, 64 Bits - BLS public key of proposer.
+  2. `pubkey`: `QUANTITY`, 48 Bytes - BLS public key of validator.
   3. `hash`: `DATA`, 32 Bytes - Hash of execution layer block the proposer will use as the proposal's parent.
 
 #### Response

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -2,32 +2,6 @@
 
 This document specifies the Builder API methods that the Consensus Layer uses to interact with external block builders.
 
-```mermaid
-sequenceDiagram
-    participant consensus
-    participant mev_boost
-    participant relays
-    Title: Block Proposal
-    Note over consensus: sign fee recipient announcement
-    consensus->>mev_boost: builder_registerValidator
-    mev_boost->>relays: builder_registerValidator
-    Note over consensus: wait for allocated slot
-    consensus->>mev_boost: builder_getHeader
-    mev_boost->>relays: builder_getHeader
-    relays-->>mev_boost: builder_getHeader response
-    Note over mev_boost: verify response matches expected
-    Note over mev_boost: select best payload
-    mev_boost-->>consensus: builder_getHeader response
-    Note over consensus: sign the block
-    consensus->>mev_boost: builder_getPayload
-    Note over mev_boost: identify payload source
-    mev_boost->>relays: builder_getPayload
-    Note over relays: validate signature
-    relays-->>mev_boost: builder_getPayload response
-    Note over mev_boost: verify response matches expected
-    mev_boost-->>consensus: builder_getPayload response
-```
-
 ## Structures
 
 ### `ExecutionPayloadV1`

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -68,7 +68,7 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `deposits`: `Array`, [`DespositV1`](#depositv1)
 - `voluntaryExits`: `Array`, [`SignedVoluntaryExitV1`](#signedvoluntaryexitv1)
 - `syncAggregate`: `object`, [`SyncAggregateV1`](#syncaggregatev1)
-- `executionPayload`: `object`, [`ExecutionPayloadHeaderV1`](#executionpayloadheader)
+- `executionPayload`: `object`, [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1)
 
 ### `Eth1DataV1`
 - `depositRoot`: `DATA`, 32 Bytes

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -1,0 +1,217 @@
+# Version 0.2.1
+
+This document specifies the Builder API methods that the Consensus Layer uses to interact with external block builders.
+
+```mermaid
+sequenceDiagram
+    participant consensus
+    participant mev_boost
+    participant relays
+    Title: Block Proposal
+    Note over consensus: sign fee recipient announcement
+    consensus->>mev_boost: builder_setFeeRecipient
+    mev_boost->>relays: builder_setFeeRecipient
+    Note over consensus: wait for allocated slot
+    consensus->>mev_boost: builder_getHeader
+    mev_boost->>relays: builder_getHeader
+    relays-->>mev_boost: builder_getHeader response
+    Note over mev_boost: verify response matches expected
+    Note over mev_boost: select best payload
+    mev_boost-->>consensus: builder_getHeader response
+    Note over consensus: sign the block
+    consensus->>mev_boost: builder_getPayload
+    Note over mev_boost: identify payload source
+    mev_boost->>relays: builder_getPayload
+    Note over relays: validate signature
+    relays-->>mev_boost: builder_getPayload response
+    Note over mev_boost: verify response matches expected
+    mev_boost-->>consensus: builder_getPayload response
+```
+
+## Structures
+
+### `ExecutionPayloadV1`
+
+Mirror of [`ExecutionPayloadV1`][execution-payload].
+
+### `ExecutionPayloadHeaderV1`
+
+Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `transactionsRoot`.
+- `parentHash`: `DATA`, 32 Bytes
+- `feeRecipient`:  `DATA`, 20 Bytes
+- `stateRoot`: `DATA`, 32 Bytes
+- `receiptsRoot`: `DATA`, 32 Bytes
+- `logsBloom`: `DATA`, 256 Bytes
+- `prevRandao`: `DATA`, 32 Bytes
+- `blockNumber`: `QUANTITY`, 64 Bits
+- `gasLimit`: `QUANTITY`, 64 Bits
+- `gasUsed`: `QUANTITY`, 64 Bits
+- `timestamp`: `QUANTITY`, 64 Bits
+- `extraData`: `DATA`, 0 to 32 Bytes
+- `baseFeePerGas`: `QUANTITY`, 256 Bits
+- `blockHash`: `DATA`, 32 Bytes
+- `transactionsRoot`: `DATA`, 32 Bytes
+
+#### SSZ Objects
+
+Consider the following definitions supplementary to the definitions in [`consensus-specs`][consensus-specs].
+
+##### `builder_setFeeRecipientV1` Request
+
+```python
+class SetFeeRecipientRequestV1(Container):
+    feeRecipient: Bytes20
+    timestamp: uint64
+```
+
+##### `builder_getPayloadV1` Response
+
+```python
+class GetPayloadResponseV1(Container):
+    payload: ExecutionPayloadHeader
+    value: uint256
+```
+
+##### `builder_getPayloadV1` Request
+
+###### `SignedBlindBeaconBlock`
+
+```python
+class SignedBlindBeaconBlock(Container):
+    message: BlindBeaconBlock
+    signature: BLSSignature
+```
+
+###### `BlindBeaconBlock`
+
+```python
+class BlindBeaconBlock(Container):
+    slot: Slot
+    proposer_index: ValidatorIndex
+    parent_root: Root
+    state_root: Root
+    body: BlindBeaconBlockBody
+```
+
+###### `BlindBeaconBlockBody`
+
+```python
+class BlindBeaconBlockBody(Container):
+    randao_reveal: BLSSignature
+    eth1_data: Eth1Data
+    graffiti: Bytes32
+    proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
+    attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
+    attestations: List[Attestation, MAX_ATTESTATIONS]
+    deposits: List[Deposit, MAX_DEPOSITS]
+    voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+    sync_aggregate: SyncAggregate
+    execution_payload: ExecutionPayloadHeader
+```
+
+## Errors
+
+The list of error codes introduced by this specification can be found below.
+
+| Code | Message | Meaning |
+| - | - | - |
+| -32000 | Server error | Generic client error while processing request. |
+| -32001 | Unknown hash | No block with the provided hash is known. |
+| -32002 | Unknown validator | No known mapping between validator and feeRecipient. |
+| -32003 | Invalid SSZ | Unable to decode SSZ. |
+| -32004 | Unknown block | Block does not match the provided header. |
+| -32005 | Invalid signature | Provided signature is invalid. |
+| -32006 | Invalid timestamp | Provided timestamp was invalid. |
+| -32600 | Invalid request | The JSON sent is not a valid Request object. |
+| -32601 | Method not found | The method does not exist / is not available. |
+| -32602 | Invalid params | Invalid method parameter(s). |
+| -32603 | Internal error | Internal JSON-RPC error. |
+| -32700 | Parse error | Invalid JSON was received by the server. |
+
+## Routines
+
+### Signing
+
+All signature operations should follow the [standard BLS operations][bls] interface defined in `consensus-specs`.
+
+There are two types of data to sign over in the Builder API:
+* In-protocol messages, e.g. [`BlindBeaconBlock`](#blindbeaconblock), which should compute the signing root using [`computer_signing_root`][compute-signing-root] and use the domain specified for beacon block proposals.
+* Builder API messages, e.g. [`builder_setFeeRecipientV1`](#builder_setFeeRecipientV1) and the response to [`builder_getHeader`](#response-2), which should compute the signing root using [`compute_signing_root`][compute-signing-root] and the domain `DomainType('0xXXXXXXXX')` (TODO: get a proper domain).
+
+As `compute_signing_root` takes `SSZObject` as input, client software should convert in-protocol messages to their SSZ representation to compute the signing root and Builder API messages to the SSZ representations defined [above](#sszobjects).
+
+## Methods
+
+### `builder_setFeeRecipientV1`
+
+#### Request
+
+- method: `builder_setFeeRecipientV1`
+- params:
+  1. `message`: `object`
+      1. `feeRecipient`: `DATA`, 20 Bytes - Address of account which should receive fees.
+      2. `timestamp`: `QUANTITY`, uint64 - Unix timestamp of announcement.
+  2. `publicKey`: `DATA`, 48 Bytes - Public key of validator.
+  3. `signature`: `DATA`, 96 Bytes - Signature over `feeRecipient` and `timestamp`.
+
+#### Response
+
+- result: `null`
+- error: code and message set in case an exception happens while getting the payload.
+
+#### Specification
+1. Builder software **MUST** verify `signature` is valid under `publicKey`.
+2. Builder software **MUST** respond to requests where `timestamp` is before the latest announcement from the validator with `-32006: Invalid timestamp`.
+3. Builder software **MUST** store `feeRecipient` in a map keyed by `publicKey`.
+
+### `builder_getHeaderV1`
+
+#### Request
+
+- method: `builder_getHeaderV1`
+- params:
+  1. `hash`: `DATA`, 32 Bytes - Hash of Execution Layer block which the validator intends to use as the parent for its proposal.
+
+#### Response
+
+- result: `object`
+    - `message`: `object`
+        - `header`: [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1).
+        - `value`: `DATA`, 32 Bytes - the payment in wei that will be directed to the `feeRecipient` account.
+    - `publicKey`: `DATA`, 48 Bytes - the public key associated with the builder.
+    - `signature`: `DATA`, 96 Bytes - BLS signature of the builder over `payload` and `value`.
+- error: code and message set in case an exception happens while getting the payload.
+
+#### Specification
+1. Builder software **SHOULD** respond immediately with the `header` that increases the `feeRecipient`'s balance by the most.
+2. Builder software **MUST** return `-32001: Unknown hash` if the block identified by `hash` does not exist.
+3. Builder software **MUST** return `-32002: Unknown validator` if the validator the builder expects to propose in the current slot has not been mapped to a `feeRecipient`.
+4. Builder software **MAY** set the `feeRecipient` for the block to a different address than the address mapped to the validator so long as a payment equal to `value` is made to `feeRecipient`.
+
+### `builder_getPayloadV1`
+
+#### Request
+
+- method: `builder_getPayloadV1`
+- params:
+  1. `block`: `DATA`, arbitray length - SSZ encoded [`SignedBlindBeaconBlock`](#blindbeaconblock).
+
+#### Response
+
+- result: [`ExecutionPayloadV1`](#executionpayloadv1).
+- error: code and message set in case an exception happens while proposing the payload.
+
+#### Specification
+1. Builder software **MUST** verify that `block` is an SSZ encoded [`SignBlindBeaconBlock`](#blindbeaconblock). If the block is encoded incorrectly, the builder **MUST** return `-32003: Invalid SSZ`. If the block is encoded correctly, but does not include a matching `ExecutionPayloadHeaderV1` provided from `builder_getHeaderV1`, the builder **SHOULD** return `-32004: Unknown block`.
+2. Builder software **MUST** verify that `signature` is a BLS signature over `block` using [`verify_block_signature`][verify-block-signature] from the validator that is expected to propose in the given slot. If the signature is determined to be invalid or from a different validator than expected, the builder **MUST** return `-32005: Invalid signature`.
+
+[consensus-specs]: https://github.com/ethereum/consensus-specs
+[bls]: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#bls-signatures
+[compute-signing-root]: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#compute_signing_root
+[bytes20]: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#aliases
+[uint256]: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#basic-types
+[execution-payload-header]: https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#executionpayloadheader
+[execution-payload]: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv1
+[hash-tree-root]: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#merkleization
+[beacon-block]: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#beaconblock
+[verify-block-signature]: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -256,8 +256,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 1. Builder software **MUST** verify `pubkey` corresponds to an active or pending validator, otherwise return error `-32002: Unknown validator`.
 2. Builder software **MUST** verify `signature` is valid under `pubkey`, otherwise return error `-32005: Invalid Signature`.
 3. Builder software **MUST** respond to requests where `timestamp` is less than or equal to the latest announcement from the validator or more than 1 hour in the future with error `-32007: Invalid timestamp`.
-4. Builder software **MUST** store `feeRecipient` in a map keyed by `pubkey`.
-5. Builder software **MUST** return `result` as `"OK"` if the request succeeds, `null` otherwise.
+4. Builder software **MUST** return `result` as `"OK"` if the request succeeds, `null` otherwise.
 
 ### `builder_getHeaderV1`
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -56,19 +56,19 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `proposerIndex`: `QUANTITY`, 64 Bits
 - `parentRoot`: `DATA`, 32 Bytes
 - `stateRoot`: `DATA`, 32 Bytes
-- `body`: `object`, `BlindBeaconBlockBodyV1`
+- `body`: `object`, [`BlindBeaconBlockBodyV1`](#blindbeaconblockbodyv1)
 
 ### `BlindBeaconBlockBodyV1`
 - `randaoReveal`: `DATA`, 96 Bytes
-- `eth1Data`: `object`, `Eth1DataV1`
+- `eth1Data`: `object`, [`Eth1DataV1`](#eth1datav1)
 - `graffiti`: `DATA`, 32 Bytes
-- `proposerSlashings`: `object`, `ProposerSlashingV1`
-- `attesterSlashings`: `object`, `AttesterSlashingV1`
-- `attestations`: `Array`, `AttestationV1`
-- `deposits`: `Array`, `DespositV1`
-- `voluntaryExits`: `Array`, `SignedVoluntaryExitV1`
-- `syncAggregate`: `object`, `SyncAggregateV1`
-- `executionPayload`: `object`, `ExecutionPayloadHeaderV1`
+- `proposerSlashings`: `object`, [`ProposerSlashingV1`](#proposerslashingv1)
+- `attesterSlashings`: `object`, [`AttesterSlashingV1`](#attesterslashingv1)
+- `attestations`: `Array`, [`AttestationV1`](#attestationv1)
+- `deposits`: `Array`, [`DespositV1`](#depositv1)
+- `voluntaryExits`: `Array`, [`SignedVoluntaryExitV1`](#signedvoluntaryexitv1)
+- `syncAggregate`: `object`, [`SyncAggregateV1`](#syncaggregatev1)
+- `executionPayload`: `object`, [`ExecutionPayloadHeaderV1`](#executionpayloadheader)
 
 ### `Eth1DataV1`
 - `depositRoot`: `DATA`, 32 Bytes
@@ -76,8 +76,8 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `blockHash`: `DATA`, 32 Bytes
 
 ### `ProposerSlashing`
-- `signedHeader1`: `object`, `SignedBeaconBlockBlockHeaderV1`
-- `signedHeader2`: `object`, `SignedBeaconBlockBlockHeaderV1`
+- `signedHeader1`: `object`, [`SignedBeaconBlockBlockHeaderV1`](#signedbeaconblockheaderv1)
+- `signedHeader2`: `object`, [`SignedBeaconBlockBlockHeaderV1`](#signedbeaconblockheaderv1)
 
 ### `BeaconBlockHeaderV1`
 - `slot`: `QUANTITY`, 64 Bits
@@ -87,20 +87,20 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `bodyRoot`: `DATA`, 32 Bytes
 
 ### `AttesterSlashingV1`
-- `attestation1`: `object`, `IndexedAttestationV1`
-- `attestation2`: `object`, `IndexedAttestationV1`
+- `attestation1`: `object`, [`IndexedAttestationV1`](#indexedattestationv1)
+- `attestation2`: `object`, [`IndexedAttestationV1`](#indexedattestationv1)
 
 ### `IndexedAttestationV1`
 - `attestingIndices`: `Array`, `QUANTITY`, 64 Bits
-- `data`: `object`, `AttestationDataV1`
+- `data`: `object`, [`AttestationDataV1`](#attestationdatav1)
 - `signature`: `DATA`, 96 Bytes
 
 ### `AttestationDataV1`
 - `slot`: `QUANTITY`, 64 Bits
 - `index`: `QUANTITY`, 64 Bits
 - `beaconBlockRoot`, `DATA`, 32 Bytes
-- `source`: `object`, `CheckpointV1`
-- `target`: `object`, `CheckpointV1`
+- `source`: `object`, [`CheckpointV1`](#checkpointv1)
+- `target`: `object`, [`CheckpointV1`](#checkpointv1)
 
 ### `CheckpointV1`
 - `epoch`: `QUANTITY`, 64 Bits
@@ -108,12 +108,12 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 
 ### `AttestationV1`
 - `aggregationBits`: `DATA`, 0 to 256 Bytes
-- `data`: `object`, `AttestationDataV1`
+- `data`: `object`, [`AttestationDataV1`](#attestationdatav1)
 - `signature`: `DATA`, 96 Bytes
 
 ### `DespositV1`
 - `proof`: `Array`, 32 Bytes
-- `data`: `object`, `DepositDataV1`
+- `data`: `object`, [`DepositDataV1`](#depositdatav1)
 
 ### `DepositDataV1`
 - `pubkey`: `DATA`, 48 Bytes
@@ -132,11 +132,11 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 #### Signed Containers
 
 ### `SignedBeaconBlockBlockHeaderV1`
-- `message`: `object`, BeaconBlockHeader
+- `message`: `object`, [`BeaconBlockHeader`](#beaconblockheaderv1)
 - `signature`: `DATA`, 96 Bytes
 
 ### `SignedVoluntaryExitV1`
-- `message`: `object`, `VoluntaryExitV1`
+- `message`: `object`, [`VoluntaryExitV1`](#voluntaryexitv1)
 - `signature`: `DATA`, 96 Bytes
 
 #### SSZ Objects
@@ -294,7 +294,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - error: code and message set in case an exception happens while proposing the payload.
 
 #### Specification
-1. Builder software **MUST** verify that the beacon block's exeuction payload is a matching `ExecutionPayloadHeaderV1` provided from `builder_getHeaderV1`, otherwise the return `-32004: Unknown block`.
+1. Builder software **MUST** verify that the beacon block's exeuction payload is a matching [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1) provided from [`builder_getHeaderV1`](#buildergetheaderv1), otherwise the return `-32004: Unknown block`.
 2. Builder software **MUST** verify that `signature` is a BLS signature over `block` using [`verify_block_signature`][verify-block-signature] from the validator that is expected to propose in the slot. If the signature is determined to be invalid or from a different validator than expected, the builder **MUST** return `-32005: Invalid signature`.
 
 [consensus-specs]: https://github.com/ethereum/consensus-specs

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -152,12 +152,13 @@ class RegisterValidatorV1(Container):
     pubkey: BLSPubkey
 ```
 
-##### `builder_getPayloadV1` Response
+##### `builder_getHeaderV1` Response
 
 ```python
-class GetPayloadResponseV1(Container):
+class GetHeaderResponseV1(Container):
     payload: ExecutionPayloadHeader
     value: uint256
+    pubkey: BLSPubkey
 ```
 
 ##### `builder_getPayloadV1` Request

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -126,7 +126,7 @@ class ValidatorRegistrationV1(Container):
     pubkey: BLSPubkey
 ```
 
-##### `BuilderReceiptV1`
+##### `BuilderBidV1`
 
 ```python
 class BuilderBidV1(Container):
@@ -273,7 +273,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
         - `header`: [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1).
         - `value`: `DATA`, 32 Bytes - Payment in wei that will be paid to the `feeRecipient` account.
         - `pubkey`: `DATA`, 48 Bytes - BLS public key associated with the builder.
-    - `signature`: `DATA`, 96 Bytes - BLS signature over [`BuilderReceiptV1`](#builderreceiptv1).
+    - `signature`: `DATA`, 96 Bytes - BLS signature over [`BuilderBid1`](#builderbidv1).
 - error: code and message set in case an exception happens while getting the header.
 
 #### Specification

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -25,14 +25,14 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `blockHash`: `DATA`, 32 Bytes
 - `transactionsRoot`: `DATA`, 32 Bytes
 
-### `BlindBeaconBlockV1`
+### `BlindedBeaconBlockV1`
 - `slot`: `QUANTITY`, 64 Bits
 - `proposerIndex`: `QUANTITY`, 64 Bits
 - `parentRoot`: `DATA`, 32 Bytes
 - `stateRoot`: `DATA`, 32 Bytes
-- `body`: `object`, [`BlindBeaconBlockBodyV1`](#blindbeaconblockbodyv1)
+- `body`: `object`, [`BlindedBeaconBlockBodyV1`](#blindedbeaconblockbodyv1)
 
-### `BlindBeaconBlockBodyV1`
+### `BlindedBeaconBlockBodyV1`
 - `randaoReveal`: `DATA`, 96 Bytes
 - `eth1Data`: `object`, [`Eth1DataV1`](#eth1datav1)
 - `graffiti`: `DATA`, 32 Bytes
@@ -135,21 +135,21 @@ class BuilderBidV1(Container):
     pubkey: BLSPubkey
 ```
 
-###### `BlindBeaconBlock`
+###### `BlindedBeaconBlock`
 
 ```python
-class BlindBeaconBlock(Container):
+class BlindedBeaconBlock(Container):
     slot: Slot
     proposer_index: ValidatorIndex
     parent_root: Root
     state_root: Root
-    body: BlindBeaconBlockBody
+    body: BlindedBeaconBlockBody
 ```
 
-###### `BlindBeaconBlockBody`
+###### `BlindedBeaconBlockBody`
 
 ```python
-class BlindBeaconBlockBody(Container):
+class BlindedBeaconBlockBody(Container):
     randao_reveal: BLSSignature
     eth1_data: Eth1Data
     graffiti: Bytes32
@@ -210,7 +210,7 @@ $ curl https://localhost:8550 \
 All signature operations should follow the [standard BLS operations][bls] interface defined in `consensus-specs`.
 
 There are two types of data to sign over in the Builder API:
-* In-protocol messages, e.g. [`BlindBeaconBlock`](#blindbeaconblock), which should compute the signing root using [`compute_signing_root`][compute-signing-root] and use the domain specified for beacon block proposals.
+* In-protocol messages, e.g. [`BlindedBeaconBlock`](#blindedbeaconblock), which should compute the signing root using [`compute_signing_root`][compute-signing-root] and use the domain specified for beacon block proposals.
 * Builder API messages, e.g. [`builder_registerValidatorV1`](#builder_registerValidatorV1) and the response to [`builder_getHeader`](#response-2), which should compute the signing root using [`compute_signing_root`][compute-signing-root] and the domain `DomainType('0xXXXXXXXX')` (TODO: get a proper domain).
 
 As `compute_signing_root` takes `SSZObject` as input, client software should convert in-protocol messages to their SSZ representation to compute the signing root and Builder API messages to the SSZ representations defined [above](#sszobjects).
@@ -289,8 +289,8 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 
 - method: `builder_getPayloadV1`
 - params:
-  1. `message`: [`BlindBeaconBlock`](#blindbeaconblockv1).
-  2. `signature`: `DATA`, 96 Bytes - BLS signature over [`BlindBeaconBlock`](#blindbeaconblockv1).
+  1. `message`: [`BlindedBeaconBlock`](#blindedbeaconblockv1).
+  2. `signature`: `DATA`, 96 Bytes - BLS signature over [`BlindedBeaconBlock`](#blindedbeaconblockv1).
 
 #### Response
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -62,8 +62,8 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `randaoReveal`: `DATA`, 96 Bytes
 - `eth1Data`: `object`, [`Eth1DataV1`](#eth1datav1)
 - `graffiti`: `DATA`, 32 Bytes
-- `proposerSlashings`: `object`, [`ProposerSlashingV1`](#proposerslashingv1)
-- `attesterSlashings`: `object`, [`AttesterSlashingV1`](#attesterslashingv1)
+- `proposerSlashings`: `Array`, [`ProposerSlashingV1`](#proposerslashingv1)
+- `attesterSlashings`: `Array`, [`AttesterSlashingV1`](#attesterslashingv1)
 - `attestations`: `Array`, [`AttestationV1`](#attestationv1)
 - `deposits`: `Array`, [`DespositV1`](#depositv1)
 - `voluntaryExits`: `Array`, [`SignedVoluntaryExitV1`](#signedvoluntaryexitv1)

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -267,7 +267,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - params:
   1. `slot`: `QUANTITY`, 64 Bits - Slot number of the block proposal.
   2. `pubkey`: `QUANTITY`, 48 Bytes - BLS public key of validator.
-  3. `hash`: `DATA`, 32 Bytes - Hash of execution layer block the proposer will use as the proposal's parent.
+  3. `parentHash`: `DATA`, 32 Bytes - Hash of execution layer block the proposer will use as the proposal's parent.
 
 #### Response
 
@@ -281,7 +281,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 
 #### Specification
 1. Builder software **SHOULD** respond immediately with the `header` that increases the `feeRecipient`'s balance by the most.
-2. Builder software **MUST** return `-32001: Unknown hash` if the block identified by `hash` is not known.
+2. Builder software **MUST** return a `header` whose `parentHash` matches the request's `parentHash`. If `parentHash` is not known by the builder, it **MUST** return `-32001: Unknown hash`.
 3. Builder software **MUST** return `-32002: Unknown validator` if `pubkey` does not map to the validator that is expected to propose at `slot`.
 4. Builder software **MUST** return `-32003: Unknown fee recipient` if the builder does not have a `feeRecipient` mapped to the validator.
 5. Builder software **MAY** set the `feeRecipient` for the block to a different address than the address mapped to the validator so long as a payment equal to `value` is made to `feeRecipient`.

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -122,6 +122,7 @@ Consider the following definitions supplementary to the definitions in [`consens
 ```python
 class ValidatorRegistrationV1(Container):
     feeRecipient: Bytes20
+    gasTarget: uint64
     timestamp: uint64
     pubkey: BLSPubkey
 ```
@@ -241,7 +242,8 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - params:
   1. `message`: `object`
       1. `feeRecipient`: `DATA`, 20 Bytes - Address of account which should receive fees.
-      2. `timestamp`: `QUANTITY`, uint64 - Unix timestamp of announcement.
+      2. `gasTarget`: QUANTITY, 64 bits - Target for block `gasTarget`.
+      2. `timestamp`: `QUANTITY`, 64 bits - Unix timestamp of announcement.
       3. `pubkey`: `DATA`, 48 Bytes - BLS public key of validator.
   3. `signature`: `DATA`, 96 Bytes - BLS signature over [`ValidatorRegistrationV1`](#validatorregistrationv1).
 
@@ -283,6 +285,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 3. Builder software **MUST** return `-32002: Unknown validator` if `pubkey` does not map to the validator that is expected to propose at `slot`.
 4. Builder software **MUST** return `-32003: Unknown fee recipient` if the builder does not have a `feeRecipient` mapped to the validator.
 5. Builder software **MAY** set the `feeRecipient` for the block to a different address than the address mapped to the validator so long as a payment equal to `value` is made to `feeRecipient`.
+6. Builder software **MUST** return a header whose `gasLimit` is equal to the validator's registered `gasTarget * 2` or as close as possible under the constraints of the consensus rules.
 
 ### `builder_getPayloadV1`
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -253,7 +253,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - error: code and message set in case an exception happens while registering the validator.
 
 #### Specification
-1. Builder software **MUST** verify `pubkey` corresponds to an active or pending validator, otherwise return error `-32003: Unknown validator`.
+1. Builder software **MUST** verify `pubkey` corresponds to an active or pending validator, otherwise return error `-32002: Unknown validator`.
 2. Builder software **MUST** verify `signature` is valid under `pubkey`, otherwise return error `-32005: Invalid Signature`.
 3. Builder software **MUST** respond to requests where `timestamp` is less than or equal to the latest announcement from the validator or more than 1 hour in the future with error `-32007: Invalid timestamp`.
 4. Builder software **MUST** store `feeRecipient` in a map keyed by `pubkey`.

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -75,7 +75,7 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `depositCount`: `QUANTITY`, 64 Bits
 - `blockHash`: `DATA`, 32 Bytes
 
-### `ProposerSlashing`
+### `ProposerSlashingV1`
 - `signedHeader1`: `object`, [`SignedBeaconBlockHeaderV1`](#signedbeaconblockheaderv1)
 - `signedHeader2`: `object`, [`SignedBeaconBlockHeaderV1`](#signedbeaconblockheaderv1)
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -122,7 +122,7 @@ Consider the following definitions supplementary to the definitions in [`consens
 ```python
 class ValidatorRegistrationV1(Container):
     feeRecipient: Bytes20
-    gasTarget: uint64
+    gasLimit: uint64
     timestamp: uint64
     pubkey: BLSPubkey
 ```
@@ -242,7 +242,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - params:
   1. `message`: `object`
       1. `feeRecipient`: `DATA`, 20 Bytes - Address of account which should receive fees.
-      2. `gasTarget`: QUANTITY, 64 bits - Target for block `gasTarget`.
+      2. `gasLimit`: `QUANTITY`, 64 bits - Target gas limit for block.
       3. `timestamp`: `QUANTITY`, 64 bits - Unix timestamp of announcement.
       4. `pubkey`: `DATA`, 48 Bytes - BLS public key of validator.
   2. `signature`: `DATA`, 96 Bytes - BLS signature over [`ValidatorRegistrationV1`](#validatorregistrationv1).
@@ -285,7 +285,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 3. Builder software **MUST** return `-32002: Unknown validator` if `pubkey` does not map to the validator that is expected to propose at `slot`.
 4. Builder software **MUST** return `-32003: Unknown fee recipient` if the builder does not have a `feeRecipient` mapped to the validator.
 5. Builder software **MAY** set the `feeRecipient` for the block to a different address than the address mapped to the validator so long as a payment equal to `value` is made to `feeRecipient`.
-6. Builder software **MUST** return a header whose `gasLimit` is equal to the validator's registered `gasTarget * 2` or as close as possible under the constraints of the consensus rules.
+6. Builder software **MUST** return a header whose `gasLimit` is equal to the validator's registered `gasLimit` or as close as possible under the constraints of the consensus rules.
 
 ### `builder_getPayloadV1`
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -97,7 +97,7 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 
 ### `VoluntaryExitV1`
 - `epoch`: `QUANTITY`, 64 Bits
-- `ValidatorIndex`: `QUANTITY`, 64 Bits
+- `validatorIndex`: `QUANTITY`, 64 Bits
 
 ### `SyncAggregateV1`
 - `syncCommitteeBits`: `DATA`, 64 Bytes

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -249,7 +249,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 
 #### Specification
 1. Builder software **MUST** verify `signature` is valid under `pubkey`, otherwise return error `-32005: Invalid Signature`.
-2. Builder software **MUST** respond to requests where `timestamp` is before the latest announcement from the validator with error `-32007: Invalid timestamp`.
+2. Builder software **MUST** respond to requests where `timestamp` is less than or equal to the latest announcement from the validator or more than 1 hour in the future with error `-32007: Invalid timestamp`.
 3. Builder software **MUST** store `feeRecipient` in a map keyed by `pubkey`.
 
 ### `builder_getHeaderV1`

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -262,12 +262,12 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 
 #### Response
 
-- result: `null`
+- result: `enum`, `"OK" | null`
 - error: code and message set in case the builder is not operating normally.
 
 #### Specification
 
-1. Builder software **SHOULD** return `-32000: Server error` if it is unable to respond to requests. `err` **MUST** be set explaining the issue.
+1. Builder software **MUST** return `-32000: Server error` if it is unable to respond to requests. `err` **SHOULD** be set explaining the issue and `result` **MUST** be `null`.
 
 ### `builder_registerValidatorV1`
 
@@ -283,13 +283,14 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 
 #### Response
 
-- result: `null`
+- result: `enum`, `"OK" | null`
 - error: code and message set in case an exception happens while registering the validator.
 
 #### Specification
 1. Builder software **MUST** verify `signature` is valid under `pubkey`, otherwise return error `-32005: Invalid Signature`.
 2. Builder software **MUST** respond to requests where `timestamp` is less than or equal to the latest announcement from the validator or more than 1 hour in the future with error `-32007: Invalid timestamp`.
 3. Builder software **MUST** store `feeRecipient` in a map keyed by `pubkey`.
+4. Builder software **MUST** return `result` as `"OK"` if the request succeeds, `null` otherwise.
 
 ### `builder_getHeaderV1`
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -143,25 +143,25 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 
 Consider the following definitions supplementary to the definitions in [`consensus-specs`][consensus-specs].
 
-##### `builder_registerValidatorV1` Request
+##### `ValidatorRegistrationV1`
 
 ```python
-class RegisterValidatorV1(Container):
+class ValidatorRegistrationV1(Container):
     feeRecipient: Bytes20
     timestamp: uint64
     pubkey: BLSPubkey
 ```
 
-##### `builder_getHeaderV1` Response
+##### `BuilderReceiptV1`
 
 ```python
-class GetHeaderResponseV1(Container):
+class BuilderReceiptV1(Container):
     payload: ExecutionPayloadHeader
     value: uint256
     pubkey: BLSPubkey
 ```
 
-##### `builder_getPayloadV1` Request
+##### `SignedBlindBeaconBlock
 
 ###### `SignedBlindBeaconBlock`
 
@@ -278,8 +278,8 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
   1. `message`: `object`
       1. `feeRecipient`: `DATA`, 20 Bytes - Address of account which should receive fees.
       2. `timestamp`: `QUANTITY`, uint64 - Unix timestamp of announcement.
-      3. `pubkey`: `DATA`, 48 Bytes - Public key of validator.
-  3. `signature`: `DATA`, 96 Bytes - Signature over `feeRecipient` and `timestamp`.
+      3. `pubkey`: `DATA`, 48 Bytes - BLS public key of validator.
+  3. `signature`: `DATA`, 96 Bytes - BLS signature over [`ValidatorRegistrationV1`](#validatorregistrationv1).
 
 #### Response
 
@@ -299,7 +299,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - method: `builder_getHeaderV1`
 - params:
   1. `slot`: `QUANTITY`, 64 Bits - Slot number of the block proposal.
-  2. `pubkey`: `QUANTITY`, 64 Bits - Corresponding public key of proposer.
+  2. `pubkey`: `QUANTITY`, 64 Bits - BLS public key of proposer.
   3. `hash`: `DATA`, 32 Bytes - Hash of execution layer block the proposer will use as the proposal's parent.
 
 #### Response
@@ -307,9 +307,9 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - result: `object`
     - `message`: `object`
         - `header`: [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1).
-        - `value`: `DATA`, 32 Bytes - the payment in wei that will be paid to the `feeRecipient` account.
-        - `pubkey`: `DATA`, 48 Bytes - the public key associated with the builder.
-    - `signature`: `DATA`, 96 Bytes - BLS signature of the builder over `message`.
+        - `value`: `DATA`, 32 Bytes - Payment in wei that will be paid to the `feeRecipient` account.
+        - `pubkey`: `DATA`, 48 Bytes - BLS public key associated with the builder.
+    - `signature`: `DATA`, 96 Bytes - BLS signature over [`BuilderReceiptV1`](#builderreceiptv1).
 - error: code and message set in case an exception happens while getting the header.
 
 #### Specification
@@ -326,7 +326,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - method: `builder_getPayloadV1`
 - params:
   1. `message`: [`SignedBlindBeaconBlock`](#signedblindbeaconblockv1).
-  2. `signature`: `DATA`, 96 Bytes.
+  2. `signature`: `DATA`, 96 Bytes - BLS signature over [`SignedBlindBeaconBlock`](#signedblindbeaconblockv1).
 
 #### Response
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -126,7 +126,7 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `ValidatorIndex`: `QUANTITY`, 64 Bits
 
 ### `SyncAggregateV1`
-- `syncCommitteeBits`: `DATA`, 0 to 64 Bytes
+- `syncCommitteeBits`: `DATA`, 64 Bytes
 - `syncCommitteeSignature`: `DATA`, 96 Bytes
 
 #### Signed Containers

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -76,8 +76,8 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `blockHash`: `DATA`, 32 Bytes
 
 ### `ProposerSlashing`
-- `signedHeader1`: `object`, [`SignedBeaconBlockBlockHeaderV1`](#signedbeaconblockheaderv1)
-- `signedHeader2`: `object`, [`SignedBeaconBlockBlockHeaderV1`](#signedbeaconblockheaderv1)
+- `signedHeader1`: `object`, [`SignedBeaconBlockHeaderV1`](#signedbeaconblockheaderv1)
+- `signedHeader2`: `object`, [`SignedBeaconBlockHeaderV1`](#signedbeaconblockheaderv1)
 
 ### `BeaconBlockHeaderV1`
 - `slot`: `QUANTITY`, 64 Bits
@@ -131,7 +131,7 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 
 #### Signed Containers
 
-### `SignedBeaconBlockBlockHeaderV1`
+### `SignedBeaconBlockHeaderV1`
 - `message`: `object`, [`BeaconBlockHeader`](#beaconblockheaderv1)
 - `signature`: `DATA`, 96 Bytes
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -161,7 +161,7 @@ class BuilderReceiptV1(Container):
     pubkey: BLSPubkey
 ```
 
-##### `SignedBlindBeaconBlock
+##### `SignedBlindBeaconBlock`
 
 ###### `SignedBlindBeaconBlock`
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -111,7 +111,7 @@ Equivalent to `ExecutionPayloadV1`, except `transactions` is replaced with `tran
 - `data`: `object`, [`AttestationDataV1`](#attestationdatav1)
 - `signature`: `DATA`, 96 Bytes
 
-### `DespositV1`
+### `DepositV1`
 - `proof`: `Array`, 32 Bytes
 - `data`: `object`, [`DepositDataV1`](#depositdatav1)
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -266,7 +266,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - method: `builder_getHeaderV1`
 - params:
   1. `slot`: `QUANTITY`, 64 Bits - Slot number of the block proposal.
-  2. `pubkey`: `QUANTITY`, 48 Bytes - BLS public key of validator.
+  2. `pubkey`: `DATA`, 48 Bytes - BLS public key of validator.
   3. `parentHash`: `DATA`, 32 Bytes - Hash of execution layer block the proposer will use as the proposal's parent.
 
 #### Response

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -243,9 +243,9 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
   1. `message`: `object`
       1. `feeRecipient`: `DATA`, 20 Bytes - Address of account which should receive fees.
       2. `gasTarget`: QUANTITY, 64 bits - Target for block `gasTarget`.
-      2. `timestamp`: `QUANTITY`, 64 bits - Unix timestamp of announcement.
-      3. `pubkey`: `DATA`, 48 Bytes - BLS public key of validator.
-  3. `signature`: `DATA`, 96 Bytes - BLS signature over [`ValidatorRegistrationV1`](#validatorregistrationv1).
+      3. `timestamp`: `QUANTITY`, 64 bits - Unix timestamp of announcement.
+      4. `pubkey`: `DATA`, 48 Bytes - BLS public key of validator.
+  2. `signature`: `DATA`, 96 Bytes - BLS signature over [`ValidatorRegistrationV1`](#validatorregistrationv1).
 
 #### Response
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -251,10 +251,11 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - error: code and message set in case an exception happens while registering the validator.
 
 #### Specification
-1. Builder software **MUST** verify `signature` is valid under `pubkey`, otherwise return error `-32005: Invalid Signature`.
-2. Builder software **MUST** respond to requests where `timestamp` is less than or equal to the latest announcement from the validator or more than 1 hour in the future with error `-32007: Invalid timestamp`.
-3. Builder software **MUST** store `feeRecipient` in a map keyed by `pubkey`.
-4. Builder software **MUST** return `result` as `"OK"` if the request succeeds, `null` otherwise.
+1. Builder software **MUST** verify `pubkey` corresponds to an active or pending validator, otherwise return error `-32003: Unknown validator`.
+2. Builder software **MUST** verify `signature` is valid under `pubkey`, otherwise return error `-32005: Invalid Signature`.
+3. Builder software **MUST** respond to requests where `timestamp` is less than or equal to the latest announcement from the validator or more than 1 hour in the future with error `-32007: Invalid timestamp`.
+4. Builder software **MUST** store `feeRecipient` in a map keyed by `pubkey`.
+5. Builder software **MUST** return `result` as `"OK"` if the request succeeds, `null` otherwise.
 
 ### `builder_getHeaderV1`
 

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -299,7 +299,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - error: code and message set in case an exception happens while proposing the payload.
 
 #### Specification
-1. Builder software **MUST** verify that the beacon block's execution payload is a matching [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1) provided from [`builder_getHeaderV1`](#buildergetheaderv1), otherwise the return `-32004: Unknown block`.
+1. Builder software **MUST** be able to un-blind the [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1) in `message`, otherwise the return `-32004: Unknown block`.
 2. Builder software **MUST** verify that `signature` is a BLS signature over `block` using [`verify_block_signature`][verify-block-signature] from the validator that is expected to propose in the slot. If the signature is determined to be invalid or from a different validator than expected, the builder **MUST** return `-32005: Invalid signature`.
 
 [consensus-specs]: https://github.com/ethereum/consensus-specs

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -300,7 +300,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 
 #### Specification
 1. Builder software **MUST** be able to un-blind the [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1) in `message`, otherwise the return `-32004: Unknown block`.
-2. Builder software **MUST** verify that `signature` is a BLS signature over `block` using [`verify_block_signature`][verify-block-signature] from the validator that is expected to propose in the slot. If the signature is determined to be invalid or from a different validator than expected, the builder **MUST** return `-32005: Invalid signature`.
+2. Builder software **MUST** verify that `signature` is a BLS signature over `block` using [`verify_block_signature`][verify-block-signature] from the validator that is expected to propose in the slot. If the signature is determined to be invalid or from a different validator than expected, the builder **MUST** return `-32005: Invalid signature`. It's possible that competing chains could have different proposer shuffling, causing multiple proposer indexes to be valid for a given slot.
 
 [consensus-specs]: https://github.com/ethereum/consensus-specs
 [bls]: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#bls-signatures

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -274,7 +274,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
         - `header`: [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1).
         - `value`: `DATA`, 32 Bytes - Payment in wei that will be paid to the `feeRecipient` account.
         - `pubkey`: `DATA`, 48 Bytes - BLS public key associated with the builder.
-    - `signature`: `DATA`, 96 Bytes - BLS signature over [`BuilderBid1`](#builderbidv1).
+    - `signature`: `DATA`, 96 Bytes - BLS signature over [`BuilderBidV1`](#builderbidv1).
 - error: code and message set in case an exception happens while getting the header.
 
 #### Specification

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -255,7 +255,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 #### Specification
 1. Builder software **MUST** verify `pubkey` corresponds to an active or pending validator, otherwise return error `-32002: Unknown validator`.
 2. Builder software **MUST** verify `signature` is valid under `pubkey`, otherwise return error `-32005: Invalid Signature`.
-3. Builder software **MUST** respond to requests where `timestamp` is less than or equal to the latest announcement from the validator or more than 1 hour in the future with error `-32007: Invalid timestamp`.
+3. Builder software **MUST** respond to requests where `timestamp` is less than or equal to the latest announcement from the validator or more than 10 seconds in the future with error `-32007: Invalid timestamp`.
 4. Builder software **MUST** return `result` as `"OK"` if the request succeeds, `null` otherwise.
 
 ### `builder_getHeaderV1`

--- a/src/builder/specification.md
+++ b/src/builder/specification.md
@@ -274,7 +274,7 @@ As `compute_signing_root` takes `SSZObject` as input, client software should con
 - result: `object`
     - `message`: `object`
         - `header`: [`ExecutionPayloadHeaderV1`](#executionpayloadheaderv1).
-        - `value`: `DATA`, 32 Bytes - Payment in wei that will be paid to the `feeRecipient` account.
+        - `value`: `QUANTITY`, 256 Bits - Payment in wei that will be paid to the `feeRecipient` account.
         - `pubkey`: `DATA`, 48 Bytes - BLS public key associated with the builder.
     - `signature`: `DATA`, 96 Bytes - BLS signature over [`BuilderBidV1`](#builderbidv1).
 - error: code and message set in case an exception happens while getting the header.

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -1,5 +1,6 @@
 apis
 attributesv
+bls
 bytecode
 configurationv
 eip
@@ -21,9 +22,10 @@ rlp
 rpc
 schemas
 secp
+sha
+ssz
 statev
 statusv
-sha
 uint
 updatedv
 url


### PR DESCRIPTION
The Builder API developed separately until now in close proximity with [`mev-boost`](https://github.com/flashbots/mev-boost), but now that the design is becoming more stable and we're soliciting feedback from a wider audience, it makes sense to bring to a more open forum.

The Builder API will be implemented by EL clients that wish to participate in a builder network. It's not likely that this will be a standard feature supported by ELs out of the box -- more likely this will be implemented by third-party software such as `mev-boost`, `mev-geth`, etc. However, because a large number of validators will rely on this interface it is important that all CLs integrate this specification. If a client were to not adopt this, it could affect their network share negatively as validators will seek other software with better economics.

With respect to the "external builder network" there are two phases to consider:
1. Direct communication -- this initial goal will be to provide direct communication to relays and therefore there will not be as much of a need for authentication of data.
2. p2p `mev-boost` -- shortly after the Builder API is stabilized, we should define a p2p protocol for sharing builder network messages. This is for a few reasons, but most poignant is the need to maintain validator privacy. This require 

The current specification tries to be forward looking to minimize the number of changes to go from the direct communication phase to the p2p communication phase.