### PR TITLE
Hold dependency versions stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,15 @@
       "version": "0.0.0",
       "license": "CC0-1.0",
       "devDependencies": {
+        "@graphql-inspector/core": "~3.3.0",
         "@open-rpc/generator": "1.18.6",
-        "@open-rpc/schema-utils-js": "^1.15.0",
-        "gatsby": "^4.16.0",
-        "gh-pages": "^4.0.0",
-        "graphql": "^16.3.0",
-        "graphql-request": "^4.1.0",
-        "js-yaml": "^4.1.0",
-        "json-schema-merge-allof": "^0.8.1"
+        "@open-rpc/schema-utils-js": "1.15.0",
+        "gatsby": "~4.16.0",
+        "gh-pages": "~4.0.0",
+        "graphql": "~16.3.0",
+        "graphql-request": "~4.1.0",
+        "js-yaml": "~4.1.0",
+        "json-schema-merge-allof": "~0.8.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2200,22 +2201,859 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-1.2.0.tgz",
-      "integrity": "sha512-4iIdquFDl+b+U8Ng0dg6dCtxB/cnH27ERrlQQlxfdaWe8e9CLo8aWc6u3UeuHwNJixBFOUbOgEFaA5qCUPwLCQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-1.8.0.tgz",
+      "integrity": "sha512-/zo67Q/i3I9G+uX84Tjp54wpZdd/DLF+btyh/Zy5uCvIlV5R/wiHmLEzrtN6Axcdtmh2DBJSkN7yB8FwfZtlYQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0",
-        "@parcel/plugin": "2.6.0",
-        "gatsby-core-utils": "^3.17.0"
+        "@parcel/namer-default": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "gatsby-core-utils": "^3.23.0"
       },
       "engines": {
         "node": ">=14.15.0",
         "parcel": "2.x"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-darwin-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-darwin-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-arm": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-arm64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-linux-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@lmdb/lmdb-win32-x64": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/cache": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.2.tgz",
+      "integrity": "sha512-hhJ6AsEGybeQZd9c/GYqfcKTgZKQXu3Xih6TlnP3gdR3KZoJOnb40ovHD1yYg4COvfcXThKP1cVJ18J6rcv3IA==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "lmdb": "2.5.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/namer-default": "2.5.0"
+        "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/codeframe": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.2.tgz",
+      "integrity": "sha512-oFlHr6HCaYYsB4SHkU+gn9DKtbzvv3/4NdwMX0/6NAKyYVI7inEsXyPGw2Bbd2ZCFatW9QJZUETF0etvh5AEfQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-7yKZUdh314Q/kU/9+27ZYTfcnXS6VYHuG+iiUlIohnvUUybxLqVJhdMU9Q+z2QcPka1IdJWz4K4Xx0y6/4goyg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.7.0",
+        "@parcel/diagnostic": "2.7.0",
+        "@parcel/events": "2.7.0",
+        "@parcel/fs": "2.7.0",
+        "@parcel/graph": "2.7.0",
+        "@parcel/hash": "2.7.0",
+        "@parcel/logger": "2.7.0",
+        "@parcel/package-manager": "2.7.0",
+        "@parcel/plugin": "2.7.0",
+        "@parcel/source-map": "^2.0.0",
+        "@parcel/types": "2.7.0",
+        "@parcel/utils": "2.7.0",
+        "@parcel/workers": "2.7.0",
+        "abortcontroller-polyfill": "^1.1.9",
+        "base-x": "^3.0.8",
+        "browserslist": "^4.6.6",
+        "clone": "^2.1.1",
+        "dotenv": "^7.0.0",
+        "dotenv-expand": "^5.1.0",
+        "json5": "^2.2.0",
+        "msgpackr": "^1.5.4",
+        "nullthrows": "^1.1.1",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/cache": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.7.0.tgz",
+      "integrity": "sha512-JlXNoZXcWzLKdDlfeF3dIj5Vtel5T9vtdBN72PJ+cjC4qNHk4Uwvc5sfOBELuibGN0bVu2bwY9nUgSwCiB1iIA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/fs": "2.7.0",
+        "@parcel/logger": "2.7.0",
+        "@parcel/utils": "2.7.0",
+        "lmdb": "2.5.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.7.0"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/codeframe": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.7.0.tgz",
+      "integrity": "sha512-UTKx0jejJmmO1dwTHSJuRgrO8N6PMlkxRT6sew8N6NC3Bgv6pu0EbO+RtlWt/jCvzcdLOPdIoTzj4MMZvgcMYg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/diagnostic": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.7.0.tgz",
+      "integrity": "sha512-pdq/cTwVoL0n8yuDCRXFRSQHVWdmmIXPt3R3iT4KtYDYvOrMT2dLPT79IMqQkhYPANW8GuL15n/WxRngfRdkug==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/fs": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.7.0.tgz",
+      "integrity": "sha512-PU5fo4Hh8y03LZgemgVREttc0wyHQUNmsJCybxTB7EjJie2CqJRumo+DFppArlvdchLwJdc9em03yQV/GNWrEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/fs-search": "2.7.0",
+        "@parcel/types": "2.7.0",
+        "@parcel/utils": "2.7.0",
+        "@parcel/watcher": "^2.0.0",
+        "@parcel/workers": "2.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.7.0"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/fs-search": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.7.0.tgz",
+      "integrity": "sha512-K1Hv25bnRpwQVA15RvcRuB8ZhfclnCHA8N8L6w7Ul1ncSJDxCIkIAc5hAubYNNYW3kWjCC2SOaEgFKnbvMllEQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/logger": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.7.0.tgz",
+      "integrity": "sha512-qjMY/bYo38+o+OiIrTRldU9CwL1E7J72t+xkTP8QIcUxLWz5LYR0YbynZUVulmBSfqsykjjxCy4a+8siVr+lPw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.7.0",
+        "@parcel/events": "2.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/markdown-ansi": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.7.0.tgz",
+      "integrity": "sha512-ipOX0D6FVZFEXeb/z8MnTMq2RQEIuaILY90olVIuHEFLHHfOPEn+RK3u13HA1ChF5/9E3cMD79tu6x9JL9Kqag==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/package-manager": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.7.0.tgz",
+      "integrity": "sha512-wmfSX1mRrTi8MeA4KrnPk/x7zGUsILCQmTo6lA4gygzAxDbM1pGuyFN8/Kt0y0SFO2lbljARtD/4an5qdotH+Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.7.0",
+        "@parcel/fs": "2.7.0",
+        "@parcel/logger": "2.7.0",
+        "@parcel/types": "2.7.0",
+        "@parcel/utils": "2.7.0",
+        "@parcel/workers": "2.7.0",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.7.0"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/plugin": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.7.0.tgz",
+      "integrity": "sha512-qqgx+nnMn6/0lRc4lKbLGmhNtBiT93S2gFNB4Eb4Pfz/SxVYoW+fmml+KdfOSiZffWOAH5L6NwhyD7N8aSikzw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/types": "2.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/types": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.7.0.tgz",
+      "integrity": "sha512-+dhXVUnseTCpJvBTGMp0V6X13z6O/A/+CUtwEpMGZ8XSmZ4Gk44GvaTiBOp0bJpWG4fvCKp+UmC8PYbrDiiziw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/cache": "2.7.0",
+        "@parcel/diagnostic": "2.7.0",
+        "@parcel/fs": "2.7.0",
+        "@parcel/package-manager": "2.7.0",
+        "@parcel/source-map": "^2.0.0",
+        "@parcel/workers": "2.7.0",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/utils": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.7.0.tgz",
+      "integrity": "sha512-jNZ5bIGg1r1RDRKi562o4kuVwnz+XJ2Ie3b0Zwrqwvgfj6AbRFIKzDd+h85dWWmcDYzKUbHp11u6VJl1u8Vapg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.7.0",
+        "@parcel/diagnostic": "2.7.0",
+        "@parcel/hash": "2.7.0",
+        "@parcel/logger": "2.7.0",
+        "@parcel/markdown-ansi": "2.7.0",
+        "@parcel/source-map": "^2.0.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/core/node_modules/@parcel/workers": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.7.0.tgz",
+      "integrity": "sha512-99VfaOX+89+RaoTSyH9ZQtkMBFZBFMvJmVJ/GeJT6QCd2wtKBStTHlaSnQOkLD/iRjJCNwV2xpZmm8YkTwV+hg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.7.0",
+        "@parcel/logger": "2.7.0",
+        "@parcel/types": "2.7.0",
+        "@parcel/utils": "2.7.0",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.7.0"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/diagnostic": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.2.tgz",
+      "integrity": "sha512-3ODSBkKVihENU763z1/1DhGAWFhYWRxOCOShC72KXp+GFnSgGiBsxclu8NBa/N948Rzp8lqQI8U1nLcKkh0O/w==",
+      "dev": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/events": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.7.0.tgz",
+      "integrity": "sha512-kQDwMKgZ1U4M/G17qeDYF6bW5kybluN6ajYPc7mZcrWg+trEI/oXi81GMFaMX0BSUhwhbiN5+/Vb2wiG/Sn6ig==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/fs": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.2.tgz",
+      "integrity": "sha512-mIhqdF3tjgeoIGqW7Nc/xfM2ClID7o8livwUe5lpQEP+ZaIBiMigXs6ckv3WToCACK+3uylrSD2A/HmlhrxMqQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/fs-search": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/watcher": "^2.0.0",
+        "@parcel/workers": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/fs-search": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.2.tgz",
+      "integrity": "sha512-4STid1zqtGnmGjHD/2TG2g/zPDiCTtE3IAS24QYH3eiUAz2uoKGgEqd2tZbZ2yI96jtCuIhC1bzVu8Hbykls7w==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/graph": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.7.0.tgz",
+      "integrity": "sha512-Q6E94GS6q45PtsZh+m+gvFRp/N1Qopxhu2sxjcWsGs5iBd6IWn2oYLWOH5iVzEjWuYpW2HkB08lH6J50O63uOA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/utils": "2.7.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/graph/node_modules/@parcel/codeframe": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.7.0.tgz",
+      "integrity": "sha512-UTKx0jejJmmO1dwTHSJuRgrO8N6PMlkxRT6sew8N6NC3Bgv6pu0EbO+RtlWt/jCvzcdLOPdIoTzj4MMZvgcMYg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/graph/node_modules/@parcel/diagnostic": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.7.0.tgz",
+      "integrity": "sha512-pdq/cTwVoL0n8yuDCRXFRSQHVWdmmIXPt3R3iT4KtYDYvOrMT2dLPT79IMqQkhYPANW8GuL15n/WxRngfRdkug==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/graph/node_modules/@parcel/logger": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.7.0.tgz",
+      "integrity": "sha512-qjMY/bYo38+o+OiIrTRldU9CwL1E7J72t+xkTP8QIcUxLWz5LYR0YbynZUVulmBSfqsykjjxCy4a+8siVr+lPw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.7.0",
+        "@parcel/events": "2.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/graph/node_modules/@parcel/markdown-ansi": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.7.0.tgz",
+      "integrity": "sha512-ipOX0D6FVZFEXeb/z8MnTMq2RQEIuaILY90olVIuHEFLHHfOPEn+RK3u13HA1ChF5/9E3cMD79tu6x9JL9Kqag==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/graph/node_modules/@parcel/utils": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.7.0.tgz",
+      "integrity": "sha512-jNZ5bIGg1r1RDRKi562o4kuVwnz+XJ2Ie3b0Zwrqwvgfj6AbRFIKzDd+h85dWWmcDYzKUbHp11u6VJl1u8Vapg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.7.0",
+        "@parcel/diagnostic": "2.7.0",
+        "@parcel/hash": "2.7.0",
+        "@parcel/logger": "2.7.0",
+        "@parcel/markdown-ansi": "2.7.0",
+        "@parcel/source-map": "^2.0.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/hash": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.7.0.tgz",
+      "integrity": "sha512-k6bSKnIlPJMPU3yjQzfgfvF9zuJZGOAlJgzpL4BbWvdbE8BTdjzLcFn0Ujrtud94EgIkiXd22sC2HpCUWoHGdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/logger": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.2.tgz",
+      "integrity": "sha512-Sz5YGCj1DbEiX0/G8Uw97LLZ0uEK+qtWcRAkHNpJpeMiSqDiRNevxXltz42EcLo+oCh4d4wyiVzwi9mNwzhS/Q==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/events": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/logger/node_modules/@parcel/events": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.2.tgz",
+      "integrity": "sha512-IaCjOeA5ercdFVi1EZOmUHhGfIysmCUgc2Th9hMugSFO0I3GzRsBcAdP6XPfWm+TV6sQ/qZRfdk/drUxoAupnw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/markdown-ansi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.2.tgz",
+      "integrity": "sha512-N/h9J4eibhc+B+krzvPMzFUWL37GudBIZBa7XSLkcuH6MnYYfh6rrMvhIyyESwk6VkcZNVzAeZrGQqxEs0dHDQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/namer-default": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.2.tgz",
+      "integrity": "sha512-mp7bx/BQaIuohmZP0uE+gAmDBzzH0Yu8F4yCtE611lc6i0mou+nWRhzyKLNC/ieuI8DB3BFh2QQKeTxJn4W0qg==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0",
+        "parcel": "^2.6.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/package-manager": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.2.tgz",
+      "integrity": "sha512-xGMqTgnwTE3rgzYwUZMKxR8fzmP5iSYz/gj2H8FR3pEmwh/8xCMtNjTSth+hPVGuqgRZ6JxwpfdY/fXdZ61ViQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "@parcel/workers": "2.6.2",
+        "semver": "^5.7.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/plugin": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.2.tgz",
+      "integrity": "sha512-wbbWsM23Pr+8xtLSvf+UopXdVYlpKCCx6PuuZaZcKo+9IcDCWoGXD4M8Kkz14qBmkFn5uM00mULUqmVdSibB2w==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/types": "2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/types": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.2.tgz",
+      "integrity": "sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/cache": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/fs": "2.6.2",
+        "@parcel/package-manager": "2.6.2",
+        "@parcel/source-map": "^2.0.0",
+        "@parcel/workers": "2.6.2",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/utils": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.2.tgz",
+      "integrity": "sha512-Ug7hpRxjgbY5AopW55nY7MmGMVmwmN+ihfCmxJkBUoESTG/3iq8uME7GjyOgW5DkQc2K7q62i8y8N0wCJT1u4Q==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/codeframe": "2.6.2",
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/hash": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/markdown-ansi": "2.6.2",
+        "@parcel/source-map": "^2.0.0",
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/utils/node_modules/@parcel/hash": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.2.tgz",
+      "integrity": "sha512-tFB+cJU1Wqag6WyJgsmx3nx+xhmjcNZqtWh/MtK1lHNnZdDRk6bjr7SapnygBwruz+SmSt5bbdVThcpk2dRCcA==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "xxhash-wasm": "^0.4.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/@parcel/workers": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.2.tgz",
+      "integrity": "sha512-wBgUjJQm+lDd12fPRUmk09+ujTA9DgwPdqylSFK0OtI/yT6A+2kArUqjp8IwWo2tCJXoMzXBne2XQIWKqMiN4Q==",
+      "dev": true,
+      "dependencies": {
+        "@parcel/diagnostic": "2.6.2",
+        "@parcel/logger": "2.6.2",
+        "@parcel/types": "2.6.2",
+        "@parcel/utils": "2.6.2",
+        "chrome-trace-event": "^1.0.2",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.6.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/lmdb": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "5.0.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "@lmdb/lmdb-darwin-arm64": "2.5.2",
+        "@lmdb/lmdb-darwin-x64": "2.5.2",
+        "@lmdb/lmdb-linux-arm": "2.5.2",
+        "@lmdb/lmdb-linux-arm64": "2.5.2",
+        "@lmdb/lmdb-linux-x64": "2.5.2",
+        "@lmdb/lmdb-win32-x64": "2.5.2"
+      }
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true
+    },
+    "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/@gatsbyjs/potrace": {
@@ -2408,6 +3246,35 @@
       }
     },
     "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "node_modules/@graphql-inspector/core": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-inspector/core/-/core-3.3.0.tgz",
