### PR TITLE
Sort RPC methods in docs

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -3,6 +3,18 @@ import yaml from "js-yaml";
 import merger from "json-schema-merge-allof";
 import { dereferenceDocument } from "@open-rpc/schema-utils-js";
 
+function sortByMethodName(methods) {
+  return methods.slice().sort((a, b) => {
+    if (a['name'] > b['name']) {
+      return 1;
+    } else if (a['name'] < b['name']) {
+      return -1;
+    } else {
+      return 0;
+    }
+  })
+}
+
 console.log("Loading files...\n");
 
 let methods = [];
@@ -53,7 +65,7 @@ const doc = {
     },
     version: "0.0.0"
   },
-  methods: methods,
+  methods: sortByMethodName(methods),
   components: {
     schemas: schemas
   }


### PR DESCRIPTION
The methods that appear in the published docs are not sorted by method name. This may not matter when looking for a particular method (as you can use Ctrl-F/Cmd-F in your browser), but not so when using the list as a whole. In our case, we have a proxy to Ethereum in our project, and we want to ensure we have proper test coverage for all public Ethereum RPC methods. This is difficult when the official list of methods is unsorted because we have to double- and triple-check that we've accounted for all of them on our side. If the list were sorted then this task would be a lot easier.

---

I tried my best to build the docs locally but ran into an error while doing so, so I hope this produces the correct result. Let me know if there's anything I need to do to prove that this works.