### PR TITLE
Contributor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 
 [View the spec][playground]
 
-The Ethereum JSON-RPC is a collection of methods that all clients implement.
+The Ethereum JSON-RPC is a standard collection of methods that all exectuion
+clients implement. It is the canonical interface between users and the network.
 This interface allows downstream tooling and infrastructure to treat different
 Ethereum clients as modules that can be swapped at will.
+
+### Contributing
+
+
+
+The specification is written in [OpenRPC][openrpc]. Refer to the
+OpenRPC specification and the JSON schema specification to get started.
 
 ### Building
 
@@ -21,11 +29,6 @@ Build successful.
 
 This will output the file `openrpc.json` in the root of the project. This file
 will have all schema `#ref`s resolved.
-
-### Contributing
-
-The specification is written in [OpenRPC][openrpc]. Refer to the
-OpenRPC specification and the JSON schema specification to get started.
 
 #### Testing
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
-# Ethereum API Specification
+# Execution API Specification
 
 ## JSON-RPC
 
 [View the spec][playground]
 
-The Ethereum JSON-RPC is a standard collection of methods that all exectuion
+The Ethereum JSON-RPC is a standard collection of methods that all execution
 clients implement. It is the canonical interface between users and the network.
 This interface allows downstream tooling and infrastructure to treat different
 Ethereum clients as modules that can be swapped at will.
 
 ### Contributing
 
+Please see the contributors guide in [`docs/making-changes.md`][making-changes]
+for general information about the process of standardizing new API methods and
+making changes to existing ones. Information on test generation can be found
+in [`tests/README.md`][test-gen]
 
-
-The specification is written in [OpenRPC][openrpc]. Refer to the
-OpenRPC specification and the JSON schema specification to get started.
+The specification itself is written in [OpenRPC][openrpc]. Refer to the OpenRPC
+specification and the JSON schema [specification][json-schema] to get started.
 
 ### Building
 
@@ -32,27 +35,39 @@ will have all schema `#ref`s resolved.
 
 #### Testing
 
-There are currently three tools for testing contributions. The main two that
-run as GitHub actions are an [OpenRPC validator][validator] and a
-[spellchecker][spellchecker]:
+There are several mechanisms for testing specification contributions and client
+conformance. 
+
+First is the [OpenRPC validator][validator]. It performs some basic syntactic
+checks on the generated specification.
 
 ```console
 $ npm install
 $ npm run lint
 OpenRPC spec validated successfully.
+```
 
+Next is `speccheck`. This tool validates the test cases in the `tests`
+directory against the specification.
+
+```console
+$ go install github.com/lightclient/rpctestgen/cmd/speccheck@latest
+$ speccheck -v
+all passing.
+```
+
+The spell checker ensures the specification is free of spelling errors.
+
+```console
 $ pip install pyspelling
 $ pyspelling -c spellcheck.yaml
 Spelling check passed :)
 ```
 
-The third tool can validate a live JSON-RPC provider hosted at
-`http://localhost:8545` against the specification:
-
-```console
-$ ./scripts/debug.sh eth_getBlockByNumber \"0xc7d772\",false
-data.json valid
-```
+Finally, the test cases in the `tests/` directory may be run against individual
+execution client using the [`hive`] simulator [`rpc-compat`][rpc-compat].
+Please see the documentation in the aforementioned repositories for more
+information.
 
 ## GraphQL
 
@@ -84,6 +99,10 @@ This repository is licensed under [CC0](LICENSE).
 [playground]: https://ethereum.github.io/execution-apis/api-documentation/
 [openrpc]: https://open-rpc.org
 [validator]: https://open-rpc.github.io/schema-utils-js/globals.html#validateopenrpcdocument
-[spellchecker]: https://facelessuser.github.io/pyspelling/
 [graphql-schema]: http://graphql-schema.ethdevops.io/?url=https://raw.githubusercontent.com/ethereum/execution-apis/main/graphql.json
 [eip-1767]: https://eips.ethereum.org/EIPS/eip-1767