+      "integrity": "sha512-LRtk9sHgj9qqVPIkkThAVq3iZ7QxgHCx6elEwd0eesZBCmaIYQxD/BFu+VT8jr10YfOURBZuAnVdyGu64vYpBg==",
+      "dev": true,
+      "dependencies": {
+        "dependency-graph": "0.11.0",
+        "object-inspect": "1.10.3",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-inspector/core/node_modules/object-inspect": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@graphql-inspector/core/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
@@ -3185,13 +4052,13 @@
       "dev": true
     },
     "node_modules/@json-schema-tools/dereferencer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.5.4.tgz",
-      "integrity": "sha512-4cmEdRPIG7WrcSWGRV6HBDCLXEOXGkaOZnopqBxoG24mKYuCHWg4M6N9nioTQyNfKqlPkOPvT4lStQqkPnhLgA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.5.1.tgz",
+      "integrity": "sha512-CUpdGpxNTq1ebMkrgVxS03FHfwkGiw63c+GNzqFAqwqsxR0OsR79aqK8h2ybxTIEhdwiaknSnlUgtUIy7FJ+3A==",
       "dev": true,
       "dependencies": {
-        "@json-schema-tools/reference-resolver": "^1.2.4",
-        "@json-schema-tools/traverse": "^1.7.8",
+        "@json-schema-tools/reference-resolver": "^1.2.1",
+        "@json-schema-tools/traverse": "^1.7.5",
         "fast-safe-stringify": "^2.0.7"
       }
     },
@@ -3266,9 +4133,9 @@
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-RXwGZ/0eCqtCY8FLTM/koR60w+MXyvBUpToXiIyjOcBnC81tAlTUHrRUavCEWPI9zc9VgvpK3+cbumPyR8BSuA==",
       "cpu": [
         "arm64"
       ],
@@ -3279,9 +4146,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-337dNzh5yCdNCTk8kPfoU7jR3otibSlPDGW0vKZT97rKnQMb9tNdto3RtWoGPsQ8hKmlRZpojOJtmwjncq1MoA==",
       "cpu": [
         "x64"
       ],
@@ -3292,9 +4159,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
-      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.3.tgz",
+      "integrity": "sha512-mU2HFJDGwECkoD9dHQEfeTG5mp8hNS2BCfwoiOpVPMeapjYpQz9Uw3FkUjRZ4dGHWKbin40oWHuL0bk2bCx+Sg==",
       "cpu": [
         "arm"
       ],
@@ -3305,9 +4172,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-VJw60Mdgb4n+L0fO1PqfB0C7TyEQolJAC8qpqvG3JoQwvyOv6LH7Ib/WE3wxEW9nuHmVz9jkK7lk5HfWWgoO1Q==",
       "cpu": [
         "arm64"
       ],
@@ -3318,9 +4185,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-qaReO5aV8griBDsBr8uBF/faO3ieGjY1RY4p8JvTL6Mu1ylLrTVvOONqKFlNaCwrmUjWw5jnf7VafxDAeQHTow==",
       "cpu": [
         "x64"
       ],
@@ -3331,9 +4198,9 @@
       ]
     },
     "node_modules/@lmdb/lmdb-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==",
       "cpu": [
         "x64"
       ],
@@ -3501,14 +4368,14 @@
       "dev": true
     },
     "node_modules/@open-rpc/schema-utils-js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@open-rpc/schema-utils-js/-/schema-utils-js-1.16.1.tgz",
