### PR TITLE
auth: relax authentication requirement when hosting on 127.0.0.1

### DIFF
--- a/src/engine/authentication.md
+++ b/src/engine/authentication.md
@@ -19,7 +19,7 @@ Authentication is performed as follows:
   - Clarification: The websocket handshake starts with the CL performing a websocket upgrade request. This is a regular http GET request, and the actual
 parameters for the WS-handshake are carried in the http headers.
 - For `inproc`, a.k.a raw ipc communication, no authentication is required, under the assumption that a process able to access `ipc` channels for the process, which usually means local file access, is already sufficiently permissioned that further authentication requirements do not add security.
-
+- If the listening address is `127.0.0.1`, no authentication is required, under the assumption that sockets bound to the localhost cannot accept external connections and therefore are not suceptible to manipulation from remote adversaries. Furthermore, EL clients **SHOULD** reject requests where the `Origin` header field does not equal the current domain as the request most likey originated from a browser.
 
 ## JWT specifications
 

--- a/src/engine/authentication.md
+++ b/src/engine/authentication.md
@@ -19,7 +19,7 @@ Authentication is performed as follows:
   - Clarification: The websocket handshake starts with the CL performing a websocket upgrade request. This is a regular http GET request, and the actual
 parameters for the WS-handshake are carried in the http headers.
 - For `inproc`, a.k.a raw ipc communication, no authentication is required, under the assumption that a process able to access `ipc` channels for the process, which usually means local file access, is already sufficiently permissioned that further authentication requirements do not add security.
-- If the listening address is `127.0.0.1`, no authentication is required, under the assumption that sockets bound to the localhost cannot accept external connections and therefore are not suceptible to manipulation from remote adversaries. Furthermore, EL clients **SHOULD** reject requests where the `Origin` header field does not equal the current domain as the request most likey originated from a browser.
+- If the listening address is `127.0.0.1`, no authentication is required, under the assumption that sockets bound to the localhost cannot accept external connections and therefore are not susceptible to manipulation from remote adversaries. Furthermore, EL clients **SHOULD** reject requests where the `Origin` header field does not equal the current domain as the request most likey originated from a browser.
 
 ## JWT specifications
 


### PR DESCRIPTION
Alternative to #297. Allows EL clients to expose an unauthenticated Engine API when the host is `127.0.0.1`.

> For the single-machine setup, it is doubtful whether JWT secret adds any signficant security: from a technical point of view, a socket bound to localhost cannot accept "outside" connections meaning that the only difference is the "filesystem" security - ie processes running as a different user may be thwarted by the additional token exchange, but we have to weigh this against the complexity and failure modes that having a file introduces. The alternative here is that we simply allow connecting without JWT as long as the socket is bound to localhost which achieves the "simple single-machine setup" with less of a hurdle (notably, the engine api is already sitting on a separate port from the "user-level" JSON-RPC interface, so the two live in different "security domains"). --@arnetheduck

--

Currently, if a user wanted casually run a EL and CL on the same host without the aid of any virtualization, it is _required_ that the user specify the `--jwt-secret` flag for at least one client. Example:

```
$ geth --sepolia
```
```
$ lighthouse beacon --network sepolia --execution-jwt $HOME/.ethereum/sepolia/geth/jwtsecret
```

I think this is both unnecessary and confusing behavior for users. Ideally, the user should be able to, in any order, bring up an EL and CL and they communicate by default.

The preferred behavior would be:

```
$ geth --sepolia
```
```
$ lighthouse beacon --network sepolia
```