+[making-changes]: docs/making-changes.md
+[json-schema]: https://json-schema.org 
+[hive]: https://github.com/ethereum/hive
+[rpc-compat]: https://github.com/ethereum/hive/tree/master/simulators/ethereum/rpc-compat
+[test-gen]: tests/README.md

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -17,27 +17,90 @@ provided over via API will not be easily accessible to users.
 When considering a change to the API, it's important to keep a few guiding
 principles in mind.
 
+### Neccesity
+
+The most common path to a newly standardized method is neccesity. As the protocol
+changes over time, new types of data become available. EIP-2930 neccesitated the
+introduction of `eth_accessList` and EIP-1559 neccesitated `eth_feeHistory`.
+
+Therefore, a good question to ask before making a new API proposal is whether
+or not the method is strictly neccessary. Sometimes the answer is yes even
+without a protocol change. For example, `eth_getProof` has been possible since
+the inital version of Ethereum -- yet, it was only standardized in recent years
+as demand for the functionality grew. Before `eth_getProof`, there was no
+interface for getting intermediary trie nodes over the API. This is a great
+example of a method that became more neccessary over time.
+
+
+### Implementation Complexity
+
+How a method is implemented should be carefully considered before proposing a
+change to the API. Although each client is able to validate the Ethereum chain,
+there can be a huge variance in the actual design decisions.
+
+As an example,  a proposal for a method such as `eth_totalSupply` seems
+reasonable. This is a quanity that users are often interested in and it would
+nice to have it available. However, tracking the total supply is tricky. There
+are several avenues where ether can enter and leave supply. This method would
+need to either i) compute the value on demand or ii) store value for each block
+height.
+
+Option i) is out, because it would involve executing each block starting with
+genesis. Option ii) is viable, but it starts enforcing certain requirements on
+clients beyond being able to simply validate the chain. Now during block
+ingestion, each client needs to store in their database the supply for that
+height. The chain reorg logic also likely needs to be updated to account for
+new data. It is not trivial.
+
 ### Backwards Compatibility
 
 There is currently no accepted path to making backwards incompatible changes to
 the API. This means that proposals which change syntax or semantics of existing
-methods are unlikely to be accepted.
-
-Even changes that would traditionally be accepted as backwards compatibible,
-like adding an optional parameter, are not currently possible. This is due
-the inability of clients to declare what version of a method they support.
-
-### Unopionated Implementation
-
+methods are unlikely to be accepted. A more viable approach is to propose a new
+method be created.
 
 ## Standardization
 
+There is not a formal process for standardization of API changes. Here is a rough
+guideline of how past proposals typically go.
+
 ### Idea
+
+An often overlooked aspect on the standardization journey is the idea phase. This
+is an important period of time because some focused effort at this point in time can
+save time and make the rest of the process much smoother.
+
+During the idea phase, it is recommended to contemplate the proposal idea in
+the context of the guiding principles above. It's also good to get feedback on
+the idea in the open. Just one or two rough acknowledgements from core
+developers that an idea makes sense and is worth pursing can avoid wasting a
+lot of time formalizing a proposal that has little change of being accepted.
 
 ### Proposal
 
-### Aquiring Support
+The formal proposal stage is where the bulk of time will be spent. A formal proposal
+is a PR to this repository ([ethereum/execution-apis][execution-apis]). A good proposal
+will have the following:
+
+* a modification to the specification implementing the proposal
+* test cases for proposal
+* motivation for the change
+* links to acknowledgements that proposal idea is sound
+* clear rationale for non-obvious design decisions
+
+### Acquiring Support
+
+Once a formal proposal has been created, formal support of clients can be
+acquired. This has historically been done via the AllCoreDevs call. It is
+recommended to post a request on the ACD agenda (usually in [ethereum/pm][pm])
+to discuss the proposal, at which point formal support can be ascertained.
+
+Often times, support will be conditional certain changes. This means that
+proposals will cycle between formal proposal work and earning support from
+clients. This should be expected and not discourage authors.
 
 ### Accepting the Change
 
-###
+
+[execution-apis]: https://github.com/ethereum/execution-apis
+[pm]: https://github.com/ethereum/pm

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -32,7 +32,7 @@ as demand for the functionality grew. Before `eth_getProof`, there was no
 interface for getting intermediary trie nodes over the API. This is a great
 example of a method that became more neccessary over time.
 