-      "integrity": "sha512-8D4OgBnHDAv7JeaYZ5v7SL4yR0YLLO4WLTWtdR8vmqSqvX3SvPzSsGYv06zqm9z1Lhm563MAcuearrc8g9eJ4w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@open-rpc/schema-utils-js/-/schema-utils-js-1.15.0.tgz",
+      "integrity": "sha512-YHTt3n3RZo1lRy8oknn2G1y0PWlo7HWtnwLOKfvVxjauKMOmlvBbpPHQZibpzIhgt+yPe4mht1ldhKOwq2tCUw==",
       "dev": true,
       "dependencies": {
-        "@json-schema-tools/dereferencer": "1.5.4",
-        "@json-schema-tools/meta-schema": "1.6.19",
-        "@json-schema-tools/reference-resolver": "1.2.4",
+        "@json-schema-tools/dereferencer": "1.5.1",
+        "@json-schema-tools/meta-schema": "^1.6.10",
+        "@json-schema-tools/reference-resolver": "^1.2.1",
         "@open-rpc/meta-schema": "1.14.2",
         "ajv": "^6.10.0",
         "detect-node": "^2.0.4",
@@ -3532,50 +4399,6 @@
       },
       "bin": {
         "open-rpc-typings": "build/cli.js"
-      }
-    },
-    "node_modules/@open-rpc/typings/node_modules/@json-schema-tools/dereferencer": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.5.1.tgz",
-      "integrity": "sha512-CUpdGpxNTq1ebMkrgVxS03FHfwkGiw63c+GNzqFAqwqsxR0OsR79aqK8h2ybxTIEhdwiaknSnlUgtUIy7FJ+3A==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-tools/reference-resolver": "^1.2.1",
-        "@json-schema-tools/traverse": "^1.7.5",
-        "fast-safe-stringify": "^2.0.7"
-      }
-    },
-    "node_modules/@open-rpc/typings/node_modules/@open-rpc/schema-utils-js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@open-rpc/schema-utils-js/-/schema-utils-js-1.15.0.tgz",
-      "integrity": "sha512-YHTt3n3RZo1lRy8oknn2G1y0PWlo7HWtnwLOKfvVxjauKMOmlvBbpPHQZibpzIhgt+yPe4mht1ldhKOwq2tCUw==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-tools/dereferencer": "1.5.1",
-        "@json-schema-tools/meta-schema": "^1.6.10",
-        "@json-schema-tools/reference-resolver": "^1.2.1",
-        "@open-rpc/meta-schema": "1.14.2",
-        "ajv": "^6.10.0",
-        "detect-node": "^2.0.4",
-        "fast-safe-stringify": "^2.0.7",
-        "fs-extra": "^9.0.0",
-        "is-url": "^1.2.4",
-        "isomorphic-fetch": "^3.0.0"
-      }
-    },
-    "node_modules/@open-rpc/typings/node_modules/@open-rpc/schema-utils-js/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@open-rpc/typings/node_modules/fs-extra": {
@@ -3902,321 +4725,22 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
-      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
+      "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.5.0"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
-      "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "lmdb": "2.2.4"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.5.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/codeframe": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
-      "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/diagnostic": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
-      "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@mischnic/json-sourcemap": "^0.1.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
-      "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/fs": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
-      "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@parcel/fs-search": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.5.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/fs-search": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
-      "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/hash": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
-      "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "xxhash-wasm": "^0.4.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/logger": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
-      "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/events": "2.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/markdown-ansi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
-      "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/package-manager": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
-      "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "@parcel/workers": "2.5.0",
-        "semver": "^5.7.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.5.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/plugin": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
-      "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@parcel/types": "2.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/types": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
-      "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@parcel/cache": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/fs": "2.5.0",
-        "@parcel/package-manager": "2.5.0",
-        "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.5.0",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
-      "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@parcel/codeframe": "2.5.0",
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/hash": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/markdown-ansi": "2.5.0",
-        "@parcel/source-map": "^2.0.0",
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/@parcel/workers": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
-      "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/logger": "2.5.0",
-        "@parcel/types": "2.5.0",
-        "@parcel/utils": "2.5.0",
-        "chrome-trace-event": "^1.0.2",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "peerDependencies": {
-        "@parcel/core": "^2.5.0"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/lmdb": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-      "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "msgpackr": "^1.5.4",
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
-        "ordered-binary": "^1.2.4",
-        "weak-lru-cache": "^1.2.2"
-      }
-    },
-    "node_modules/@parcel/namer-default/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/@parcel/node-resolver-core": {
@@ -4317,15 +4841,27 @@
       }
     },
     "node_modules/@parcel/packager-js/node_modules/globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@parcel/packager-js/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4477,9 +5013,9 @@
       }
     },
     "node_modules/@parcel/source-map": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.5.tgz",
-      "integrity": "sha512-DRVlCFKLpqBSIbMxUoVlHgfiv12HTW/U7nnhzw52YgzDVXUX9OA41dXS1PU0pJ1si+D1k8msATUC+AoldN43mg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.0.tgz",
+      "integrity": "sha512-E7UOEIof2o89LrKk1agSLmwakjigmEdDp1ZaEdsLVEvq63R/bul4Ij5CT+0ZDcijGpl5tnTbQADY9EyYGtjYgQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
@@ -6574,6 +7110,18 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -9745,6 +10293,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10978,9 +11538,9 @@
       }
     },
     "node_modules/gatsby": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.17.0.tgz",
-      "integrity": "sha512-5304jXujCuYZZ6Gm+zDLG/y2cIQtxZHzbyX6PiKc+DxjWSTnAVvAbLcbBRLsSseiSwTRNEw52cwqK2fEeGx9rw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.16.0.tgz",
+      "integrity": "sha512-C8rmUsx8LnhtDKMOyfoXH1A27tuU+5OP/p1X0vIoOfW2pcRty5pjWRlFl/OM1BHcrdrfEXTsen30eU+S4iQG8Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -11018,8 +11578,8 @@
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-lodash": "^3.3.4",
-        "babel-plugin-remove-graphql-queries": "^4.17.0",
-        "babel-preset-gatsby": "^2.17.0",
+        "babel-plugin-remove-graphql-queries": "^4.16.0",
+        "babel-preset-gatsby": "^2.16.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.0",
@@ -11062,20 +11622,20 @@
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^10.1.0",
-        "gatsby-cli": "^4.17.0",
-        "gatsby-core-utils": "^3.17.0",
-        "gatsby-graphiql-explorer": "^2.17.0",
-        "gatsby-legacy-polyfills": "^2.17.0",
-        "gatsby-link": "^4.17.0",
-        "gatsby-page-utils": "^2.17.0",
-        "gatsby-parcel-config": "^0.8.0",
-        "gatsby-plugin-page-creator": "^4.17.0",
-        "gatsby-plugin-typescript": "^4.17.0",
-        "gatsby-plugin-utils": "^3.11.0",
-        "gatsby-react-router-scroll": "^5.17.0",
-        "gatsby-script": "^1.2.0",
-        "gatsby-telemetry": "^3.17.0",
-        "gatsby-worker": "^1.17.0",
+        "gatsby-cli": "^4.16.0",
+        "gatsby-core-utils": "^3.16.0",
+        "gatsby-graphiql-explorer": "^2.16.0",
+        "gatsby-legacy-polyfills": "^2.16.0",
+        "gatsby-link": "^4.16.0",
+        "gatsby-page-utils": "^2.16.0",
+        "gatsby-parcel-config": "^0.7.0",
+        "gatsby-plugin-page-creator": "^4.16.0",
+        "gatsby-plugin-typescript": "^4.16.0",
+        "gatsby-plugin-utils": "^3.10.0",
+        "gatsby-react-router-scroll": "^5.16.0",
+        "gatsby-script": "^1.1.0",
+        "gatsby-telemetry": "^3.16.0",
+        "gatsby-worker": "^1.16.0",
         "glob": "^7.2.3",
         "globby": "^11.1.0",
         "got": "^11.8.2",
@@ -11090,7 +11650,7 @@
         "joi": "^17.4.2",
         "json-loader": "^0.5.7",
         "latest-version": "5.1.0",
-        "lmdb": "2.5.2",
+        "lmdb": "2.3.10",
         "lodash": "^4.17.21",
         "md5-file": "^5.0.0",
         "meant": "^1.0.3",
@@ -11154,7 +11714,7 @@
         "node": ">=14.15.0"
       },
       "optionalDependencies": {
-        "gatsby-sharp": "^0.11.0"
+        "gatsby-sharp": "^0.10.0"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
@@ -11244,9 +11804,9 @@
       }
     },
     "node_modules/gatsby-core-utils": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.17.0.tgz",
-      "integrity": "sha512-1e0YaqTAEpSSBkpWkY703lu+Bl76ASXUvUcpnNO3CavCYZsRQxAXtMXIKIEvhm1z6zWJmY9HILo6/DjP+PHeyw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.23.0.tgz",
+      "integrity": "sha512-ABVTAkjZh+2H4u6GZ+r1uZrdcWuT5KG2nEpKmBWBp21GWEE+yvUqtGOocBgUeGac1A3ggvn02UzcE6BIEm9PYg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
@@ -11255,9 +11815,9 @@
         "fastq": "^1.13.0",
         "file-type": "^16.5.3",
         "fs-extra": "^10.1.0",
-        "got": "^11.8.3",
+        "got": "^11.8.5",
         "import-from": "^4.0.0",
-        "lmdb": "2.5.2",
+        "lmdb": "2.5.3",
         "lock": "^1.1.0",
         "node-object-hash": "^2.3.10",
         "proper-lockfile": "^4.1.2",
@@ -11368,12 +11928,12 @@
       }
     },
     "node_modules/gatsby-parcel-config": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.8.0.tgz",
-      "integrity": "sha512-HzLU8uoJLuakH08T27K8GKx7rcLEVkKVClffAuVKrlcVYhNH+x1LvIwe+uMTIIdfu+YtUpUP1PpTdua6YfrVTQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.7.0.tgz",
+      "integrity": "sha512-M4syRbthB0qA6IwRwHz4kGB/zSrMUvkDGWTK3nmmdfRtX+U7JITE2e1Le1IU54f1r/uaotLqH3T/e5j6tEb2sg==",
       "dev": true,
       "dependencies": {
-        "@gatsbyjs/parcel-namer-relative-to-cwd": "^1.2.0",
+        "@gatsbyjs/parcel-namer-relative-to-cwd": "^1.1.0",
         "@parcel/bundler-default": "2.6.0",
         "@parcel/compressor-raw": "2.6.0",
         "@parcel/namer-default": "2.6.0",
@@ -11396,25 +11956,6 @@
       },
       "peerDependencies": {
         "@parcel/core": "2.6.0"
-      }
-    },
-    "node_modules/gatsby-parcel-config/node_modules/@parcel/namer-default": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
-      "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
-      "dev": true,
-      "dependencies": {
-        "@parcel/diagnostic": "2.6.0",
-        "@parcel/plugin": "2.6.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0",
-        "parcel": "^2.6.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/gatsby-plugin-page-creator": {
@@ -11983,6 +12524,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/gatsby/node_modules/gatsby-sharp": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-0.10.0.tgz",
+      "integrity": "sha512-Wvtl5wfQJw7NDWI9J/xDhew1dXnI/MgkvHwrSulT00GgtTmBc7knplapfdU1E2k8PwpssqEBqWXvrxMszT5oWg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/sharp": "^0.30.0",
+        "sharp": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      }
+    },
     "node_modules/gatsby/node_modules/globby": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
