### PR TITLE
Block nonce is 8 bytes

### DIFF
--- a/src/schemas/block.json
+++ b/src/schemas/block.json
@@ -81,7 +81,7 @@
 			},
 			"nonce": {
 				"title": "Nonce",
-				"$ref": "#/components/schemas/bytes"
+				"$ref": "#/components/schemas/bytes8"
 			},
 			"totalDifficulty": {
 				"title": "Total difficult",


### PR DESCRIPTION
The original non-formal spec set the size of the block nonce to 8 bytes.
This PR updates the block nonce (and only the block nonce) to require an
8 byte value.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>