### PR TITLE
Add `engine_newPayloadSyncContextV1`

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -178,7 +178,7 @@ Values of a field of `QUANTITY` type **MUST** be encoded as a hexadecimal string
 
 ### ExecutionPayloadV1
 
-This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#ExecutionPayload) structure of the beacon chain spec. The fields are encoded as follows:
+This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#ExecutionPayload) structure of the Bellatrix beacon chain spec. The fields are encoded as follows:
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
@@ -211,6 +211,8 @@ The fields are encoded as follows:
 
 This structure has the syntax of `ExecutionPayloadV1` and appends a single field: `withdrawals`.
 
+This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#ExecutionPayload) structure of the Capella beacon chain spec, extending the `ExecutionPayloadV1` with the fields: `transactionsRoot`, `withdrawals`, and `withdrawalsRoot`. The fields are encoded as follows:
+
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
 - `stateRoot`: `DATA`, 32 Bytes
@@ -225,11 +227,13 @@ This structure has the syntax of `ExecutionPayloadV1` and appends a single field
 - `baseFeePerGas`: `QUANTITY`, 256 Bits
 - `blockHash`: `DATA`, 32 Bytes
 - `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
+- `transactionsRoot`: `DATA`, 32 Bytes - RLP hash (`transactions_hash` in beacon chain spec)
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
+- `withdrawalsRoot`: `DATA`, 32 Bytes - RLP hash (`withdrawals_hash` in beacon chain spec)
 
 ### ExecutionPayloadHeaderV1
 
-This structure maps on the [`ExecutionPayloadHeader`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#executionpayloadheader) structure of the Capella beacon chain spec. The fields are encoded as follows:
+This structure matches [`ExecutionPayloadV2`](#executionpayloadv2) but omits the `transactions` and `withdrawals` arrays. The fields are encoded as follows:
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
@@ -244,8 +248,8 @@ This structure maps on the [`ExecutionPayloadHeader`](https://github.com/ethereu
 - `extraData`: `DATA`, 0 to 32 Bytes
 - `baseFeePerGas`: `QUANTITY`, 256 Bits
 - `blockHash`: `DATA`, 32 Bytes
-- `transactionsRoot`: `DATA`, 32 Bytes - `hash_tree_root(transactions)`, not the keccak256 hash but instead the Consensus Layer [SSZ merkle root](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md)
-- `withdrawalsRoot`: `DATA`, 32 Bytes - `hash_tree_root(withdrawals)`, not the keccak256 hash but instead the Consensus Layer [SSZ merkle root](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md)
+- `transactionsRoot`: `DATA`, 32 Bytes - RLP hash (`transactions_hash` in beacon chain spec)
+- `withdrawalsRoot`: `DATA`, 32 Bytes - RLP hash (`withdrawals_hash` in beacon chain spec)
 
 ### ForkchoiceStateV1
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -548,10 +548,10 @@ Refer to the response for [`engine_newPayloadV2`](#engine_newpayloadv2).
 
 2. Execution Layer client software **MUST** respond to this method call in the following way:
   * `{status: SYNCING, latestValidHash: null, validationError: null}` if the request was processed
-  * With an error object in any error conditions unrelated to the normal processing flow of the method
+  * An error object in any error conditions unrelated to the normal processing flow of the method
 
 3. Consensus Layer client software **MUST NOT** use this endpoint for validator duties. Instead, the [`engine_newPayloadV2`](#engine_getpayloadv2) endpoint **MUST** be used to validate the full `ExecutionPayload` structure.
 
-4. Consensus layer client software **MAY** use this endpoint during an ongoing sync to inform Execution Layer client software about blocks far in the future (e.g., by running a [light client](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md) during [optimistic sync](https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md)). Execution Layer client software **SHOULD** consider interrupting the ongoing sync when requested to switch to the provided `blockHash` using `engine_forkchoiceUpdated`.
+4. Consensus Layer client software **MAY** use this endpoint during an ongoing sync to inform Execution Layer client software about blocks far in the future (e.g., by running a [light client](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md) during [optimistic sync](https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md)). Execution Layer client software **SHOULD** consider interrupting the ongoing sync when requested to switch to the provided `blockHash` using `engine_forkchoiceUpdated`.
 
 5. Client software **MAY** offer configuration options to limit the sync scope to use case dependent data (e.g., only sync data related to a certain wallet).

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -547,7 +547,8 @@ Refer to the response for [`engine_newPayloadV2`](#engine_newpayloadv2).
 1. Execution Layer client software **MAY** initiate a sync process if the described block is not locally available. Sync process is specified in the [Sync](#sync) section. Execution Layer client software **MUST** support syncing solely based on calls to this endpoint and `engine_forkchoiceUpdated`. Notably, syncing **MUST** be possible without `engine_newPayload` calls.
 
 2. Execution Layer client software **MUST** respond to this method call in the following way:
-  * `{status: SYNCING, latestValidHash: null, validationError: null}` in all cases.
+  * `{status: SYNCING, latestValidHash: null, validationError: null}` if the request was processed
+  * With an error object in any error conditions unrelated to the normal processing flow of the method
 
 3. Consensus Layer client software **MUST NOT** use this endpoint for validator duties. Instead, the [`engine_newPayloadV2`](#engine_getpayloadv2) endpoint **MUST** be used to validate the full `ExecutionPayload` structure.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -549,7 +549,7 @@ Refer to the response for [`engine_newPayloadV2`](#engine_newpayloadv2).
   * If the block referred to by the provided `blockHash` is not locally available, Execution Layer client software **MUST** respond to this method call with `{status: SYNCING, latestValidHash: null, validationError: null}`
   * If the provided data does not match the corresponding data from the locally available block with provided `blockHash`, Execution Layer client software **MUST** respond to this method call with `{status: INVALID_BLOCK_HASH, latestValidHash: null, validationError: errorMessage | null}`
 
-2. Execution Layer client **MUST** support syncing solely based on calls to this endpoint and `engine_forkchoiceUpdated`. Notably, syncing **MUST NOT** require `engine_newPayload` calls.
+2. Execution Layer client software **MUST** support syncing solely based on calls to this endpoint and `engine_forkchoiceUpdated`. Notably, syncing **MUST NOT** require `engine_newPayload` calls.
 
 3. Consensus Layer client software **MUST NOT** use this endpoint for validator duties. Instead, the [`engine_newPayloadV2`](#engine_getpayloadv2) endpoint **MUST** be used to validate the full `ExecutionPayload` structure.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -558,7 +558,7 @@ Refer to the response for [`engine_newPayloadV2`](#engine_newpayloadv2).
 
 #### Specification
 
-1. Execution Layer client software **MUST** handle calls to this endpoint the same as [`engine_newPayloadV2`](#engine_getpayloadv2) and provide compatible responses. When needed, Execution Layer client software **MUST** obtain the block's transactions autonomously.
+1. Execution Layer client software **MUST** handle calls to this endpoint the same as [`engine_newPayloadV2`](#engine_getpayloadv2) and provide compatible responses. When needed, Execution Layer client software **MUST** obtain the block's transactions and withdrawals autonomously.
 
 2. Consensus Layer client software **SHOULD NOT** use this endpoint for validator duties. Instead, the [`engine_newPayloadV2`](#engine_getpayloadv2) endpoint **SHOULD** be used to reduce sync latency and maximize validator rewards.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -181,7 +181,7 @@ Values of a field of `QUANTITY` type **MUST** be encoded as a hexadecimal string
 This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#ExecutionPayload) structure of the Bellatrix beacon chain spec. The fields are encoded as follows:
 
 - `parentHash`: `DATA`, 32 Bytes
-- `feeRecipient`:  `DATA`, 20 Bytes
+- `feeRecipient`: `DATA`, 20 Bytes
 - `stateRoot`: `DATA`, 32 Bytes
 - `receiptsRoot`: `DATA`, 32 Bytes
 - `logsBloom`: `DATA`, 256 Bytes
@@ -212,7 +212,7 @@ The fields are encoded as follows:
 This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#ExecutionPayload) structure of the Capella beacon chain spec, extending the [`ExecutionPayloadV1`](#executionpayloadv1) structure with the fields `transactionsRoot`, `withdrawals`, and `withdrawalsRoot`. The fields are encoded as follows:
 
 - `parentHash`: `DATA`, 32 Bytes
-- `feeRecipient`:  `DATA`, 20 Bytes
+- `feeRecipient`: `DATA`, 20 Bytes
 - `stateRoot`: `DATA`, 32 Bytes
 - `receiptsRoot`: `DATA`, 32 Bytes
 - `logsBloom`: `DATA`, 256 Bytes
@@ -234,7 +234,7 @@ This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/cons
 This structure matches [`ExecutionPayloadV2`](#executionpayloadv2) but omits the `transactions` and `withdrawals` arrays. The fields are encoded as follows:
 
 - `parentHash`: `DATA`, 32 Bytes
-- `feeRecipient`:  `DATA`, 20 Bytes
+- `feeRecipient`: `DATA`, 20 Bytes
 - `stateRoot`: `DATA`, 32 Bytes
 - `receiptsRoot`: `DATA`, 32 Bytes
 - `logsBloom`: `DATA`, 256 Bytes
@@ -246,8 +246,8 @@ This structure matches [`ExecutionPayloadV2`](#executionpayloadv2) but omits the
 - `extraData`: `DATA`, 0 to 32 Bytes
 - `baseFeePerGas`: `QUANTITY`, 256 Bits
 - `blockHash`: `DATA`, 32 Bytes
-- `transactionsRoot`: `DATA`, 32 Bytes - RLP hash (`transactions_hash` in beacon chain spec)
-- `withdrawalsRoot`: `DATA`, 32 Bytes - RLP hash (`withdrawals_hash` in beacon chain spec)
+- `transactionsRoot`: `DATA`, 32 Bytes - RLP hash; `transactions_hash` in beacon chain spec
+- `withdrawalsRoot`: `DATA`, 32 Bytes - RLP hash; `withdrawals_hash` in beacon chain spec
 
 ### ForkchoiceStateV1
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -225,9 +225,9 @@ This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/cons
 - `baseFeePerGas`: `QUANTITY`, 256 Bits
 - `blockHash`: `DATA`, 32 Bytes
 - `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
