### PR TITLE
graphql: add raw fields to block and tx

### DIFF
--- a/graphql.json
+++ b/graphql.json
@@ -734,6 +734,38 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "rawHeader",
+            "description": "RawHeader is the RLP encoding of the block's header.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Bytes",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "raw",
+            "description": "Raw is the RLP encoding of the block.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Bytes",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -2056,6 +2088,38 @@
                   "name": "AccessTuple",
                   "ofType": null
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "raw",
+            "description": "Raw is the canonical encoding of the transaction.\nFor legacy transactions, it returns the RLP encoding.\nFor EIP-2718 typed transactions, it returns the type and payload.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Bytes",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rawReceipt",
+            "description": "RawReceipt is the canonical encoding of the receipt. For post EIP-2718 typed transactions\nthis is equivalent to TxType || ReceiptEncoding.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Bytes",
+                "ofType": null
               }
             },
             "isDeprecated": false,


### PR DESCRIPTION
Adds the consensus encoding of the following types to the graphql schema:

- `block`
- `block.header`
- `transaction`
- `transaction.receipt`

These fields can be computed on the client side so they're not strictly necessary. But having them as part of the schema makes debugging easier. It was first raised for receipts as part of https://github.com/ethereum/go-ethereum/issues/24720 and then extended to other types. Implementation in geth: https://github.com/ethereum/go-ethereum/pull/24816 and https://github.com/ethereum/go-ethereum/pull/24738