-Sometimes efficiency is the basis of neccesity. If certain patterns of requests
+Sometimes efficiency is the basis of necessity. If certain patterns of requests
 becomes popular, it can be adventageous to enshrine the behavior into the API.
 
 

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -7,7 +7,7 @@ propose changes to Ethereum JSON-RPC API.
 
 The Ethereum JSON-RPC API is the canonical interface between users and the
 Ethereum network. Each execution layer client implements the API as defined by
-the spec (or aspires to). 
+the spec. 
 
 As the main source of chain information, anything that is not
 provided over via API will not be easily accessible to users. 
@@ -31,14 +31,17 @@ as demand for the functionality grew. Before `eth_getProof`, there was no
 interface for getting intermediary trie nodes over the API. This is a great
 example of a method that became more neccessary over time.
 
+Sometimes efficiency is the basis of neccesity. If certain patterns of requests
+becomes popular, it can be adventageous to enshrine the behavior into the API.
+
 
 ### Implementation Complexity
 
 How a method is implemented should be carefully considered before proposing a
 change to the API. Although each client is able to validate the Ethereum chain,
-there can be a huge variance in the actual design decisions.
+there can be a huge variance in actual design decisions.
 
-As an example,  a proposal for a method such as `eth_totalSupply` seems
+As an example, a proposal for a method such as `eth_totalSupply` seems
 reasonable. This is a quanity that users are often interested in and it would
 nice to have it available. However, tracking the total supply is tricky. There
 are several avenues where ether can enter and leave supply. This method would
@@ -49,8 +52,8 @@ Option i) is out, because it would involve executing each block starting with
 genesis. Option ii) is viable, but it starts enforcing certain requirements on
 clients beyond being able to simply validate the chain. Now during block
 ingestion, each client needs to store in their database the supply for that
-height. The chain reorg logic also likely needs to be updated to account for
-new data. It is not trivial.
+height. The chain reorg logic also needs to consider this new data. It is not
+trivial.
 
 ### Backwards Compatibility
 
@@ -61,18 +64,19 @@ method be created.
 
 ## Standardization
 
-There is not a formal process for standardization of API changes. Here is a rough
-guideline of how past proposals typically go.
+There is not a formal process for standardization of API changes. However, the
+outline below should given proposal authors and champions a rough proccess to
+follow.
 
 ### Idea
 
-An often overlooked aspect on the standardization journey is the idea phase. This
-is an important period of time because some focused effort at this point in time can
-save time and make the rest of the process much smoother.
+An often overlooked aspect on the standardization journey is the idea phase.
+This is an important period of time, because some focused effort at this point
+in time can save time and make the rest of the process much smoother.
 
 During the idea phase, it is recommended to contemplate the proposal idea in
 the context of the guiding principles above. It's also good to get feedback on
-the idea in the open. Just one or two rough acknowledgements from core
+the idea in the open. Just one or two rough acknowledgements from client
 developers that an idea makes sense and is worth pursing can avoid wasting a
 lot of time formalizing a proposal that has little change of being accepted.
 
@@ -100,6 +104,12 @@ proposals will cycle between formal proposal work and earning support from
 clients. This should be expected and not discourage authors.
 
 ### Accepting the Change
+
+After client teams acknowledge and accept the change, it is usually on them to
+implement the method in their client. Due to the lack of versioning of the API,
+it is preferable that clients release the method roughly at the same time so
+that there is not much time where some clients support a certain methods and
+others don't.
 
 
 [execution-apis]: https://github.com/ethereum/execution-apis

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -9,8 +9,8 @@ The Ethereum JSON-RPC API is the canonical interface between users and the
 Ethereum network. Each execution layer client implements the API as defined by
 the spec. 
 
-As the main source of chain information, anything that is not
-provided over via API will not be easily accessible to users. 
+As the main source of chain information, anything that is not provided over via
+API will not be easily accessible to users. 
 
 ## Guiding Principles
 

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -35,7 +35,6 @@ example of a method that became more neccessary over time.
 Sometimes efficiency is the basis of necessity. If certain patterns of requests
 becomes popular, it can be adventageous to enshrine the behavior into the API.
 
