### PR TITLE
log.transactionHash is required

### DIFF
--- a/src/schemas/receipt.json
+++ b/src/schemas/receipt.json
@@ -2,6 +2,9 @@
 	"Log": {
 		"title": "log",
 		"type": "object",
+		"required": [
+			"transactionHash"
+		],
 		"properties": {
 			"removed": {
 				"title": "removed",


### PR DESCRIPTION
There is a schema disagreement over log.transactionHash between the ethereum execution apis and go-ethereum.

The ethereum execution apis do not mark that property as required https://github.com/ethereum/execution-apis/blob/main/src/schemas/receipt.json#L18-L21

The go-ethereum client however does mark that property as required https://github.com/ethereum/go-ethereum/blob/master/core/types/log.go#L45.

This PR marks log.transactionHash as required.

PS: there are more required properties missing (address, topics, data) but they are out of scope for this PR.