### PR TITLE
Engine API: narrow down fcU skip conditions

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -311,7 +311,7 @@ The payload build process is specified as follows:
 
 1. Client software **MAY** initiate a sync process if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because data that are requisite for the validation is missing. The sync process is specified in the [Sync](#sync) section.
 
-2. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` references the head of canonical chain. In the case of such an event, client software **MUST** return `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`.
+2. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` references an ancestor of the head of canonical chain. In the case of such an event, client software **MUST** return `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`.
 
 3. If `forkchoiceState.headBlockHash` references a PoW block, client software **MUST** validate this block with respect to terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#transition-block-validity). This check maps to the transition block validity section of the EIP. Additionally, if this validation fails, client software **MUST NOT** update the forkchoice state and **MUST NOT** begin a payload build process.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -311,7 +311,7 @@ The payload build process is specified as follows:
 
 1. Client software **MAY** initiate a sync process if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because data that are requisite for the validation is missing. The sync process is specified in the [Sync](#sync) section.
 
-2. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` doesn't reference a leaf of the block tree. That is, the block referenced by `forkchoiceState.headBlockHash` is neither the head of the canonical chain nor a block at the tip of any other chain. In the case of such an event, client software **MUST** return `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`.
+2. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` references the head of canonical chain. In the case of such an event, client software **MUST** return `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`.
 
 3. If `forkchoiceState.headBlockHash` references a PoW block, client software **MUST** validate this block with respect to terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#transition-block-validity). This check maps to the transition block validity section of the EIP. Additionally, if this validation fails, client software **MUST NOT** update the forkchoice state and **MUST NOT** begin a payload build process.
 


### PR DESCRIPTION
Considering the following EL block tree:

```
CA <- A1 <- A2 <- HEAD
  \
   <- B1 <- B2 <- B3  
```

Current spec allows to skip processing in following cases:
* `fcU(head: A2.blockHash)`, `fcU(head: A1.blockHash)` -- ancestors of the head of canonical chain
* `fcU(head: B2.blockHash)` -- ancestor of a tip of another chain (not a leaf)

After this change, the spec disallows to skip `fcU(head: B2.blockHash)`. For instance, when `BeaconBlock(B3)` appeared to be invalid but the `B3` itself is `VALID`, and then the network re-orgs to `BeaconBlock(B2)` the EL must handle such a re-org properly and start a build process if requested.

TODO:
* [x] add Hive test, https://github.com/txrx-research/TestingTheMerge/pull/6

Thanks to @rjl493456442 for helping to identify this issue.

H/t @djrtwo for the review
