### PR TITLE
Make explicit that the child of LVH is INVALID

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -219,11 +219,13 @@ Payload validation process consists of validating a payload with respect to the 
 
 3. Client software **MUST** validate a payload according to the block header and execution environment rule set with modifications to these rule sets defined in the [Block Validity](https://eips.ethereum.org/EIPS/eip-3675#block-validity) section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification):
   * If validation succeeds, the response **MUST** contain `{status: VALID, latestValidHash: payload.blockHash}`
-  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the unique ancestor of the invalid payload satisfying the following two conditions:
-    - It is fully validated and deemed `VALID`
-    - Any other ancestor of the invalid payload with a higher `blockNumber` is `INVALID`
-
-    if such a block exists and is a PoS block. `validHash` is `0x0000000000000000000000000000000000000000000000000000000000000000` if such a block exists and it is a PoW block, and `null` otherwise. 
+  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` **MUST** be:
+    - The block hash of the ancestor of the invalid payload satisfying the following two conditions:
+      - It is fully validated and deemed `VALID`
+      - Any other ancestor of the invalid payload with a higher `blockNumber` is `INVALID`
+    - `0x0000000000000000000000000000000000000000000000000000000000000000` if the above conditions are satisfied by a PoW block.
+    - `null` if client software cannot determine the ancestor of the invalid
+      payload satisfying the above conditions.
   * Client software **MUST NOT** surface an `INVALID` payload over any API endpoint and p2p interface.
 
 4. Client software **MAY** provide additional details on the validation error if a payload is deemed `INVALID` by assigning the corresponding message to the `validationError` field.

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -219,7 +219,7 @@ Payload validation process consists of validating a payload with respect to the 
 
 3. Client software **MUST** validate a payload according to the block header and execution environment rule set with modifications to these rule sets defined in the [Block Validity](https://eips.ethereum.org/EIPS/eip-3675#block-validity) section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification):
   * If validation succeeds, the response **MUST** contain `{status: VALID, latestValidHash: payload.blockHash}`
-  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the unique ancestor of the invalid payload satisfying the following two conditions:
+  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is either `null`, or the block hash of the unique ancestor of the invalid payload satisfying the following two conditions:
     - It is fully validated and deemed `VALID`
     - Any other ancestor of the invalid payload with a higher `blockNumber` is `INVALID`
   * If the most recent valid ancestor is a PoW block, `latestValidHash` **MUST** be set to `0x0000000000000000000000000000000000000000000000000000000000000000`

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -219,7 +219,9 @@ Payload validation process consists of validating a payload with respect to the 
 
 3. Client software **MUST** validate a payload according to the block header and execution environment rule set with modifications to these rule sets defined in the [Block Validity](https://eips.ethereum.org/EIPS/eip-3675#block-validity) section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification):
   * If validation succeeds, the response **MUST** contain `{status: VALID, latestValidHash: payload.blockHash}`
-  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the most recent *valid* ancestor of the invalid payload. That is, the valid ancestor of the payload with the highest `blockNumber`
+  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the unique ancestor of the invalid payload satisfying the following two conditions:
+    - It is `VALID`
+    - Any other ancestor of the invalid payload with a higher `blockNumber` is `INVALID`
   * If the most recent valid ancestor is a PoW block, `latestValidHash` **MUST** be set to `0x0000000000000000000000000000000000000000000000000000000000000000`
   * Client software **MUST NOT** surface an `INVALID` payload over any API endpoint and p2p interface.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -220,7 +220,7 @@ Payload validation process consists of validating a payload with respect to the 
 3. Client software **MUST** validate a payload according to the block header and execution environment rule set with modifications to these rule sets defined in the [Block Validity](https://eips.ethereum.org/EIPS/eip-3675#block-validity) section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification):
   * If validation succeeds, the response **MUST** contain `{status: VALID, latestValidHash: payload.blockHash}`
   * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the unique ancestor of the invalid payload satisfying the following two conditions:
-    - It is `VALID`
+    - It is fully validated and deemed `VALID`
     - Any other ancestor of the invalid payload with a higher `blockNumber` is `INVALID`
   * If the most recent valid ancestor is a PoW block, `latestValidHash` **MUST** be set to `0x0000000000000000000000000000000000000000000000000000000000000000`
   * Client software **MUST NOT** surface an `INVALID` payload over any API endpoint and p2p interface.

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -219,10 +219,11 @@ Payload validation process consists of validating a payload with respect to the 
 
 3. Client software **MUST** validate a payload according to the block header and execution environment rule set with modifications to these rule sets defined in the [Block Validity](https://eips.ethereum.org/EIPS/eip-3675#block-validity) section of [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#specification):
   * If validation succeeds, the response **MUST** contain `{status: VALID, latestValidHash: payload.blockHash}`
-  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is either `null`, or the block hash of the unique ancestor of the invalid payload satisfying the following two conditions:
+  * If validation fails, the response **MUST** contain `{status: INVALID, latestValidHash: validHash}` where `validHash` is the block hash of the unique ancestor of the invalid payload satisfying the following two conditions:
     - It is fully validated and deemed `VALID`
     - Any other ancestor of the invalid payload with a higher `blockNumber` is `INVALID`
-  * If the most recent valid ancestor is a PoW block, `latestValidHash` **MUST** be set to `0x0000000000000000000000000000000000000000000000000000000000000000`
+
+    if such a block exists and is a PoS block. `validHash` is `0x0000000000000000000000000000000000000000000000000000000000000000` if such a block exists and it is a PoW block, and `null` otherwise. 
   * Client software **MUST NOT** surface an `INVALID` payload over any API endpoint and p2p interface.
 
 4. Client software **MAY** provide additional details on the validation error if a payload is deemed `INVALID` by assigning the corresponding message to the `validationError` field.


### PR DESCRIPTION
Make explicit that when returning `INVALID` from payload validation, the child of the `latestValidHash`  in the invalid payload branch, is indeed `INVALID`, allowing thus the consumer to prune any block in this branch starting from said child. 