### PR TITLE
Engine API: recommend to retry the call after timeout

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -143,7 +143,7 @@ $ curl https://localhost:8551 \
 
 ## Timeouts
 
-Consensus Layer client software **MUST** wait for a specified `timeout` before aborting the call. In such an event, the Consensus Layer client software **MAY** retry the call.
+Consensus Layer client software **MUST** wait for a specified `timeout` before aborting the call. In such an event, the Consensus Layer client software **SHOULD** retry the call when it is needed to keep progressing.
 
 Consensus Layer client software **MAY** wait for response longer than it is specified by the `timeout` parameter.
 


### PR DESCRIPTION
This change is proposed after the following situation occurred on MSF7:
* CL was syncing and sending an `fcU` to EL
* EL wasn't responding and CL timed out after 8s of waiting for the response
  * An exact reason of why EL didn't respond doesn't matter, in this particular case EL started to sync and didn't respond with `SYNCING`
* CL didn't retry the call later on, thus, processing a beacon block stayed unfinished which bricked the sync process
* A node got stuck in a deadlock as CL stopped sending anything to EL because it was needed a signal from EL to proceed

CL could try to i) resend `fcU` ii) reprocess entire beacon block or do anything else to keep progressing in this scenario. These reactions are pretty much implementation specific. Therefore, the intention of proposed change is to recommend retrying a call after timeout when it may be crucial for CL to keep progressing which ultimately depends on the implementation.

h/t @djrtwo for review
cc @parithosh