### PR TITLE
engine timeouts (redux)

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -135,9 +135,9 @@ $ curl https://localhost:8550 \
 
 ## Timeouts
 
-After the specified `timeout` for a given call transpires without a response, Consensus Layer software **MUST** abort and consider the call as failed.
+Consensus Layer client software **MUST** wait for a specified `timeout` before aborting the call. In such an event, the Consensus Layer client software **MAY** retry the call.
 
-In such an event, the Consensus Layer software **MAY** retry the call.
+Consensus Layer client software **MAY** wait for response longer than it is specified by the `timeout` parameter.
 
 ## Structures
 
@@ -246,7 +246,7 @@ The payload build process is specified as follows:
 * method: `engine_newPayloadV1`
 * params: 
   1. [`ExecutionPayloadV1`](#ExecutionPayloadV1)
-* timeout: 120s
+* timeout: 8s
 
 #### Response
 
@@ -283,7 +283,7 @@ The payload build process is specified as follows:
 * params: 
   1. `forkchoiceState`: `Object` - instance of [`ForkchoiceStateV1`](#ForkchoiceStateV1)
   2. `payloadAttributes`: `Object|null` - instance of [`PayloadAttributesV1`](#PayloadAttributesV1) or `null`
-* timeout: 120s
+* timeout: 8s
 
 #### Response
 
@@ -328,7 +328,7 @@ The payload build process is specified as follows:
 * method: `engine_getPayloadV1`
 * params:
   1. `payloadId`: `DATA`, 8 Bytes - Identifier of the payload build process
-* timeout: 12s
+* timeout: 1s
 
 #### Response
 
@@ -350,7 +350,7 @@ The payload build process is specified as follows:
 * method: `engine_exchangeTransitionConfigurationV1`
 * params:
   1. `transitionConfiguration`: `Object` - instance of [`TransitionConfigurationV1`](#TransitionConfigurationV1)
-* timeout: 12s
+* timeout: 1s
 
 #### Response
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -12,6 +12,7 @@ This document specifies the Engine API methods that the Consensus Layer uses to 
 - [Message ordering](#message-ordering)
 - [Load-balancing and advanced configurations](#load-balancing-and-advanced-configurations)
 - [Errors](#errors)
+- [Timeouts](#timeouts)
 - [Structures](#structures)
   - [ExecutionPayloadV1](#executionpayloadv1)
   - [ForkchoiceStateV1](#forkchoicestatev1)
@@ -132,6 +133,12 @@ $ curl https://localhost:8550 \
 }
 ```
 
+## Timeouts
+
+After the specified `timeout` for a given call transpires without a response, Consensus Layer software **MUST** abort and consider the call as failed.
+
+In such an event, the Consensus Layer software **MAY** retry the call.
+
 ## Structures
 
 Values of a field of `DATA` type **MUST** be encoded as a hexadecimal string with a `0x` prefix matching the regular expression `^0x(?:[a-fA-F0-9]{2})*$`.
@@ -239,6 +246,7 @@ The payload build process is specified as follows:
 * method: `engine_newPayloadV1`
 * params: 
   1. [`ExecutionPayloadV1`](#ExecutionPayloadV1)
+* timeout: 120s
 
 #### Response
 
@@ -275,6 +283,7 @@ The payload build process is specified as follows:
 * params: 
   1. `forkchoiceState`: `Object` - instance of [`ForkchoiceStateV1`](#ForkchoiceStateV1)
   2. `payloadAttributes`: `Object|null` - instance of [`PayloadAttributesV1`](#PayloadAttributesV1) or `null`
+* timeout: 120s
 
 #### Response
 
@@ -319,6 +328,7 @@ The payload build process is specified as follows:
 * method: `engine_getPayloadV1`
 * params:
   1. `payloadId`: `DATA`, 8 Bytes - Identifier of the payload build process
+* timeout: 12s
 
 #### Response
 
@@ -340,6 +350,7 @@ The payload build process is specified as follows:
 * method: `engine_exchangeTransitionConfigurationV1`
 * params:
   1. `transitionConfiguration`: `Object` - instance of [`TransitionConfigurationV1`](#TransitionConfigurationV1)
+* timeout: 12s
 
 #### Response
 


### PR DESCRIPTION
(supersedes #207)


* 8s timeout for engine endpoints **with** block execution semantics
* 1s timeout for engine endpoints **without** execution semantics
* provide directive that CL **MAY** call endpoints again that timeout (but they can also move on to other blocks [other chains or descendents).

Likely EL does not abort just because CL does, but EL can/should make the decision on how long to attempt to process (or attempt longer if called again).