@@ -12095,6 +12650,29 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true
     },
+    "node_modules/gatsby/node_modules/lmdb": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
+      "integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "nan": "^2.14.2",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "^4.3.2",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "lmdb-darwin-arm64": "2.3.10",
+        "lmdb-darwin-x64": "2.3.10",
+        "lmdb-linux-arm": "2.3.10",
+        "lmdb-linux-arm64": "2.3.10",
+        "lmdb-linux-x64": "2.3.10",
+        "lmdb-win32-x64": "2.3.10"
+      }
+    },
     "node_modules/gatsby/node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -12107,6 +12685,12 @@
         "node": "*"
       }
     },
+    "node_modules/gatsby/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true
+    },
     "node_modules/gatsby/node_modules/node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -12114,6 +12698,17 @@
       "dev": true,
       "engines": {
         "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/gatsby/node_modules/node-gyp-build-optional-packages": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.5.tgz",
+      "integrity": "sha512-5ke7D8SiQsTQL7CkHpfR1tLwfqtKc0KYEmlnkwd40jHCASskZeS98qoZ1qDUns2aUQWikcjidRUs6PM/3iyN/w==",
+      "dev": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/gatsby/node_modules/redux": {
@@ -12592,12 +13187,12 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-      "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
       "dev": true,
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
       }
     },
     "node_modules/graphql-compose": {
@@ -12634,12 +13229,12 @@
       }
     },
     "node_modules/graphql-request": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-4.3.0.tgz",
-      "integrity": "sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-4.1.0.tgz",
+      "integrity": "sha512-CBFcO6LP7cg+aBMc+x9C1dZEQsKTBZKR2J+HzuB0cR/6aaU4K4/tRXTQu8CDMp5195ZU+DTNKZZOSK1WRbTeAg==",
       "dev": true,
       "dependencies": {
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^3.0.6",
         "extract-files": "^9.0.0",
         "form-data": "^3.0.0"
       },
@@ -14563,9 +15158,9 @@
       "dev": true
     },
     "node_modules/lmdb": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
-      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.3.tgz",
+      "integrity": "sha512-iBA0cb13CobBSoGJLfZgnrykLlfJipDAnvtf+YwIqqzBEsTeQYsXrHaSBkaHd5wCWeabwrNvhjZoFMUrlo+eLw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -14576,12 +15171,12 @@
         "weak-lru-cache": "^1.2.2"
       },
       "optionalDependencies": {
-        "@lmdb/lmdb-darwin-arm64": "2.5.2",
-        "@lmdb/lmdb-darwin-x64": "2.5.2",
-        "@lmdb/lmdb-linux-arm": "2.5.2",
-        "@lmdb/lmdb-linux-arm64": "2.5.2",
-        "@lmdb/lmdb-linux-x64": "2.5.2",
-        "@lmdb/lmdb-win32-x64": "2.5.2"
+        "@lmdb/lmdb-darwin-arm64": "2.5.3",
+        "@lmdb/lmdb-darwin-x64": "2.5.3",
+        "@lmdb/lmdb-linux-arm": "2.5.3",
+        "@lmdb/lmdb-linux-arm64": "2.5.3",
+        "@lmdb/lmdb-linux-x64": "2.5.3",
+        "@lmdb/lmdb-win32-x64": "2.5.3"
       }
     },
     "node_modules/lmdb-darwin-arm64": {
@@ -15602,9 +16197,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -20989,10 +21584,12 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -24875,18 +25472,554 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         }
       }
     },
     "@gatsbyjs/parcel-namer-relative-to-cwd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-1.2.0.tgz",
