### PR TITLE
Change BlockNumber to BlockTags for existing APIs

### DIFF
--- a/src/eth/block.json
+++ b/src/eth/block.json
@@ -31,10 +31,10 @@
 		"summary": "Returns information about a block by number.",
 		"params": [
 			{
-				"name": "Block number",
+				"name": "Block",
 				"required": true,
 				"schema": {
-					"$ref": "#/components/schemas/uint"
+					"$ref": "#/components/schemas/BlockNumberOrTag"
 				}
 			},
 			{
@@ -80,9 +80,9 @@
 		"summary": "Returns the number of transactions in a block matching the given block number.",
 		"params": [
 			{
-				"name": "Block number",
+				"name": "Block",
 				"schema": {
-					"$ref": "#/components/schemas/uint"
+					"$ref": "#/components/schemas/BlockNumberOrTag"
 				}
 			}
 		],
@@ -124,9 +124,9 @@
 		"summary": "Returns the number of transactions in a block matching the given block number.",
 		"params": [
 			{
-				"name": "Block number",
+				"name": "Block",
 				"schema": {
-					"$ref": "#/components/schemas/uint"
+					"$ref": "#/components/schemas/BlockNumberOrTag"
 				}
 			}
 		],

--- a/src/eth/transaction.json
+++ b/src/eth/transaction.json
@@ -49,10 +49,10 @@
 		"summary": "Returns information about a transaction by block number and transaction index position.",
 		"params": [
 			{
-				"name": "Block number",
+				"name": "Block",
 				"required": true,
 				"schema": {
-					"$ref": "#/components/schemas/uint"
+					"$ref": "#/components/schemas/BlockNumberOrTag"
 				}
 			},
 			{

--- a/src/schemas/filter.json
+++ b/src/schemas/filter.json
@@ -31,11 +31,11 @@
 		"properties": {
 			"fromBlock": {
 				"title": "from block",
-				"$ref": "#/components/schemas/BlockNumberOrTag"
+				"$ref": "#/components/schemas/uint"
 			},
 			"toBlock": {
 				"title": "to block",
-				"$ref": "#/components/schemas/BlockNumberOrTag"
+				"$ref": "#/components/schemas/uint"
 			},
 			"address": {
 				"title": "Address(es)",

--- a/src/schemas/filter.json
+++ b/src/schemas/filter.json
@@ -31,11 +31,11 @@
 		"properties": {
 			"fromBlock": {
 				"title": "from block",
-				"$ref": "#/components/schemas/uint"
+				"$ref": "#/components/schemas/BlockNumberOrTag"
 			},
 			"toBlock": {
 				"title": "to block",
-				"$ref": "#/components/schemas/uint"
+				"$ref": "#/components/schemas/BlockNumberOrTag"
 			},
 			"address": {
 				"title": "Address(es)",


### PR DESCRIPTION
Some APIs specified in older JSON-RPC documentation
accepted a block number or a block tag. Some carried
that difference over, some didn't.

This delta adds tags as an option to
* eth_getBlockByNumber
* eth_getBlockTransactionCountByNumber
* eth_getUncleCountByBlockNumber
* eth_getTransactionByBlockNumberAndIndex

This brings those APIs  in line with https://eth.wiki/json-rpc/API, 
except for eth_getLogs and eth_newFilter which have only 50% support for block tags among clients

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>