### PR TITLE
Add `eth_batchCall`

### DIFF
--- a/src/eth/execute.yaml
+++ b/src/eth/execute.yaml
@@ -54,13 +54,13 @@
         gasUsed:
           title: Gas used
           $ref: '#/components/schemas/uint'
-- name: eth_batchCall
+- name: eth_multicall
   summary: Executes a sequence of message calls building on eachother's state immediately without creating transactions on the block chain.
   params:
     - name: Arguments
       required: true
       schema:
-        $ref: '#/components/schemas/BatchCallArgs'
+        $ref: '#/components/schemas/MulticallArgs'
   result:
     name: Result of calls
     schema:

--- a/src/eth/execute.yaml
+++ b/src/eth/execute.yaml
@@ -54,3 +54,14 @@
         gasUsed:
           title: Gas used
           $ref: '#/components/schemas/uint'
+- name: eth_batchCall
+  summary: Executes a sequence of message calls building on eachother's state immediately without creating transactions on the block chain.
+  params:
+    - name: Arguments
+      required: true
+      schema:
+        $ref: '#/components/schemas/BatchCallArgs'
+  result:
+    name: Result of calls
+    schema:
+      $ref: '#/components/schemas/CallResults'

--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -1,5 +1,5 @@
-BatchCallArgs:
-  title: Arguments for batch call
+MulticallArgs:
+  title: Arguments for multi call
   type: object
   required:
     - block
@@ -103,7 +103,7 @@ BlockOverrides:
       title: Base fee
       $ref: '#/components/schemas/uint256'
 CallResults:
-  title: Results of batch call
+  title: Results of multi call
   type: array
   items:
     $ref: '#/components/schemas/CallResult'

--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -11,6 +11,9 @@ MulticallArgs:
     stateOverrides:
       title: State overrides
       $ref: '#/components/schemas/StateOverrides'
+    blockOverrides:
+      title: Overrides for block metadata
+      $ref: '#/components/schemas/BlockOverrides'
     calls:
       title: List of calls
       $ref: '#/components/schemas/Calls'
@@ -18,19 +21,7 @@ Calls:
   title: List of message calls
   type: array
   items:
-    $ref: '#/components/schemas/Call'
-Call:
-  title: Call + block overrides
-  type: object
-  required:
-    - transactionArgs
-  properties:
-    transactionArgs:
-      title: Call arguments
-      $ref: '#/components/schemas/GenericTransaction'
-    blockOverrides:
-      title: Overrides for block metadata
-      $ref: '#/components/schemas/BlockOverrides'
+    $ref: '#/components/schemas/GenericTransaction'
 StateOverrides:
   title: Accounts in state to be overridden
   type: object

--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -26,7 +26,7 @@ Call:
     - transactionArgs
   properties:
     transactionArgs:
-      title: Call args
+      title: Call arguments
       $ref: '#/components/schemas/GenericTransaction'
     blockOverrides:
       title: Overrides for block metadata

--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -108,5 +108,5 @@ CallResult:
       title: Return data
       $ref: '#/components/schemas/bytes'
     error:
-      title: Execution error
+      title: Errors arising during processing of request
       type: string

--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -108,5 +108,5 @@ CallResult:
       title: Return data
       $ref: '#/components/schemas/bytes'
     error:
-      title: Errors arising during processing of request
+      title: Execution error
       type: string

--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -1,0 +1,84 @@
+BatchCallArgs:
+  title: Arguments for batch call
+  type: object
+  required:
+    - block
+    - calls
+  properties:
+    block:
+      title: Block tag
+      $ref: '#/components/schemas/BlockNumberOrTag'
+    stateOverrides:
+      title: State overrides
+      $ref: '#/components/schemas/StateOverrides'
+    calls:
+      title: List of calls
+      $ref: '#/components/schemas/Calls'
+Calls:
+  title: List of message calls
+  type: array
+  items:
+    $ref: '#/components/schemas/GenericTransaction'
+StateOverrides:
+  title: Accounts in state to be overridden
+  type: object
+  additionalProperties:
+    $ref: '#/components/schemas/AccountOverride'
+AccountOverride:
+  title: Details of an account to be overridden
+  type: object
+  oneOf:
+    - $ref: '#/components/schemas/AccountOverrideState'
+    - $ref: '#/components/schemas/AccountOverrideStateDiff'
+AccountOverrideState:
+  title: Account override with whole storage replacement
+  properties:
+    nonce:
+      title: Nonce
+      $ref: '#/components/schemas/uint64'
+    balance:
+      title: Balance
+      $ref: '#/components/schemas/uint256'
+    code:
+      title: Code
+      $ref: '#/components/schemas/bytes'
+    state:
+      title: Storage
+      $ref: '#/components/schemas/AccountStorage'
+AccountOverrideStateDiff:
+  title: Account override with partial storage modification
+  properties:
+    nonce:
+      title: Nonce
+      $ref: '#/components/schemas/uint64'
+    balance:
+      title: Balance
+      $ref: '#/components/schemas/uint256'
+    code:
+      title: Code
+      $ref: '#/components/schemas/bytes'
+    stateDiff:
+      title: Storage difference
+      $ref: '#/components/schemas/AccountStorage'
+AccountStorage:
+  title: Storage slots for an account
+  type: object
+  additionalProperties:
+    - $ref: '#/components/schemas/bytes256'
+CallResults:
+  title: Results of batch call
+  type: array
+  items:
+    $ref: '#/components/schemas/CallResult'
+CallResult:
+  title: Result of a call
+  type: object
+  required:
+    - return
+  properties:
+    return:
+      title: Return data
+      $ref: '#/components/schemas/bytes'
+    error:
+      title: Execution error
+      type: string