-      "integrity": "sha512-4iIdquFDl+b+U8Ng0dg6dCtxB/cnH27ERrlQQlxfdaWe8e9CLo8aWc6u3UeuHwNJixBFOUbOgEFaA5qCUPwLCQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-1.8.0.tgz",
+      "integrity": "sha512-/zo67Q/i3I9G+uX84Tjp54wpZdd/DLF+btyh/Zy5uCvIlV5R/wiHmLEzrtN6Axcdtmh2DBJSkN7yB8FwfZtlYQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.18.0",
-        "@parcel/plugin": "2.6.0",
-        "gatsby-core-utils": "^3.17.0"
+        "@parcel/namer-default": "2.6.2",
+        "@parcel/plugin": "2.6.2",
+        "gatsby-core-utils": "^3.23.0"
+      },
+      "dependencies": {
+        "@lmdb/lmdb-darwin-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
+          "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+          "dev": true,
+          "optional": true
+        },
+        "@lmdb/lmdb-darwin-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
+          "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+          "dev": true,
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
+          "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+          "dev": true,
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-arm64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
+          "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@lmdb/lmdb-linux-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
+          "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+          "dev": true,
+          "optional": true
+        },
+        "@lmdb/lmdb-win32-x64": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
+          "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+          "dev": true,
+          "optional": true
+        },
+        "@parcel/cache": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.2.tgz",
+          "integrity": "sha512-hhJ6AsEGybeQZd9c/GYqfcKTgZKQXu3Xih6TlnP3gdR3KZoJOnb40ovHD1yYg4COvfcXThKP1cVJ18J6rcv3IA==",
+          "dev": true,
+          "requires": {
+            "@parcel/fs": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "lmdb": "2.5.2"
+          }
+        },
+        "@parcel/codeframe": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.2.tgz",
+          "integrity": "sha512-oFlHr6HCaYYsB4SHkU+gn9DKtbzvv3/4NdwMX0/6NAKyYVI7inEsXyPGw2Bbd2ZCFatW9QJZUETF0etvh5AEfQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/core": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.7.0.tgz",
+          "integrity": "sha512-7yKZUdh314Q/kU/9+27ZYTfcnXS6VYHuG+iiUlIohnvUUybxLqVJhdMU9Q+z2QcPka1IdJWz4K4Xx0y6/4goyg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@mischnic/json-sourcemap": "^0.1.0",
+            "@parcel/cache": "2.7.0",
+            "@parcel/diagnostic": "2.7.0",
+            "@parcel/events": "2.7.0",
+            "@parcel/fs": "2.7.0",
+            "@parcel/graph": "2.7.0",
+            "@parcel/hash": "2.7.0",
+            "@parcel/logger": "2.7.0",
+            "@parcel/package-manager": "2.7.0",
+            "@parcel/plugin": "2.7.0",
+            "@parcel/source-map": "^2.0.0",
+            "@parcel/types": "2.7.0",
+            "@parcel/utils": "2.7.0",
+            "@parcel/workers": "2.7.0",
+            "abortcontroller-polyfill": "^1.1.9",
+            "base-x": "^3.0.8",
+            "browserslist": "^4.6.6",
+            "clone": "^2.1.1",
+            "dotenv": "^7.0.0",
+            "dotenv-expand": "^5.1.0",
+            "json5": "^2.2.0",
+            "msgpackr": "^1.5.4",
+            "nullthrows": "^1.1.1",
+            "semver": "^5.7.1"
+          },
+          "dependencies": {
+            "@parcel/cache": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.7.0.tgz",
+              "integrity": "sha512-JlXNoZXcWzLKdDlfeF3dIj5Vtel5T9vtdBN72PJ+cjC4qNHk4Uwvc5sfOBELuibGN0bVu2bwY9nUgSwCiB1iIA==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/fs": "2.7.0",
+                "@parcel/logger": "2.7.0",
+                "@parcel/utils": "2.7.0",
+                "lmdb": "2.5.2"
+              }
+            },
+            "@parcel/codeframe": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.7.0.tgz",
+              "integrity": "sha512-UTKx0jejJmmO1dwTHSJuRgrO8N6PMlkxRT6sew8N6NC3Bgv6pu0EbO+RtlWt/jCvzcdLOPdIoTzj4MMZvgcMYg==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "chalk": "^4.1.0"
+              }
+            },
+            "@parcel/diagnostic": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.7.0.tgz",
+              "integrity": "sha512-pdq/cTwVoL0n8yuDCRXFRSQHVWdmmIXPt3R3iT4KtYDYvOrMT2dLPT79IMqQkhYPANW8GuL15n/WxRngfRdkug==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@mischnic/json-sourcemap": "^0.1.0",
+                "nullthrows": "^1.1.1"
+              }
+            },
+            "@parcel/fs": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.7.0.tgz",
+              "integrity": "sha512-PU5fo4Hh8y03LZgemgVREttc0wyHQUNmsJCybxTB7EjJie2CqJRumo+DFppArlvdchLwJdc9em03yQV/GNWrEg==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/fs-search": "2.7.0",
+                "@parcel/types": "2.7.0",
+                "@parcel/utils": "2.7.0",
+                "@parcel/watcher": "^2.0.0",
+                "@parcel/workers": "2.7.0"
+              }
+            },
+            "@parcel/fs-search": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.7.0.tgz",
+              "integrity": "sha512-K1Hv25bnRpwQVA15RvcRuB8ZhfclnCHA8N8L6w7Ul1ncSJDxCIkIAc5hAubYNNYW3kWjCC2SOaEgFKnbvMllEQ==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "detect-libc": "^1.0.3"
+              }
+            },
+            "@parcel/logger": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.7.0.tgz",
+              "integrity": "sha512-qjMY/bYo38+o+OiIrTRldU9CwL1E7J72t+xkTP8QIcUxLWz5LYR0YbynZUVulmBSfqsykjjxCy4a+8siVr+lPw==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/diagnostic": "2.7.0",
+                "@parcel/events": "2.7.0"
+              }
+            },
+            "@parcel/markdown-ansi": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.7.0.tgz",
+              "integrity": "sha512-ipOX0D6FVZFEXeb/z8MnTMq2RQEIuaILY90olVIuHEFLHHfOPEn+RK3u13HA1ChF5/9E3cMD79tu6x9JL9Kqag==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "chalk": "^4.1.0"
+              }
+            },
+            "@parcel/package-manager": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.7.0.tgz",
+              "integrity": "sha512-wmfSX1mRrTi8MeA4KrnPk/x7zGUsILCQmTo6lA4gygzAxDbM1pGuyFN8/Kt0y0SFO2lbljARtD/4an5qdotH+Q==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/diagnostic": "2.7.0",
+                "@parcel/fs": "2.7.0",
+                "@parcel/logger": "2.7.0",
+                "@parcel/types": "2.7.0",
+                "@parcel/utils": "2.7.0",
+                "@parcel/workers": "2.7.0",
+                "semver": "^5.7.1"
+              }
+            },
+            "@parcel/plugin": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.7.0.tgz",
+              "integrity": "sha512-qqgx+nnMn6/0lRc4lKbLGmhNtBiT93S2gFNB4Eb4Pfz/SxVYoW+fmml+KdfOSiZffWOAH5L6NwhyD7N8aSikzw==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/types": "2.7.0"
+              }
+            },
+            "@parcel/types": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.7.0.tgz",
+              "integrity": "sha512-+dhXVUnseTCpJvBTGMp0V6X13z6O/A/+CUtwEpMGZ8XSmZ4Gk44GvaTiBOp0bJpWG4fvCKp+UmC8PYbrDiiziw==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/cache": "2.7.0",
+                "@parcel/diagnostic": "2.7.0",
+                "@parcel/fs": "2.7.0",
+                "@parcel/package-manager": "2.7.0",
+                "@parcel/source-map": "^2.0.0",
+                "@parcel/workers": "2.7.0",
+                "utility-types": "^3.10.0"
+              }
+            },
+            "@parcel/utils": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.7.0.tgz",
+              "integrity": "sha512-jNZ5bIGg1r1RDRKi562o4kuVwnz+XJ2Ie3b0Zwrqwvgfj6AbRFIKzDd+h85dWWmcDYzKUbHp11u6VJl1u8Vapg==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/codeframe": "2.7.0",
+                "@parcel/diagnostic": "2.7.0",
+                "@parcel/hash": "2.7.0",
+                "@parcel/logger": "2.7.0",
+                "@parcel/markdown-ansi": "2.7.0",
+                "@parcel/source-map": "^2.0.0",
+                "chalk": "^4.1.0"
+              }
+            },
+            "@parcel/workers": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.7.0.tgz",
+              "integrity": "sha512-99VfaOX+89+RaoTSyH9ZQtkMBFZBFMvJmVJ/GeJT6QCd2wtKBStTHlaSnQOkLD/iRjJCNwV2xpZmm8YkTwV+hg==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/diagnostic": "2.7.0",
+                "@parcel/logger": "2.7.0",
+                "@parcel/types": "2.7.0",
+                "@parcel/utils": "2.7.0",
+                "chrome-trace-event": "^1.0.2",
+                "nullthrows": "^1.1.1"
+              }
+            }
+          }
+        },
+        "@parcel/diagnostic": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.2.tgz",
+          "integrity": "sha512-3ODSBkKVihENU763z1/1DhGAWFhYWRxOCOShC72KXp+GFnSgGiBsxclu8NBa/N948Rzp8lqQI8U1nLcKkh0O/w==",
+          "dev": true,
+          "requires": {
+            "@mischnic/json-sourcemap": "^0.1.0",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/events": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.7.0.tgz",
+          "integrity": "sha512-kQDwMKgZ1U4M/G17qeDYF6bW5kybluN6ajYPc7mZcrWg+trEI/oXi81GMFaMX0BSUhwhbiN5+/Vb2wiG/Sn6ig==",
+          "dev": true,
+          "peer": true
+        },
+        "@parcel/fs": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.2.tgz",
+          "integrity": "sha512-mIhqdF3tjgeoIGqW7Nc/xfM2ClID7o8livwUe5lpQEP+ZaIBiMigXs6ckv3WToCACK+3uylrSD2A/HmlhrxMqQ==",
+          "dev": true,
+          "requires": {
+            "@parcel/fs-search": "2.6.2",
+            "@parcel/types": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "@parcel/watcher": "^2.0.0",
+            "@parcel/workers": "2.6.2"
+          }
+        },
+        "@parcel/fs-search": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.2.tgz",
+          "integrity": "sha512-4STid1zqtGnmGjHD/2TG2g/zPDiCTtE3IAS24QYH3eiUAz2uoKGgEqd2tZbZ2yI96jtCuIhC1bzVu8Hbykls7w==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3"
+          }
+        },
+        "@parcel/graph": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.7.0.tgz",
+          "integrity": "sha512-Q6E94GS6q45PtsZh+m+gvFRp/N1Qopxhu2sxjcWsGs5iBd6IWn2oYLWOH5iVzEjWuYpW2HkB08lH6J50O63uOA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "@parcel/utils": "2.7.0",
+            "nullthrows": "^1.1.1"
+          },
+          "dependencies": {
+            "@parcel/codeframe": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.7.0.tgz",
+              "integrity": "sha512-UTKx0jejJmmO1dwTHSJuRgrO8N6PMlkxRT6sew8N6NC3Bgv6pu0EbO+RtlWt/jCvzcdLOPdIoTzj4MMZvgcMYg==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "chalk": "^4.1.0"
+              }
+            },
+            "@parcel/diagnostic": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.7.0.tgz",
+              "integrity": "sha512-pdq/cTwVoL0n8yuDCRXFRSQHVWdmmIXPt3R3iT4KtYDYvOrMT2dLPT79IMqQkhYPANW8GuL15n/WxRngfRdkug==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@mischnic/json-sourcemap": "^0.1.0",
+                "nullthrows": "^1.1.1"
+              }
+            },
+            "@parcel/logger": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.7.0.tgz",
+              "integrity": "sha512-qjMY/bYo38+o+OiIrTRldU9CwL1E7J72t+xkTP8QIcUxLWz5LYR0YbynZUVulmBSfqsykjjxCy4a+8siVr+lPw==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/diagnostic": "2.7.0",
+                "@parcel/events": "2.7.0"
+              }
+            },
+            "@parcel/markdown-ansi": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.7.0.tgz",
+              "integrity": "sha512-ipOX0D6FVZFEXeb/z8MnTMq2RQEIuaILY90olVIuHEFLHHfOPEn+RK3u13HA1ChF5/9E3cMD79tu6x9JL9Kqag==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "chalk": "^4.1.0"
+              }
+            },
+            "@parcel/utils": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.7.0.tgz",
+              "integrity": "sha512-jNZ5bIGg1r1RDRKi562o4kuVwnz+XJ2Ie3b0Zwrqwvgfj6AbRFIKzDd+h85dWWmcDYzKUbHp11u6VJl1u8Vapg==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "@parcel/codeframe": "2.7.0",
+                "@parcel/diagnostic": "2.7.0",
+                "@parcel/hash": "2.7.0",
+                "@parcel/logger": "2.7.0",
+                "@parcel/markdown-ansi": "2.7.0",
+                "@parcel/source-map": "^2.0.0",
+                "chalk": "^4.1.0"
+              }
+            }
+          }
+        },
+        "@parcel/hash": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.7.0.tgz",
+          "integrity": "sha512-k6bSKnIlPJMPU3yjQzfgfvF9zuJZGOAlJgzpL4BbWvdbE8BTdjzLcFn0Ujrtud94EgIkiXd22sC2HpCUWoHGdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "xxhash-wasm": "^0.4.2"
+          }
+        },
+        "@parcel/logger": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.2.tgz",
+          "integrity": "sha512-Sz5YGCj1DbEiX0/G8Uw97LLZ0uEK+qtWcRAkHNpJpeMiSqDiRNevxXltz42EcLo+oCh4d4wyiVzwi9mNwzhS/Q==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/events": "2.6.2"
+          },
+          "dependencies": {
+            "@parcel/events": {
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.2.tgz",
+              "integrity": "sha512-IaCjOeA5ercdFVi1EZOmUHhGfIysmCUgc2Th9hMugSFO0I3GzRsBcAdP6XPfWm+TV6sQ/qZRfdk/drUxoAupnw==",
+              "dev": true
+            }
+          }
+        },
+        "@parcel/markdown-ansi": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.2.tgz",
+          "integrity": "sha512-N/h9J4eibhc+B+krzvPMzFUWL37GudBIZBa7XSLkcuH6MnYYfh6rrMvhIyyESwk6VkcZNVzAeZrGQqxEs0dHDQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0"
+          }
+        },
+        "@parcel/namer-default": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.2.tgz",
+          "integrity": "sha512-mp7bx/BQaIuohmZP0uE+gAmDBzzH0Yu8F4yCtE611lc6i0mou+nWRhzyKLNC/ieuI8DB3BFh2QQKeTxJn4W0qg==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/plugin": "2.6.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "@parcel/package-manager": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.2.tgz",
+          "integrity": "sha512-xGMqTgnwTE3rgzYwUZMKxR8fzmP5iSYz/gj2H8FR3pEmwh/8xCMtNjTSth+hPVGuqgRZ6JxwpfdY/fXdZ61ViQ==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/fs": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/types": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "@parcel/workers": "2.6.2",
+            "semver": "^5.7.1"
+          }
+        },
+        "@parcel/plugin": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.2.tgz",
+          "integrity": "sha512-wbbWsM23Pr+8xtLSvf+UopXdVYlpKCCx6PuuZaZcKo+9IcDCWoGXD4M8Kkz14qBmkFn5uM00mULUqmVdSibB2w==",
+          "dev": true,
+          "requires": {
+            "@parcel/types": "2.6.2"
+          }
+        },
+        "@parcel/types": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.2.tgz",
+          "integrity": "sha512-MV8BFpCIs2jMUvK2RHqzkoiuOQ//JIbrD1zocA2YRW3zuPL/iABvbAABJoXpoPCKikVWOoCWASgBfWQo26VvJQ==",
+          "dev": true,
+          "requires": {
+            "@parcel/cache": "2.6.2",
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/fs": "2.6.2",
+            "@parcel/package-manager": "2.6.2",
+            "@parcel/source-map": "^2.0.0",
+            "@parcel/workers": "2.6.2",
+            "utility-types": "^3.10.0"
+          }
+        },
+        "@parcel/utils": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.2.tgz",
+          "integrity": "sha512-Ug7hpRxjgbY5AopW55nY7MmGMVmwmN+ihfCmxJkBUoESTG/3iq8uME7GjyOgW5DkQc2K7q62i8y8N0wCJT1u4Q==",
+          "dev": true,
+          "requires": {
+            "@parcel/codeframe": "2.6.2",
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/hash": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/markdown-ansi": "2.6.2",
+            "@parcel/source-map": "^2.0.0",
+            "chalk": "^4.1.0"
+          },
+          "dependencies": {
+            "@parcel/hash": {
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.2.tgz",
+              "integrity": "sha512-tFB+cJU1Wqag6WyJgsmx3nx+xhmjcNZqtWh/MtK1lHNnZdDRk6bjr7SapnygBwruz+SmSt5bbdVThcpk2dRCcA==",
+              "dev": true,
+              "requires": {
+                "detect-libc": "^1.0.3",
+                "xxhash-wasm": "^0.4.2"
+              }
+            }
+          }
+        },
+        "@parcel/workers": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.2.tgz",
+          "integrity": "sha512-wBgUjJQm+lDd12fPRUmk09+ujTA9DgwPdqylSFK0OtI/yT6A+2kArUqjp8IwWo2tCJXoMzXBne2XQIWKqMiN4Q==",
+          "dev": true,
+          "requires": {
+            "@parcel/diagnostic": "2.6.2",
+            "@parcel/logger": "2.6.2",
+            "@parcel/types": "2.6.2",
+            "@parcel/utils": "2.6.2",
+            "chrome-trace-event": "^1.0.2",
+            "nullthrows": "^1.1.1"
+          }
+        },
+        "dotenv": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+          "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+          "dev": true,
+          "peer": true
+        },
+        "lmdb": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
+          "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+          "dev": true,
+          "requires": {
+            "@lmdb/lmdb-darwin-arm64": "2.5.2",
+            "@lmdb/lmdb-darwin-x64": "2.5.2",
+            "@lmdb/lmdb-linux-arm": "2.5.2",
+            "@lmdb/lmdb-linux-arm64": "2.5.2",
+            "@lmdb/lmdb-linux-x64": "2.5.2",
+            "@lmdb/lmdb-win32-x64": "2.5.2",
+            "msgpackr": "^1.5.4",
+            "node-addon-api": "^4.3.0",
+            "node-gyp-build-optional-packages": "5.0.3",
+            "ordered-binary": "^1.2.4",
+            "weak-lru-cache": "^1.2.2"
+          }
+        },
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "@gatsbyjs/potrace": {
@@ -25067,6 +26200,31 @@
         "tslib": "~2.4.0"
       },
       "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-inspector/core": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-inspector/core/-/core-3.3.0.tgz",