-
 ### Implementation Complexity
 
 How a method is implemented should be carefully considered before proposing a

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -1,0 +1,43 @@
+# Contributors Guide
+
+This guide will explain for new and experienced contributors alike how to
+propose changes to Ethereum JSON-RPC API.
+
+## Introduction
+
+The Ethereum JSON-RPC API is the canonical interface between users and the
+Ethereum network. Each execution layer client implements the API as defined by
+the spec (or aspires to). 
+
+As the main source of chain information, anything that is not
+provided over via API will not be easily accessible to users. 
+
+## Guiding Principles
+
+When considering a change to the API, it's important to keep a few guiding
+principles in mind.
+
+### Backwards Compatibility
+
+There is currently no accepted path to making backwards incompatible changes to
+the API. This means that proposals which change syntax or semantics of existing
+methods are unlikely to be accepted.
+
+Even changes that would traditionally be accepted as backwards compatibible,
+like adding an optional parameter, are not currently possible. This is due
+the inability of clients to declare what version of a method they support.
+
+### Unopionated Implementation
+
+
+## Standardization
+
+### Idea
+
+### Proposal
+
+### Aquiring Support
+
+### Accepting the Change
+
+###

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -17,11 +17,12 @@ provided over via API will not be easily accessible to users.
 When considering a change to the API, it's important to keep a few guiding
 principles in mind.
 
-### Neccesity
+### Necessity
 
-The most common path to a newly standardized method is neccesity. As the protocol
-changes over time, new types of data become available. EIP-2930 neccesitated the
-introduction of `eth_accessList` and EIP-1559 neccesitated `eth_feeHistory`.
+The most common path to a newly standardized method is necessity. As the
+protocol changes over time, new types of data become available. EIP-2930
+necessitated the introduction of `eth_accessList` and EIP-1559 neccesitated
+`eth_feeHistory`.
 
 Therefore, a good question to ask before making a new API proposal is whether
 or not the method is strictly neccessary. Sometimes the answer is yes even
@@ -65,7 +66,7 @@ method be created.
 ## Standardization
 
 There is not a formal process for standardization of API changes. However, the
-outline below should given proposal authors and champions a rough proccess to
+outline below should given proposal authors and champions a rough process to
 follow.
 
 ### Idea
@@ -82,9 +83,9 @@ lot of time formalizing a proposal that has little change of being accepted.
 
 ### Proposal
 
-The formal proposal stage is where the bulk of time will be spent. A formal proposal
-is a PR to this repository ([ethereum/execution-apis][execution-apis]). A good proposal
-will have the following:
+The formal proposal stage is where the bulk of time will be spent. A formal
+proposal is a PR to this repository ([ethereum/execution-apis][exec-apis]). A
+good proposal will have the following:
 
 * a modification to the specification implementing the proposal
 * test cases for proposal ([guide][test-gen])
@@ -96,8 +97,9 @@ will have the following:
 
 Once a formal proposal has been created, formal support of clients can be
 acquired. This has historically been done via the AllCoreDevs call. It is
-recommended to post a request on the ACD agenda (usually in [ethereum/pm][pm])
-to discuss the proposal, at which point formal support can be ascertained.
+recommended to post a request on the AllCoreDevs agenda (usually in
+[ethereum/pm][pm]) to discuss the proposal, at which point formal support can
+be ascertained.
 
 Often times, support will be conditional certain changes. This means that
 proposals will cycle between formal proposal work and earning support from
@@ -112,6 +114,6 @@ that there is not much time where some clients support a certain methods and
 others don't.
 
 
-[execution-apis]: https://github.com/ethereum/execution-apis
+[exec-apis]: https://github.com/ethereum/execution-apis
 [pm]: https://github.com/ethereum/pm
 [test-gen]: ../tests/README.md

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -87,7 +87,7 @@ is a PR to this repository ([ethereum/execution-apis][execution-apis]). A good p
 will have the following:
 
 * a modification to the specification implementing the proposal
-* test cases for proposal
+* test cases for proposal ([guide][test-gen])
 * motivation for the change
 * links to acknowledgements that proposal idea is sound
 * clear rationale for non-obvious design decisions
@@ -114,3 +114,4 @@ others don't.
 
 [execution-apis]: https://github.com/ethereum/execution-apis
 [pm]: https://github.com/ethereum/pm
