### PR TITLE
Don't regenerate gatsby after changing config

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,7 +41,7 @@ jobs:
           node-version: '15'
       - run: npm ci
       - run: npm run build
-      - run: npm run build:docs
+      - run: npm run generate-clients
       - run: 'sed -i -e "s|Prefix: \"\"|Prefix: \"/execution-apis\"|g" build/docs/gatsby/gatsby-config.js'
       - run: 'sed -i -e "s|/api|api|g" build/docs/gatsby/src/pages/index.tsx'
       - run: npm run build:docs

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "build": "npm run build:spec",
     "build:spec": "node scripts/build.js",
-    "build:docs": "mkdir -p build && npm run generate-clients && cd build/docs/gatsby && npm install --legacy-peer-deps && gatsby build --prefix-paths",
+    "build:docs": "cd build/docs/gatsby && npm install --legacy-peer-deps && gatsby build --prefix-paths",
     "lint": "node scripts/build.js && node scripts/validate.js && node scripts/graphql-validate.js",
     "clean": "rm -rf build && mkdir -p build",
-    "generate-clients": "open-rpc-generator generate -c open-rpc-generator-config.json",
+    "generate-clients": "mkdir -p build && open-rpc-generator generate -c open-rpc-generator-config.json",
     "graphql:schema": "node scripts/graphql.js",
     "graphql:validate": "node scripts/graphql-validate.js"
   },


### PR DESCRIPTION
By running `npm run build:docs`, we overwrote the changes made with the preceding `sed` commands.