+      "integrity": "sha512-LRtk9sHgj9qqVPIkkThAVq3iZ7QxgHCx6elEwd0eesZBCmaIYQxD/BFu+VT8jr10YfOURBZuAnVdyGu64vYpBg==",
+      "dev": true,
+      "requires": {
+        "dependency-graph": "0.11.0",
+        "object-inspect": "1.10.3",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+          "dev": true
+        },
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -25716,13 +26874,13 @@
       "dev": true
     },
     "@json-schema-tools/dereferencer": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.5.4.tgz",
-      "integrity": "sha512-4cmEdRPIG7WrcSWGRV6HBDCLXEOXGkaOZnopqBxoG24mKYuCHWg4M6N9nioTQyNfKqlPkOPvT4lStQqkPnhLgA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.5.1.tgz",
+      "integrity": "sha512-CUpdGpxNTq1ebMkrgVxS03FHfwkGiw63c+GNzqFAqwqsxR0OsR79aqK8h2ybxTIEhdwiaknSnlUgtUIy7FJ+3A==",
       "dev": true,
       "requires": {
-        "@json-schema-tools/reference-resolver": "^1.2.4",
-        "@json-schema-tools/traverse": "^1.7.8",
+        "@json-schema-tools/reference-resolver": "^1.2.1",
+        "@json-schema-tools/traverse": "^1.7.5",
         "fast-safe-stringify": "^2.0.7"
       }
     },
@@ -25797,44 +26955,44 @@
       }
     },
     "@lmdb/lmdb-darwin-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.2.tgz",
-      "integrity": "sha512-+F8ioQIUN68B4UFiIBYu0QQvgb9FmlKw2ctQMSBfW2QBrZIxz9vD9jCGqTCPqZBRbPHAS/vG1zSXnKqnS2ch/A==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-RXwGZ/0eCqtCY8FLTM/koR60w+MXyvBUpToXiIyjOcBnC81tAlTUHrRUavCEWPI9zc9VgvpK3+cbumPyR8BSuA==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-darwin-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.2.tgz",
-      "integrity": "sha512-KvPH56KRLLx4KSfKBx0m1r7GGGUMXm0jrKmNE7plbHlesZMuPJICtn07HYgQhj1LNsK7Yqwuvnqh1QxhJnF1EA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-darwin-x64/-/lmdb-darwin-x64-2.5.3.tgz",
+      "integrity": "sha512-337dNzh5yCdNCTk8kPfoU7jR3otibSlPDGW0vKZT97rKnQMb9tNdto3RtWoGPsQ8hKmlRZpojOJtmwjncq1MoA==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-arm": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.2.tgz",
-      "integrity": "sha512-5kQAP21hAkfW5Bl+e0P57dV4dGYnkNIpR7f/GAh6QHlgXx+vp/teVj4PGRZaKAvt0GX6++N6hF8NnGElLDuIDw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm/-/lmdb-linux-arm-2.5.3.tgz",
+      "integrity": "sha512-mU2HFJDGwECkoD9dHQEfeTG5mp8hNS2BCfwoiOpVPMeapjYpQz9Uw3FkUjRZ4dGHWKbin40oWHuL0bk2bCx+Sg==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-arm64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.2.tgz",
-      "integrity": "sha512-aLl89VHL/wjhievEOlPocoefUyWdvzVrcQ/MHQYZm2JfV1jUsrbr/ZfkPPUFvZBf+VSE+Q0clWs9l29PCX1hTQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-arm64/-/lmdb-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-VJw60Mdgb4n+L0fO1PqfB0C7TyEQolJAC8qpqvG3JoQwvyOv6LH7Ib/WE3wxEW9nuHmVz9jkK7lk5HfWWgoO1Q==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-linux-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.2.tgz",
-      "integrity": "sha512-xUdUfwDJLGjOUPH3BuPBt0NlIrR7f/QHKgu3GZIXswMMIihAekj2i97oI0iWG5Bok/b+OBjHPfa8IU9velnP/Q==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-linux-x64/-/lmdb-linux-x64-2.5.3.tgz",
+      "integrity": "sha512-qaReO5aV8griBDsBr8uBF/faO3ieGjY1RY4p8JvTL6Mu1ylLrTVvOONqKFlNaCwrmUjWw5jnf7VafxDAeQHTow==",
       "dev": true,
       "optional": true
     },
     "@lmdb/lmdb-win32-x64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.2.tgz",
-      "integrity": "sha512-zrBczSbXKxEyK2ijtbRdICDygRqWSRPpZMN5dD1T8VMEW5RIhIbwFWw2phDRXuBQdVDpSjalCIUMWMV2h3JaZA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@lmdb/lmdb-win32-x64/-/lmdb-win32-x64-2.5.3.tgz",
+      "integrity": "sha512-cK+Elf3RjEzrm3SerAhrFWL5oQAsZSJ/LmjL1joIpTfEP1etJJ9CTRvdaV6XLYAxaEkfdhk/9hOvHLbR9yIhCA==",
       "dev": true,
       "optional": true
     },
@@ -25945,14 +27103,14 @@
       "dev": true
     },
     "@open-rpc/schema-utils-js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@open-rpc/schema-utils-js/-/schema-utils-js-1.16.1.tgz",
-      "integrity": "sha512-8D4OgBnHDAv7JeaYZ5v7SL4yR0YLLO4WLTWtdR8vmqSqvX3SvPzSsGYv06zqm9z1Lhm563MAcuearrc8g9eJ4w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@open-rpc/schema-utils-js/-/schema-utils-js-1.15.0.tgz",
+      "integrity": "sha512-YHTt3n3RZo1lRy8oknn2G1y0PWlo7HWtnwLOKfvVxjauKMOmlvBbpPHQZibpzIhgt+yPe4mht1ldhKOwq2tCUw==",
       "dev": true,
       "requires": {
-        "@json-schema-tools/dereferencer": "1.5.4",
-        "@json-schema-tools/meta-schema": "1.6.19",
-        "@json-schema-tools/reference-resolver": "1.2.4",
+        "@json-schema-tools/dereferencer": "1.5.1",
+        "@json-schema-tools/meta-schema": "^1.6.10",
+        "@json-schema-tools/reference-resolver": "^1.2.1",
         "@open-rpc/meta-schema": "1.14.2",
         "ajv": "^6.10.0",
         "detect-node": "^2.0.4",
@@ -25975,49 +27133,6 @@
         "fs-extra": "^10.0.0"
       },
       "dependencies": {
-        "@json-schema-tools/dereferencer": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.5.1.tgz",
-          "integrity": "sha512-CUpdGpxNTq1ebMkrgVxS03FHfwkGiw63c+GNzqFAqwqsxR0OsR79aqK8h2ybxTIEhdwiaknSnlUgtUIy7FJ+3A==",
-          "dev": true,
-          "requires": {
-            "@json-schema-tools/reference-resolver": "^1.2.1",
-            "@json-schema-tools/traverse": "^1.7.5",
-            "fast-safe-stringify": "^2.0.7"
-          }
-        },
-        "@open-rpc/schema-utils-js": {
-          "version": "1.15.0",
-          "resolved": "https://registry.npmjs.org/@open-rpc/schema-utils-js/-/schema-utils-js-1.15.0.tgz",
-          "integrity": "sha512-YHTt3n3RZo1lRy8oknn2G1y0PWlo7HWtnwLOKfvVxjauKMOmlvBbpPHQZibpzIhgt+yPe4mht1ldhKOwq2tCUw==",
-          "dev": true,
-          "requires": {
-            "@json-schema-tools/dereferencer": "1.5.1",
-            "@json-schema-tools/meta-schema": "^1.6.10",
-            "@json-schema-tools/reference-resolver": "^1.2.1",
-            "@open-rpc/meta-schema": "1.14.2",
-            "ajv": "^6.10.0",
-            "detect-node": "^2.0.4",
-            "fast-safe-stringify": "^2.0.7",
-            "fs-extra": "^9.0.0",
-            "is-url": "^1.2.4",
-            "isomorphic-fetch": "^3.0.0"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "9.1.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-              "dev": true,
-              "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            }
-          }
-        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -26232,208 +27347,14 @@
       }
     },
     "@parcel/namer-default": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.5.0.tgz",
