### PR TITLE
Drop chainId from legacy transaction schema

### DIFF
--- a/src/schemas/transaction.json
+++ b/src/schemas/transaction.json
@@ -167,11 +167,6 @@
 				"title": "gas price",
 				"description": "The gas price willing to be paid by the sender in wei",
 				"$ref": "#/components/schemas/uint"
-			},
-			"chainId": {
-				"title": "chainId",
-				"description": "Chain ID that this transaction is valid on.",
-				"$ref": "#/components/schemas/uint"
 			}
 		}
 	},


### PR DESCRIPTION
AFAIK legacy txes don't have a `chainId` field. Only type-1 and type-2 txes.