-- `transactionsRoot`: `DATA`, 32 Bytes - RLP hash; `transactions_hash` in beacon chain spec
-- `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
-- `withdrawalsRoot`: `DATA`, 32 Bytes - RLP hash; `withdrawals_hash` in beacon chain spec
+- `transactionsRoot`: `DATA|null`, 32 Bytes - RLP hash; `transactions_hash` in beacon chain spec
+- `withdrawals`: `Array of WithdrawalV1|null` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
+- `withdrawalsRoot`: `DATA|null`, 32 Bytes - RLP hash; `withdrawals_hash` in beacon chain spec
 
 ### ExecutionPayloadHeaderV1
 
@@ -392,10 +392,11 @@ Refer to the response for [`engine_newPayloadV1`](#engine_newpayloadv1).
 
 This method follows the same specification as [`engine_newPayloadV1`](#engine_newpayloadv1) with the exception of the following:
 
-1. If withdrawal functionality is activated, client software **MUST** return an `INVALID` status with the appropriate `latestValidHash` if `payload.withdrawals` is `null`.
-   Similarly, if the functionality is not activated, client software **MUST** return an `INVALID` status with the appropriate `latestValidHash` if `payloadAttributes.withdrawals` is not `null`.
-   Blocks without withdrawals **MUST** be expressed with an explicit empty list `[]` value.
+1. The fields `payload.transactionsRoot`, `payload.withdrawals`, and `payload.withdrawalsRoot` **MUST NOT** be `null` iff withdrawal functionality is activated.
+   Likewise, these fields **MUST** be `null` if withdrawal functionality is not activated.
+   Client software **MUST** return an `INVALID` status with the appropriate `latestValidHash` if fields are inappropriately specified/omitted.
    Refer to the validity conditions for [`engine_newPayloadV1`](#engine_newpayloadv1) to specification of the appropriate `latestValidHash` value.
+   Blocks without withdrawals **MUST** be expressed with an explicit empty list `[]` value.
 
 ### engine_forkchoiceUpdatedV1
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -553,8 +553,7 @@ Refer to the specification for [`engine_getPayloadV1`](#engine_getpayloadv1).
 
 #### Response
 
-* result: [`PayloadStatusV1`](#PayloadStatusV1)
-* error: code and message set in case an exception happens while processing the payload.
+Refer to the response for [`engine_newPayloadV2`](#engine_newpayloadv2).
 
 #### Specification
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -209,8 +209,6 @@ The fields are encoded as follows:
 
 ### ExecutionPayloadV2
 
-This structure has the syntax of `ExecutionPayloadV1` and appends a single field: `withdrawals`.
-
 This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#ExecutionPayload) structure of the Capella beacon chain spec, extending the `ExecutionPayloadV1` with the fields: `transactionsRoot`, `withdrawals`, and `withdrawalsRoot`. The fields are encoded as follows:
 
 - `parentHash`: `DATA`, 32 Bytes
@@ -227,9 +225,9 @@ This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/cons
 - `baseFeePerGas`: `QUANTITY`, 256 Bits
 - `blockHash`: `DATA`, 32 Bytes
 - `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
