### PR TITLE
Add stage to run `npm run build:docs`

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,6 +41,7 @@ jobs:
           node-version: '15'
       - run: npm ci
       - run: npm run build
+      - run: npm run build:docs
       - run: 'sed -i -e "s|Prefix: \"\"|Prefix: \"/execution-apis\"|g" build/docs/gatsby/gatsby-config.js'
       - run: 'sed -i -e "s|/api|api|g" build/docs/gatsby/src/pages/index.tsx'
       - run: npm run build:docs


### PR DESCRIPTION
I made a modification to what `npm build` runs and forgot to update the CI deploy action. This should fix the error.