### PR TITLE
Engine API: adjust error codes with JSON-RPC 2.0 spec

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -108,8 +108,8 @@ The list of error codes introduced by this specification can be found below.
 | -32602 | Invalid params | Invalid method parameter(s). | 
 | -32603 | Internal error | Internal JSON-RPC error. |
 | -32000 | Server error | Generic client error while processing request. |
-| -31001 | Unknown payload | Payload does not exist / is not available. |
-| -31002 | Invalid payload attributes | Payload attributes are invalid / inconsistent. |
+| -38001 | Unknown payload | Payload does not exist / is not available. |
+| -38002 | Invalid payload attributes | Payload attributes are invalid / inconsistent. |
 
 Each error returns a `null` `data` value, except `-32000` which returns the `data` object with a `err` member that explains the error encountered.
 
@@ -302,7 +302,7 @@ The payload build process is specified as follows:
   * The values `(forkchoiceState.headBlockHash, forkchoiceState.finalizedBlockHash)` of this method call map on the `POS_FORKCHOICE_UPDATED` event of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#block-validity) and **MUST** be processed according to the specification defined in the EIP
   * All updates to the forkchoice state resulting from this call **MUST** be made atomically.
 
-6. Client software **MUST** ensure that `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by `forkchoiceState.headBlockHash`. If this condition isn't held client software **MUST** respond with `-31002: Invalid payload attributes` and **MUST NOT** begin a payload build process. In such an event, the `forkchoiceState` update **MUST NOT** be rolled back.
+6. Client software **MUST** ensure that `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by `forkchoiceState.headBlockHash`. If this condition isn't held client software **MUST** respond with `-38002: Invalid payload attributes` and **MUST NOT** begin a payload build process. In such an event, the `forkchoiceState` update **MUST NOT** be rolled back.
 
 7. Client software **MUST** begin a payload build process building on top of `forkchoiceState.headBlockHash` and identified via `buildProcessId` value if `payloadAttributes` is not `null` and the forkchoice state has been updated successfully. The build process is specified in the [Payload building](#payload-building) section.
 
@@ -312,7 +312,7 @@ The payload build process is specified as follows:
   * `{payloadStatus: {status: INVALID_TERMINAL_BLOCK, latestValidHash: null, validationError: errorMessage | null}, payloadId: null}` obtained either from the [Payload validation](#payload-validation) process or as a result of validating a PoW block referenced by `forkchoiceState.headBlockHash`
   * `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}` if the payload is deemed `VALID` and a build process hasn't been started
   * `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: buildProcessId}` if the payload is deemed `VALID` and the build process has begun
-  * `{error: {code: -31002, message: "Invalid payload attributes"}}` if the payload is deemed `VALID` and `forkchoiceState` has been applied successfully, but no build process has been started due to invalid `payloadAttributes`.
+  * `{error: {code: -38002, message: "Invalid payload attributes"}}` if the payload is deemed `VALID` and `forkchoiceState` has been applied successfully, but no build process has been started due to invalid `payloadAttributes`.
 
 9. If any of the above fails due to errors unrelated to the normal processing flow of the method, client software **MUST** respond with an error object.
 
@@ -333,7 +333,7 @@ The payload build process is specified as follows:
 
 1. Given the `payloadId` client software **MUST** return the most recent version of the payload that is available in the corresponding build process at the time of receiving the call.
 
-2. The call **MUST** return `-31001: Unknown payload` error if the build process identified by the `payloadId` does not exist.
+2. The call **MUST** return `-38001: Unknown payload` error if the build process identified by the `payloadId` does not exist.
 
 3. Client software **MAY** stop the corresponding build process after serving this call.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -108,7 +108,7 @@ The list of error codes introduced by this specification can be found below.
 | -32602 | Invalid params | Invalid method parameter(s). | 
 | -32603 | Internal error | Internal JSON-RPC error. |
 | -32000 | Server error | Generic client error while processing request. |
-| -32001 | Unknown payload | Payload does not exist / is not available. |
+| -31001 | Unknown payload | Payload does not exist / is not available. |
 
 Each error returns a `null` `data` value, except `-32000` which returns the `data` object with a `err` member that explains the error encountered.
 
@@ -329,7 +329,7 @@ The payload build process is specified as follows:
 
 1. Given the `payloadId` client software **MUST** return the most recent version of the payload that is available in the corresponding build process at the time of receiving the call.
 
-2. The call **MUST** return `-32001: Unknown payload` error if the build process identified by the `payloadId` does not exist.
+2. The call **MUST** return `-31001: Unknown payload` error if the build process identified by the `payloadId` does not exist.
 
 3. Client software **MAY** stop the corresponding build process after serving this call.
 


### PR DESCRIPTION
According to [JSON-RPC 2.0](https://www.jsonrpc.org/specification#error_object) spec, the range `[-32768; -32000]` is reserved for pre-defined errors. Applications should use values outside of this range.

This PR updates existing error codes. It might be a breaking change if a logic of any CL client relies on exact error code value (`-32001`).