### PR TITLE
Increase JWT issued-at window to 60s

### DIFF
--- a/src/engine/authentication.md
+++ b/src/engine/authentication.md
@@ -43,7 +43,7 @@ If such a parameter _is_ given, but the file cannot be read, or does not contain
 
 This specification utilizes the following list of JWT claims:
 
-- Required: `iat` (issued-at) claim. The EL **SHOULD** only accept `iat` timestamps which are within +-5 seconds from the current time.
+- Required: `iat` (issued-at) claim. The EL **SHOULD** only accept `iat` timestamps which are within +-60 seconds from the current time.
 - Optional: `id` claim. The CL **MAY** use this to communicate a unique identifier for the individual CL node.
 - Optional: `clv` claim. The CL **MAY** use this to communicate the CL node type/version.
 


### PR DESCRIPTION
Clock drift can occur in resource constraint machines. During network issues both CLs and ELs resources tend to increase a lot, which can delay message processing and affect the JWT iat window. Having a "short" window of 5 seconds can escalate bad network condition into a full disconnect between CL and EL. If that happens the network stalls. Due to this DOS vectors could be cheaper since you only need to push one of the clients out of the 5s window.

@holiman is there any reasoning for the 5s value? Proposing to increase the value has:
**pros**:
- Higher resilience against broken comms between CL-EL during high resource usage
**cons**:
- ??

For this PR I picked 60s as a random value that's > 5s, but don't have any specific argument for it. Would like to hear opinions for
- 5s
- 20s
- 60s
- 300s, etc

According to the doc:
> The type of attacks that this authentication scheme attempts to protect against are the following:
> - RPC port exposed towards the internet, allowing attackers to exchange messages with EL engine API.
> - RPC port exposed towards the browser, allowing malicious webpages to submit messages to the EL engine API.

So, if the token is stolen, what attack can you do in 60s that you can not do in 5s? For a profit driven attacker you probably want to override the fee_recepient, so in that case shorter windows reduce the change of producing a block after stealing. However, if you are able to steal one token, are you likely to be able to steal next token with higher iat?


