### PR TITLE
eth: remove gasPrce and maxPriorityFee tests due to non-determinism

### DIFF
--- a/tests/eth_gasPrice/get-current-gas-price.io
+++ b/tests/eth_gasPrice/get-current-gas-price.io
@@ -1,2 +1,0 @@
->> {"jsonrpc":"2.0","id":28,"method":"eth_gasPrice"}
-<< {"jsonrpc":"2.0","id":28,"result":"0x63a1889d"}

--- a/tests/eth_maxPriorityFeePerGas/get-current-tip.io
+++ b/tests/eth_maxPriorityFeePerGas/get-current-tip.io
@@ -1,2 +1,0 @@
->> {"jsonrpc":"2.0","id":29,"method":"eth_maxPriorityFeePerGas"}
-<< {"jsonrpc":"2.0","id":29,"result":"0x3b9aca00"}


### PR DESCRIPTION
These two methods are not deterministic across clients and have been failing on hive 2 for a while. I am going to remove them from the test suite, however, there is [hope](https://github.com/ethereum/hive/issues/640) to continue ensuring their correctness by making a few modifications to hive.