### PR TITLE
Fix ambiguous spec defintion

### DIFF
--- a/src/engine/authentication.md
+++ b/src/engine/authentication.md
@@ -35,7 +35,7 @@ The HMAC algorithm implies that several CLs will be able to use the same key, an
 
 The `EL` and `CL` clients **MUST** accept a cli/config parameter: `jwt-secret`, which designates a file containing the hex-encoded 256 bit secret key to be used for verifying/generating JWT tokens.
 
-If such a parameter is not given, the client **SHOULD** generate such a token, valid for the duration of the execution, and store the hex-encoded secret as a `jwt.hex` file on the filesystem.  This file can then be used to provision the counterpart client.
+If such a parameter is not given, the `EL` client **SHOULD** generate such a token, valid for the duration of the execution, and store the hex-encoded secret as a `jwt.hex` file on the filesystem.  This file can then be used to provision the counterpart client.
 
 If such a parameter _is_ given, but the file cannot be read, or does not contain a hex-encoded key of `256` bits, the client should treat this as an error: either abort the startup, or show error and continue without exposing the authenticated port.
 


### PR DESCRIPTION
There has been a misunderstanding from the Nimbus team. Without specifying which client SHOULD generate the jwt token, it could be assumed that it's up to the CL client also. This modification request would suggest that only the EL client should generate the jwt token, not the CL client.

[Link to discussion](https://discord.com/channels/613988663034118151/641680546191376384/1007227161385631784). (Nimbus discord)