-      "integrity": "sha512-ahGQqHJzsWE5Qux8zXMAU+lyNBOl+ZpcOFzRGE2DWOsmAlytsHl7DBVCQvzUyNBFg1/HmIj+7D4efv2kjR7rTg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
+      "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "@parcel/diagnostic": "2.5.0",
-        "@parcel/plugin": "2.5.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "nullthrows": "^1.1.1"
-      },
-      "dependencies": {
-        "@parcel/cache": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.5.0.tgz",
-          "integrity": "sha512-3kOO3cZQv0FAKhrMHGLdb4Qtzpmy78Q6jPN3u8eCY4yqeDTnyQBZvWNHoyCm5WlmL8y6Q6REYMbETLxSH1ggAQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@parcel/fs": "2.5.0",
-            "@parcel/logger": "2.5.0",
-            "@parcel/utils": "2.5.0",
-            "lmdb": "2.2.4"
-          }
-        },
-        "@parcel/codeframe": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.5.0.tgz",
-          "integrity": "sha512-qafqL8Vu2kr932cCWESoDEEoAeKVi7/xdzTBuhzEJng1AfmRT0rCbt/P4ao3RjiDyozPSjXsHOqM6GDZcto4eQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/diagnostic": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.5.0.tgz",
-          "integrity": "sha512-KiMGGRpEV7wl5gjcxBKcgX84a+cG+IEn94gwy5LK3lENR09nuKShqqgKGAmj/17CobJgw1QNP94/H4Md+oxIWg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@mischnic/json-sourcemap": "^0.1.0",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "@parcel/events": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.5.0.tgz",
-          "integrity": "sha512-Gc2LPwL1H34Ony5MENbKZg7wvCscZ4x9y7Fu92sfbdWpLo3K13hVtsX3TMIIgYt3B7R7OmO8yR880U2T+JfVkQ==",
-          "dev": true,
-          "peer": true
-        },
-        "@parcel/fs": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.5.0.tgz",
-          "integrity": "sha512-YYr14BWtx/bJ+hu6PPQQ6G/3omOTWgVqEw+UFI3iQH3P6+e0LRXW/Ja1yAcJeepGcTwIP0opnXZBQOm8PBQ2SA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@parcel/fs-search": "2.5.0",
-            "@parcel/types": "2.5.0",
-            "@parcel/utils": "2.5.0",
-            "@parcel/watcher": "^2.0.0",
-            "@parcel/workers": "2.5.0"
-          }
-        },
-        "@parcel/fs-search": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.5.0.tgz",
-          "integrity": "sha512-uBONkz9ZCNSOqbPGWJY3MNl+pqBTfvzHH9+4UhzHEHPArvK2oD0+syYPVE60+zGrxybXTESYMCJp4bHvH6Z2hA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "detect-libc": "^1.0.3"
-          }
-        },
-        "@parcel/hash": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.5.0.tgz",
-          "integrity": "sha512-47JL0XpB7UvIW6Ijf8vv+yVMt9dLvB/lRlBHFmAkmovisueVMVbYD7smxVZnCSehD8UH8BcymKbMzyL5dimgoQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "xxhash-wasm": "^0.4.2"
-          }
-        },
-        "@parcel/logger": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.5.0.tgz",
-          "integrity": "sha512-pT1L3ceH6trL1N3I3r2HawPjz/PCubOo/Kazu7IeXsMsKVjj1a6AeieZHzkNZIbhiGPtm/cHbBNLz2zTWDLeOA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/events": "2.5.0"
-          }
-        },
-        "@parcel/markdown-ansi": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.5.0.tgz",
-          "integrity": "sha512-ixkNF3KWIqxMlfxTe9Gb2cp/uNmklQev8VEUxujMVxmUfGyQs4859zdJIQlIinabWYhArhsXATkVf3MzCUN6TQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/package-manager": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.5.0.tgz",
-          "integrity": "sha512-zTuF55/lITUjw9dUU/X0HiF++589xbPXw/zUiG9T6s8BQThLvrxAhYP89S719pw7cTqDimGkTxnIuK+a0djEkg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/fs": "2.5.0",
-            "@parcel/logger": "2.5.0",
-            "@parcel/types": "2.5.0",
-            "@parcel/utils": "2.5.0",
-            "@parcel/workers": "2.5.0",
-            "semver": "^5.7.1"
-          }
-        },
-        "@parcel/plugin": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.5.0.tgz",
-          "integrity": "sha512-obtb6/Gql6YFQ86bdv75A2Noabx8679reFZeyfKKf0L7Lppx4DFQetXwM9XVy7Gx6hJ1Ekm3UMuuIyVJk33YHQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@parcel/types": "2.5.0"
-          }
-        },
-        "@parcel/types": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.5.0.tgz",
-          "integrity": "sha512-bA0fhG6aXSGYEVo5Dt96x6lseUQHeVZVzgmiRdZsvb614Gvx22ItfaKhPmAVbM9vzbObZDHl9l9G2Ovw8Xve4g==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@parcel/cache": "2.5.0",
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/fs": "2.5.0",
-            "@parcel/package-manager": "2.5.0",
-            "@parcel/source-map": "^2.0.0",
-            "@parcel/workers": "2.5.0",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "@parcel/utils": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.5.0.tgz",
-          "integrity": "sha512-kaLGXtQuOOH55KZqXdYDvczhh3mk2eeTVqrrXuuihGjbLKYFlUW2tFDm+5r2s9nCPwTQxOO43ZEOCKSnia+e4w==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@parcel/codeframe": "2.5.0",
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/hash": "2.5.0",
-            "@parcel/logger": "2.5.0",
-            "@parcel/markdown-ansi": "2.5.0",
-            "@parcel/source-map": "^2.0.0",
-            "chalk": "^4.1.0"
-          }
-        },
-        "@parcel/workers": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.5.0.tgz",
-          "integrity": "sha512-/Ow5OKJWs+9OzV3Jy4J++VnbNx0j3ls/M1CGVBLiBWyCada9DMtquYoBQ4Sk6Uam50BKkIFYetGOeXPNQyyMjg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@parcel/diagnostic": "2.5.0",
-            "@parcel/logger": "2.5.0",
-            "@parcel/types": "2.5.0",
-            "@parcel/utils": "2.5.0",
-            "chrome-trace-event": "^1.0.2",
-            "nullthrows": "^1.1.1"
-          }
-        },
-        "lmdb": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-          "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "msgpackr": "^1.5.4",
-            "nan": "^2.14.2",
-            "node-gyp-build": "^4.2.3",
-            "ordered-binary": "^1.2.4",
-            "weak-lru-cache": "^1.2.2"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true,
-          "peer": true
-        }
       }
     },
     "@parcel/node-resolver-core": {
@@ -26500,13 +27421,19 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.15.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+          "version": "13.17.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         }
       }
     },
@@ -26593,9 +27520,9 @@
       }
     },
     "@parcel/source-map": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.5.tgz",
-      "integrity": "sha512-DRVlCFKLpqBSIbMxUoVlHgfiv12HTW/U7nnhzw52YgzDVXUX9OA41dXS1PU0pJ1si+D1k8msATUC+AoldN43mg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.0.tgz",
+      "integrity": "sha512-E7UOEIof2o89LrKk1agSLmwakjigmEdDp1ZaEdsLVEvq63R/bul4Ij5CT+0ZDcijGpl5tnTbQADY9EyYGtjYgQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3"
@@ -28227,6 +29154,12 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
           "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
@@ -30453,6 +31386,12 @@
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -31653,9 +32592,9 @@
       "dev": true
     },
     "gatsby": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.17.0.tgz",