--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -75,8 +75,8 @@ BlockOverrides:
     number:
       title: Number
       $ref: '#/components/schemas/uint256'
-    difficulty:
-      title: Difficulty
+    prevRandao:
+      title: Randomness beacon
       $ref: '#/components/schemas/uint256'
     time:
       title: Time

--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -18,7 +18,19 @@ Calls:
   title: List of message calls
   type: array
   items:
-    $ref: '#/components/schemas/GenericTransaction'
+    $ref: '#/components/schemas/Call'
+Call:
+  title: Call + block overrides
+  type: object
+  required:
+    - transactionArgs
+  properties:
+    transactionArgs:
+      title: Call args
+      $ref: '#/components/schemas/GenericTransaction'
+    blockOverrides:
+      title: Overrides for block metadata
+      $ref: '#/components/schemas/BlockOverrides'
 StateOverrides:
   title: Accounts in state to be overridden
   type: object
@@ -64,7 +76,32 @@ AccountStorage:
   title: Storage slots for an account
   type: object
   additionalProperties:
-    - $ref: '#/components/schemas/bytes256'
+    - $ref: '#/components/schemas/hash32'
+BlockOverrides:
+  title: Context fields related to the block being executed
+  type: object
+  properties:
+    number:
+      title: Number
+      $ref: '#/components/schemas/uint256'
+    difficulty:
+      title: Difficulty
+      $ref: '#/components/schemas/uint256'
+    time:
+      title: Time
+      $ref: '#/components/schemas/uint256'
+    gasLimit:
+      title: Gas limit
+      $ref: '#/components/schemas/uint64'
+    coinbase:
+      title: Coinbase
+      $ref: '#/components/schemas/address'
+    random:
+      title: Random
+      $ref: '#/components/schemas/hash32'
+    baseFee:
+      title: Base fee
+      $ref: '#/components/schemas/uint256'
 CallResults:
   title: Results of batch call
   type: array

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -42,3 +42,4 @@ ipc
 cli
 besu
 graphql
+prevRandao


### PR DESCRIPTION
### Summary

This PR adds a new method to the `eth` namespace which performs a sequence of call messages, each building on the previous call's state. It will use a given block tag as base state similar to `eth_call`. However this state can be overridden by providing a map of addresses to accounts.

### Motivation

https://github.com/ethereum/execution-apis/issues/267 already describes the motivation a bit. Further, this is a demanded feature in geth (see https://github.com/ethereum/go-ethereum/issues/24089).

### Rationale

1. This method takes in an args object as opposed to a list of params which is the convention. I did this to allow more forwards-compatibility. E.g. the `debug_traceCall` method in geth now supports state and block overrides which couldn't be added to `eth_call` as they'd be a breaking change (assuming there would be consensus to add these fields). See next 2 points for possible future additions.
2. Allowing state to be based on (block, tx_idx): I didn't add this for simplicity. IMO it's not strictly necessary as users can specify the block and pass in the txes in that block as is as part of the batch until their target `tx_idx` to get the same effect.
3. Allowing state overrides for every call: Similarly this would be a convenience feature IMO. As state override for a call can be simulated through a call message.

### Implementation

https://github.com/ethereum/go-ethereum/pull/25743

### Notes

The storage schema doesn't validate the fact that keys can be only 256bit since JSON supports only string keys for objects.

### Todos

- [x] block overrides
- [ ] tests

---

Alternative to #272