### PR TITLE
Specify a placeholder TTD

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -393,4 +393,6 @@ The payload build process is specified as follows:
 
 6. Considering the absence of the `TERMINAL_BLOCK_NUMBER` setting, Consensus Layer client software **MAY** use `0` value for the `terminalBlockNumber` field in the input parameters of this call.
 
+7. Considering the absence of the `TERMINAL_TOTAL_DIFFICULTY` value (i.e. when a value has not been decided), Consensus Layer and Execution Layer client software **MUST** use `115792089237316195423570985008687907853269984665640564039457584007913129638912` (`2**256-2**10`) value for the `terminalTotalDifficulty` input parameter of this call. 
+
 [json-rpc-spec]: https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/execution-apis/assembled-spec/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -393,6 +393,6 @@ The payload build process is specified as follows:
 
 6. Considering the absence of the `TERMINAL_BLOCK_NUMBER` setting, Consensus Layer client software **MAY** use `0` value for the `terminalBlockNumber` field in the input parameters of this call.
 
-7. Considering the absence of the `TERMINAL_TOTAL_DIFFICULTY` value (i.e. when a value has not been decided), Consensus Layer and Execution Layer client software **MUST** use `115792089237316195423570985008687907853269984665640564039457584007913129638912` (`2**256-2**10`) value for the `terminalTotalDifficulty` input parameter of this call. 
+7. Considering the absence of the `TERMINAL_TOTAL_DIFFICULTY` value (i.e. when a value has not been decided), Consensus Layer and Execution Layer client software **MUST** use `115792089237316195423570985008687907853269984665640564039457584007913129638912` value (equal to`2**256-2**10`) for the `terminalTotalDifficulty` input parameter of this call. 
 
 [json-rpc-spec]: https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/execution-apis/assembled-spec/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false


### PR DESCRIPTION
Allowing the successful exchange of the transition config values before the TTD is known allows users to setup their EL+CL *today*. This helps ensure the network is Ready For The Merge™ and helps with Testing The Merge™.

The consensus specs [specify a placeholder TTD](https://github.com/ethereum/consensus-specs/blob/c04f221fada2cf9bea33d05985fed8fcdcccde74/configs/mainnet.yaml#L16) of `115792089237316195423570985008687907853269984665640564039457584007913129638912`, which is equal to `2**256-2**10`. This value is absurdly high, but not the full size of a `uint256` such that we can still perform tests with greater-than-TTD values.

AFAIK, there is no equivalent placeholder value in the EL specs. Geth presently returns a TTD of `null` and Nethermind a value of `0`.

For reasons specified earlier, I think CL and EL should agree on these placeholder values. Since a specification already exists for the CL (although it is somewhat implicit), I propose that we explicitly apply the same specification to both EL and CL.