+[test-gen]: ../tests/README.md

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,1 @@
+# Testing

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,1 +1,0 @@
-# Testing

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,14 @@
 # Tests
 
 The Execution API has a comprehensive test suite to verify conformance of
-clients. It is run multiple times a day and results from all major clients are
-available [here][hivetests2] under the tag `rpc-compat`.
+clients. The tests in this repository are loaded into the [`hive`][hive] test
+simulator [`rpc-compat`][rpc-compat] and validated against every major client.
+
+The test suite is run daily and results are always available [here][hivetests2]
+under the tag `rpc-compat`. 
+
+To learn more about the `rpc-compat` simulator, please see its
+[documentation][rpc-compat].
 
 ## Format
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,68 @@
+# Tests
+
+The Execution API has a comprehensive test suite to verify conformance of
+clients. It is run multiple times a day and results from all major clients are
+available [here][hivetests2] under the tag `rpc-compat`.
+
+## Format
+
+Tests are written to describe the round-trip of a single request-response
+cycle. A test starts with a `>> ` denoting the request portion. It is delimited
+by `\n` and then a `<< ` is used to denote the response. All together, it looks
+something like this:
+
+```javascript
+>> {"jsonrpc":"2.0","id":1,"method":"eth_blockNumber"}
+<< {"jsonrpc":"2.0","id":1,"result":"0x3"}
+```
+
+For organizational purposes, tests are stored at a path following the template
+`tests/{method-name}/{test-name}.io`. The path does not affect the validity of
+the test and is only used to describe what the test is aiming to test.
+
+## Generation
+
+Test generation can be broken down into two parts. First is the generation of a
+chain against which tests will be executed. Second is executing the actual
+tests and recording their round-trip.
+
+Although the `io` format is agnostic to the generation tool, it is preferred
+test contributors use the generation tool [`rpctestgen`][rpctestgen].
+`rpctestgen` takes care of both pieces of test generation.
+
+### Chain making
+
+Inside the `tests` directory are three chain-related files that test authors
+must be aware of.
+
+
+`genesis.json` - a standard genesis config file in the go-ethereum format.
+`chain.rlp`    - a newline-delimited list of blocks making up the test chain.
+`bad.rlp`      - a newline-delimited list of blocks that are sealed and
+                 conduct an invalid transition. 
+
+Generally, test authors should ingest `genesis.json` and `chain.rlp` and
+generate tests against the head of that chain. If a test requires a certain
+condition exist in the chain that does not currently exist, then the author may
+append a block to head of the chain and regenerate all tests against the new
+`chain.rlp`.
+
+### Test Generation
+
+Once a test chain has been created, test authors may move on to generating the
+actual test fixtures. To do so, authors must follow the format defined above.
+Tests should be limited to a single round-trip interaction. At this time, this
+precludes subscription methods from being tested.
+
+It is also recommended that test authors test their tests. Each interaction
+should be validated against the expected values. Due to the number of fixtures
+generated, it is easy accept incorrect responses.
+
+A good final verification of tests is to run them in the hive simulator
+[`rpc-compat`][rpc-compat]. More information on how to run custom tests in the
+simulator can be found with there.
+
+[hive]: https://github.com/ethereum/hive
+[hivetests2]: https://hivetests2.ethdevops.io
+[rpc-compat]: https://github.com/ethereum/hive/tree/master/simulators/ethereum/rpc-compat
+[rpctestgen]: https://github.com/lightclient/rpctestgen

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,6 @@ test contributors use the generation tool [`rpctestgen`][rpctestgen].
 Inside the `tests` directory are three chain-related files that test authors
 must be aware of.
 
-
 `genesis.json` - a standard genesis config file in the go-ethereum format.
 `chain.rlp`    - a newline-delimited list of blocks making up the test chain.
 `bad.rlp`      - a newline-delimited list of blocks that are sealed and


### PR DESCRIPTION
This PR adds some documentation around contributions to the specification. It specifically outlines the rough, informal process people usual follow when modifying the JSON-RPC and more concretely explains how to generate valid tests that can be consumed by the `rpc-compat` simulator. I am in parallel preparing some additional documentation in `rpc-compat`, so some of the references to "see the documentation in `rpc-compat`" currently fall flat.

PTAL and share any feedback!