### PR TITLE
`oneOf` fails to match when block txs is empty

### DIFF
--- a/src/schemas/block.json
+++ b/src/schemas/block.json
@@ -96,7 +96,7 @@
 				"$ref": "#/components/schemas/uint"
 			},
 			"transactions": {
-				"oneOf": [
+				"anyOf": [
 					{
 						"title": "Transaction hashes",
 						"type": "array",


### PR DESCRIPTION
In cases where `transactions` is an empty array `[]`, the `oneOf` keyword matches both array items since it can't differentiate. This causes schema validation to fail, because `oneOf` must match _only_ one of the item subschemas.

Two possible fixes:
 1. Change `oneOf` to `anyOf`. The subschemas deviate enough that the only time both can match is in the case of an empty array.
 2. Keep `oneOf` but set `minItems` of one of the item schemas to 1. This way, the empty array would only match one item.

I went with option 1) because it seems more correct. Under 2), the schema would make the distinction that the empty array is _definitely_ one item type or the other, when in reality there isn't enough information for it to make that conclusion.