### PR TITLE
Increase strictness of base types

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: ^1.18
         id: go
-      - name: Install staticcheck
+      - name: Install speccheck
         run: go install github.com/lightclient/rpctestgen/cmd/speccheck@latest
-      - name: Install staticcheck
+      - name: Run speccheck
         run: speccheck -v

--- a/src/eth/state.yaml
+++ b/src/eth/state.yaml
@@ -75,7 +75,7 @@
         title: Storage keys
         type: array
         items:
-          $ref: '#/components/schemas/hash32'
+          $ref: '#/components/schemas/bytesMax32'
     - name: Block
       required: true
       schema:

--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -22,7 +22,7 @@ bytes8:
 bytes32:
   title: 32 hex encoded bytes
   type: string
-  pattern: ^0x([0-9a-f][0-9a-f]){0,32}$
+  pattern: ^0x[0-9a-f]{64}$
 bytes256:
   title: 256 hex encoded bytes
   type: string
@@ -30,20 +30,20 @@ bytes256:
 bytes65:
   title: 65 hex encoded bytes
   type: string
-  pattern: ^0x[0-9a-f]{512}$
+  pattern: ^0x[0-9a-f]{65}$
 uint:
   title: hex encoded unsigned integer
   type: string
   pattern: ^0x([1-9a-f]+[0-9a-f]*|0)$
 uint64:
-  title: hex encoded unsigned integer
+  title: hex encoded 64 bit unsigned integer
   type: string
-  pattern: ^0x([1-9a-f][0-9a-f]{0,15})|0$
+  pattern: ^0x([1-9a-f]+[0-9a-f]{0,15})|0$
 uint256:
-  title: hex encoded unsigned integer
+  title: hex encoded 256 bit unsigned integer
   type: string
-  pattern: ^0x[0-9a-f]{0,64}$
+  pattern: ^0x([1-9a-f]+[0-9a-f]{0,31})|0$
 hash32:
   title: 32 byte hex value
   type: string
-  pattern: ^0x([0-9a-f][0-9a-f]){0,32}$
+  pattern: ^0x[0-9a-f]{64}$

--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -15,6 +15,10 @@ bytes:
   title: hex encoded bytes
   type: string
   pattern: ^0x[0-9a-f]*$
+bytesMax32:
+  title: 32 hex encoded bytes
+  type: string
+  pattern: ^0x[0-9a-f]{0,64}$
 bytes8:
   title: 8 hex encoded bytes
   type: string

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -93,7 +93,7 @@ ReceiptInfo:
     root:
       title: state root
       description: The post-transaction state root. Only specified for transactions included before the Byzantium upgrade.
-      $ref: '#/components/schemas/bytes32'
+      $ref: '#/components/schemas/hash32'
     status:
       title: status
       description: Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade.

--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -45,7 +45,7 @@ StorageProof:
   properties:
     key:
       title: key
-      $ref: '#/components/schemas/hash32'
+      $ref: '#/components/schemas/bytesMax32'
     value:
       title: value
       $ref: '#/components/schemas/uint256'

--- a/tests/eth_getStorage/get-storage-invalid-key-too-large.io
+++ b/tests/eth_getStorage/get-storage-invalid-key-too-large.io
@@ -1,0 +1,2 @@
+>> {"jsonrpc":"2.0","id":12,"method":"eth_getStorageAt","params":["0xaa00000000000000000000000000000000000000","0x00000000000000000000000000000000000000000000000000000000000000000","latest"]}
+<< {"jsonrpc":"2.0","id":12,"error":{"code":-32000,"message":"hex string of odd length"}}

--- a/tests/eth_getStorage/get-storage-invalid-key.io
+++ b/tests/eth_getStorage/get-storage-invalid-key.io
@@ -1,0 +1,2 @@
+>> {"jsonrpc":"2.0","id":11,"method":"eth_getStorageAt","params":["0xaa00000000000000000000000000000000000000","0xasdf","latest"]}
+<< {"jsonrpc":"2.0","id":11,"error":{"code":-32000,"message":"invalid hex string"}}


### PR DESCRIPTION
Fixes #303.

* There is an inconsistency with the base types where some types with a numeric post-fix value accept _only_ that quantity and other accept _up to_ that quantity. This PR makes it so all types accept _only_ that quantity (e.g. `Bytes32` requires exactly 32 bytes), with the exception of integers. They will continue to accept values _up to_ their quantity (e.g. `0x1` will match `uint256`).
* There is an error where `Bytes65` was copied from `Bytes512` and the bound was not updated. This has been resolved.
* There is an error with `uint256` where `0x` matched validly. It's been updated to follow the same pattern matching as other `uint` sizes, requiring no leading zeros.
* Some byte values actually have caps. I've added `BytesMax32` for use with storage keys. They don't quite fall within the domain of `uint256` (especially with the above fix) and they don't always serialize to 32 full bytes. This is the main issue in #303.
* Generally improved the readability of the definitions a bit.