-- `transactionsRoot`: `DATA`, 32 Bytes - RLP hash (`transactions_hash` in beacon chain spec)
+- `transactionsRoot`: `DATA`, 32 Bytes - RLP hash; `transactions_hash` in beacon chain spec
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
-- `withdrawalsRoot`: `DATA`, 32 Bytes - RLP hash (`withdrawals_hash` in beacon chain spec)
+- `withdrawalsRoot`: `DATA`, 32 Bytes - RLP hash; `withdrawals_hash` in beacon chain spec
 
 ### ExecutionPayloadHeaderV1
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -544,12 +544,10 @@ Refer to the response for [`engine_newPayloadV2`](#engine_newpayloadv2).
 
 #### Specification
 
-1. Execution Layer client software **MUST** handle calls to this endpoint the same as if the corresponding full `ExecutionPayload` were passed to the `engine_newPayload` endpoint, with the exception of the following:
-  * `blockHash` validation is skipped
-  * If the block referred to by the provided `blockHash` is not locally available, Execution Layer client software **MUST** respond to this method call with `{status: SYNCING, latestValidHash: null, validationError: null}`
-  * If the provided data does not match the corresponding data from the locally available block with provided `blockHash`, Execution Layer client software **MUST** respond to this method call with `{status: INVALID_BLOCK_HASH, latestValidHash: null, validationError: errorMessage | null}`
+1. Execution Layer client software **MAY** initiate a sync process if the described block is not locally available. Sync process is specified in the [Sync](#sync) section. Execution Layer client software **MUST** support syncing solely based on calls to this endpoint and `engine_forkchoiceUpdated`. Notably, syncing **MUST** be possible without `engine_newPayload` calls.
 
-2. Execution Layer client software **MUST** support syncing solely based on calls to this endpoint and `engine_forkchoiceUpdated`. Notably, syncing **MUST NOT** require `engine_newPayload` calls.
+2. Execution Layer client software **MUST** respond to this method call in the following way:
+  * `{status: SYNCING, latestValidHash: null, validationError: null}` in all cases.
 
 3. Consensus Layer client software **MUST NOT** use this endpoint for validator duties. Instead, the [`engine_newPayloadV2`](#engine_getpayloadv2) endpoint **MUST** be used to validate the full `ExecutionPayload` structure.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -209,7 +209,7 @@ The fields are encoded as follows:
 
 ### ExecutionPayloadV2
 
-This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#ExecutionPayload) structure of the Capella beacon chain spec, extending the `ExecutionPayloadV1` with the fields: `transactionsRoot`, `withdrawals`, and `withdrawalsRoot`. The fields are encoded as follows:
+This structure maps on the [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#ExecutionPayload) structure of the Capella beacon chain spec, extending the [`ExecutionPayloadV1`](#executionpayloadv1) structure with the fields `transactionsRoot`, `withdrawals`, and `withdrawalsRoot`. The fields are encoded as follows:
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -8,10 +8,13 @@ endian
 enum
 eth
 ethereum
+executionpayloadheaderv
 interop
 json
+keccak
 mempool
 merkle
+newpayloadheaderv
 npm
 ommers
 openrpc

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -8,13 +8,10 @@ endian
 enum
 eth
 ethereum
-executionpayloadheaderv
 interop
 json
-keccak
 mempool
 merkle
-newpayloadheaderv
 npm
 ommers
 openrpc


### PR DESCRIPTION
While `engine_forkchoiceUpdatedV1` specifies that passing an unknown `headBlockHash` MAY trigger a sync, EL implementations practically require `engine_newPayloadV1` to be called as well.

This is prohibitive for applications where the CL is a light client that does not have the capabilities to obtain full beacon block data. To better support that scenario, a new endpoint is proposed to provide the EL client software with just the `ExecutionPayloadHeader`, therefore simplifying integration with existing sync logic.

Furthermore, this unlocks additional experiences:
1. A CL that is syncing optimistically after a prolonged outage can run CL light client sync to obtain the latest `ExecutionPayloadHeader`. This allows the EL to start syncing to a state close to wall time without having to wait for the CL optimistic sync to catch up.
2. EL light client implementations that wish to sync only data relevant to a certain use case (e.g., transactions for a specific wallet) can use the `ExecutionPayloadHeader` to decide what blocks are relevant. The new endpoint enables combined CL/EL deployments.