### PR TITLE
Add `eth_multicall`

### DIFF
--- a/src/eth/execute.yaml
+++ b/src/eth/execute.yaml
@@ -13,6 +13,27 @@
     name: Return data
     schema:
       $ref: '#/components/schemas/bytes'
+- name: eth_multicall
+  summary: Executes multiple message calls immediately one after the other without creating transactions on the block chain.
+  params:
+    - name: Transactions
+      required: true
+      schema:
+        title: Transactions
+        type: array
+        items:
+          $ref: '#/components/schemas/GenericTransaction'
+    - name: Block
+      required: false
+      schema:
+        $ref: '#/components/schemas/BlockNumberOrTag'
+  result:
+    name: Return data
+    schema:
+      title: Return data
+      type: array
+      items:
+        $ref: '#/components/schemas/bytes'
 - name: eth_estimateGas
   summary: Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
   params:


### PR DESCRIPTION
The `eth_call` executes every message call on the latest state and then discards the state. When someone wants to inspect a state that would be after a transaction would go through, currently it involves a non cheap way, i.e. using the mainnet fork (like ganache/hardhat network/anvil) to confirm the first tx and then query state on it, which makes a lot of rpc calls. This PR proposes addition of `eth_multicall` to the JSON-RPC spec.

```go
eth_multicall([]transction) -> []bytes
```

This method enables following use cases:
- easy state inspection after a series of transactions.
- batching of multiple `eth_call`s from frontends, similar to [makerdao/multicall](https://github.com/makerdao/multicall/blob/master/src/Multicall2.sol) (more efficiently since it does not need to execute multicall contract code)

Closes #267