-      "integrity": "sha512-5304jXujCuYZZ6Gm+zDLG/y2cIQtxZHzbyX6PiKc+DxjWSTnAVvAbLcbBRLsSseiSwTRNEw52cwqK2fEeGx9rw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.16.0.tgz",
+      "integrity": "sha512-C8rmUsx8LnhtDKMOyfoXH1A27tuU+5OP/p1X0vIoOfW2pcRty5pjWRlFl/OM1BHcrdrfEXTsen30eU+S4iQG8Q==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.0",
@@ -31692,8 +32631,8 @@
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-lodash": "^3.3.4",
-        "babel-plugin-remove-graphql-queries": "^4.17.0",
-        "babel-preset-gatsby": "^2.17.0",
+        "babel-plugin-remove-graphql-queries": "^4.16.0",
+        "babel-preset-gatsby": "^2.16.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.0",
@@ -31736,21 +32675,21 @@
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^10.1.0",
-        "gatsby-cli": "^4.17.0",
-        "gatsby-core-utils": "^3.17.0",
-        "gatsby-graphiql-explorer": "^2.17.0",
-        "gatsby-legacy-polyfills": "^2.17.0",
-        "gatsby-link": "^4.17.0",
-        "gatsby-page-utils": "^2.17.0",
-        "gatsby-parcel-config": "^0.8.0",
-        "gatsby-plugin-page-creator": "^4.17.0",
-        "gatsby-plugin-typescript": "^4.17.0",
-        "gatsby-plugin-utils": "^3.11.0",
-        "gatsby-react-router-scroll": "^5.17.0",
-        "gatsby-script": "^1.2.0",
-        "gatsby-sharp": "^0.11.0",
-        "gatsby-telemetry": "^3.17.0",
-        "gatsby-worker": "^1.17.0",
+        "gatsby-cli": "^4.16.0",
+        "gatsby-core-utils": "^3.16.0",
+        "gatsby-graphiql-explorer": "^2.16.0",
+        "gatsby-legacy-polyfills": "^2.16.0",
+        "gatsby-link": "^4.16.0",
+        "gatsby-page-utils": "^2.16.0",
+        "gatsby-parcel-config": "^0.7.0",
+        "gatsby-plugin-page-creator": "^4.16.0",
+        "gatsby-plugin-typescript": "^4.16.0",
+        "gatsby-plugin-utils": "^3.10.0",
+        "gatsby-react-router-scroll": "^5.16.0",
+        "gatsby-script": "^1.1.0",
+        "gatsby-sharp": "^0.10.0",
+        "gatsby-telemetry": "^3.16.0",
+        "gatsby-worker": "^1.16.0",
         "glob": "^7.2.3",
         "globby": "^11.1.0",
         "got": "^11.8.2",
@@ -31765,7 +32704,7 @@
         "joi": "^17.4.2",
         "json-loader": "^0.5.7",
         "latest-version": "5.1.0",
-        "lmdb": "2.5.2",
+        "lmdb": "2.3.10",
         "lodash": "^4.17.21",
         "md5-file": "^5.0.0",
         "meant": "^1.0.3",
@@ -32113,6 +33052,17 @@
             "universalify": "^2.0.0"
           }
         },
+        "gatsby-sharp": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-0.10.0.tgz",
+          "integrity": "sha512-Wvtl5wfQJw7NDWI9J/xDhew1dXnI/MgkvHwrSulT00GgtTmBc7knplapfdU1E2k8PwpssqEBqWXvrxMszT5oWg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/sharp": "^0.30.0",
+            "sharp": "^0.30.3"
+          }
+        },
         "globby": {
           "version": "11.0.3",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
@@ -32196,6 +33146,26 @@
           "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
           "dev": true
         },
+        "lmdb": {
+          "version": "2.3.10",
+          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
+          "integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
+          "dev": true,
+          "requires": {
+            "lmdb-darwin-arm64": "2.3.10",
+            "lmdb-darwin-x64": "2.3.10",
+            "lmdb-linux-arm": "2.3.10",
+            "lmdb-linux-arm64": "2.3.10",
+            "lmdb-linux-x64": "2.3.10",
+            "lmdb-win32-x64": "2.3.10",
+            "msgpackr": "^1.5.4",
+            "nan": "^2.14.2",
+            "node-addon-api": "^4.3.0",
+            "node-gyp-build-optional-packages": "^4.3.2",
+            "ordered-binary": "^1.2.4",
+            "weak-lru-cache": "^1.2.2"
+          }
+        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -32205,10 +33175,22 @@
             "brace-expansion": "^1.1.7"
           }
         },
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "dev": true
+        },
         "node-fetch": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
           "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "dev": true
+        },
+        "node-gyp-build-optional-packages": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.5.tgz",
+          "integrity": "sha512-5ke7D8SiQsTQL7CkHpfR1tLwfqtKc0KYEmlnkwd40jHCASskZeS98qoZ1qDUns2aUQWikcjidRUs6PM/3iyN/w==",
           "dev": true
         },
         "redux": {
@@ -32353,9 +33335,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.17.0.tgz",
-      "integrity": "sha512-1e0YaqTAEpSSBkpWkY703lu+Bl76ASXUvUcpnNO3CavCYZsRQxAXtMXIKIEvhm1z6zWJmY9HILo6/DjP+PHeyw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.23.0.tgz",
+      "integrity": "sha512-ABVTAkjZh+2H4u6GZ+r1uZrdcWuT5KG2nEpKmBWBp21GWEE+yvUqtGOocBgUeGac1A3ggvn02UzcE6BIEm9PYg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.15.4",
@@ -32364,9 +33346,9 @@
         "fastq": "^1.13.0",
         "file-type": "^16.5.3",
         "fs-extra": "^10.1.0",
-        "got": "^11.8.3",
+        "got": "^11.8.5",
         "import-from": "^4.0.0",
-        "lmdb": "2.5.2",
+        "lmdb": "2.5.3",
         "lock": "^1.1.0",
         "node-object-hash": "^2.3.10",
         "proper-lockfile": "^4.1.2",
@@ -32454,12 +33436,12 @@
       }
     },
     "gatsby-parcel-config": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.8.0.tgz",
-      "integrity": "sha512-HzLU8uoJLuakH08T27K8GKx7rcLEVkKVClffAuVKrlcVYhNH+x1LvIwe+uMTIIdfu+YtUpUP1PpTdua6YfrVTQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.7.0.tgz",
+      "integrity": "sha512-M4syRbthB0qA6IwRwHz4kGB/zSrMUvkDGWTK3nmmdfRtX+U7JITE2e1Le1IU54f1r/uaotLqH3T/e5j6tEb2sg==",
       "dev": true,
       "requires": {
-        "@gatsbyjs/parcel-namer-relative-to-cwd": "^1.2.0",
+        "@gatsbyjs/parcel-namer-relative-to-cwd": "^1.1.0",
         "@parcel/bundler-default": "2.6.0",
         "@parcel/compressor-raw": "2.6.0",
         "@parcel/namer-default": "2.6.0",
@@ -32476,19 +33458,6 @@
         "@parcel/transformer-json": "2.6.0",
         "@parcel/transformer-raw": "2.6.0",
         "@parcel/transformer-react-refresh-wrap": "2.6.0"
-      },
-      "dependencies": {
-        "@parcel/namer-default": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
-          "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
-          "dev": true,
-          "requires": {
-            "@parcel/diagnostic": "2.6.0",
-            "@parcel/plugin": "2.6.0",
-            "nullthrows": "^1.1.1"
-          }
-        }
       }
     },
     "gatsby-plugin-page-creator": {
@@ -32953,9 +33922,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-      "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
+      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
       "dev": true
     },
     "graphql-compose": {
@@ -32986,12 +33955,12 @@
       }
     },
     "graphql-request": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-4.3.0.tgz",
-      "integrity": "sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-4.1.0.tgz",
+      "integrity": "sha512-CBFcO6LP7cg+aBMc+x9C1dZEQsKTBZKR2J+HzuB0cR/6aaU4K4/tRXTQu8CDMp5195ZU+DTNKZZOSK1WRbTeAg==",
       "dev": true,
       "requires": {
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^3.0.6",
         "extract-files": "^9.0.0",
         "form-data": "^3.0.0"
       }
@@ -34499,17 +35468,17 @@
       "dev": true
     },
     "lmdb": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.2.tgz",
-      "integrity": "sha512-V5V5Xa2Hp9i2XsbDALkBTeHXnBXh/lEmk9p22zdr7jtuOIY9TGhjK6vAvTpOOx9IKU4hJkRWZxn/HsvR1ELLtA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.3.tgz",
+      "integrity": "sha512-iBA0cb13CobBSoGJLfZgnrykLlfJipDAnvtf+YwIqqzBEsTeQYsXrHaSBkaHd5wCWeabwrNvhjZoFMUrlo+eLw==",
       "dev": true,
       "requires": {
-        "@lmdb/lmdb-darwin-arm64": "2.5.2",
-        "@lmdb/lmdb-darwin-x64": "2.5.2",
-        "@lmdb/lmdb-linux-arm": "2.5.2",
-        "@lmdb/lmdb-linux-arm64": "2.5.2",
-        "@lmdb/lmdb-linux-x64": "2.5.2",
-        "@lmdb/lmdb-win32-x64": "2.5.2",
+        "@lmdb/lmdb-darwin-arm64": "2.5.3",
+        "@lmdb/lmdb-darwin-x64": "2.5.3",
+        "@lmdb/lmdb-linux-arm": "2.5.3",
+        "@lmdb/lmdb-linux-arm64": "2.5.3",
+        "@lmdb/lmdb-linux-x64": "2.5.3",
+        "@lmdb/lmdb-win32-x64": "2.5.3",
         "msgpackr": "^1.5.4",
         "node-addon-api": "^4.3.0",
         "node-gyp-build-optional-packages": "5.0.3",
@@ -35336,9 +36305,9 @@
       "peer": true
     },
     "node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true
     },
     "node-gyp-build-optional-packages": {
@@ -39516,10 +40485,12 @@
       }
     },
     "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   },
   "homepage": "https://github.com/ethereum/execution-apis#readme",
   "devDependencies": {
-    "@graphql-inspector/core": "^3.3.0",
+    "@graphql-inspector/core": "~3.3.0",
     "@open-rpc/generator": "1.18.6",
-    "@open-rpc/schema-utils-js": "^1.15.0",
-    "gatsby": "^4.16.0",
-    "gh-pages": "^4.0.0",
-    "graphql": "^16.3.0",
-    "graphql-request": "^4.1.0",
-    "js-yaml": "^4.1.0",
-    "json-schema-merge-allof": "^0.8.1"
+    "@open-rpc/schema-utils-js": "1.15.0",
+    "gatsby": "~4.16.0",
+    "gh-pages": "~4.0.0",
+    "graphql": "~16.3.0",
+    "graphql-request": "~4.1.0",
+    "js-yaml": "~4.1.0",
+    "json-schema-merge-allof": "~0.8.1"
   }
 }


### PR DESCRIPTION
A regression was introduced in one of the graphql dependencies that cause CI to break. This PR makes it so we only accept patch updates to the listed versions.