### PR TITLE
Clients should have autonomy for mechanism of configuration.

### DIFF
--- a/src/engine/authentication.md
+++ b/src/engine/authentication.md
@@ -33,11 +33,11 @@ The HMAC algorithm implies that several CLs will be able to use the same key, an
 
 ## Key distribution
 
-The `EL` and `CL` clients **MUST** accept a cli/config parameter: `jwt-secret`, which designates a file containing the hex-encoded 256 bit secret key to be used for verifying/generating JWT tokens.
+The execution layer and consensus layer clients **SHOULD** accept a configuration parameter: `jwt-secret`, which contains the hex-encoded 256 bit secret key to be used for verifying/generating JWT tokens, or a file path to a file containing such a key.
 
 If such a parameter is not given, the client **SHOULD** generate such a token, valid for the duration of the execution, and store the hex-encoded secret as a `jwt.hex` file on the filesystem.  This file can then be used to provision the counterpart client.
 
-If such a parameter _is_ given, but the file cannot be read, or does not contain a hex-encoded key of `256` bits, the client should treat this as an error: either abort the startup, or show error and continue without exposing the authenticated port.
+If such a parameter _is_ given and it is a file path but the file cannot be read, or if it or the file it points to does not contain a hex-encoded key of `256` bits, the client should treat this as an error: either abort the startup, or show error and continue without exposing the authenticated port.
 
 ## JWT Claims
 


### PR DESCRIPTION
This spec, as currently written is incredibly prescriptive about exactly how the key should be provided to the client.  This doesn't allow clients to differentiate in ways that are useful to their customers without falling out of spec compliance.

One can easily imagine a user wanting to configure this via environment variable, or CLI parameter rather than via file.  Also, files on disk may not be secure against reading by unauthorized users (for example, disk backups may not be encrypted) while access to startup parameters and environment variables may be better protected.  A client may also integrate with a secure secret storage system that allows the client to fetch secrets from a server over a secure connection at startup, thus protecting the key from anyone who doesn't have the ability to read the contents of RAM while the client is running.

Note, this change should be merged after #298 as it incorporates some of the wording changes found there.

I can appreciate the value in having consistency in configuration parameter naming, I don't think we should be setting such things as required.  Nethermind, for example, namespaces its configuration variables and having this be un-namespaced is likely to cause more confusion for users and more complexity in their client.