### PR TITLE
stop effectively requiring `engine_exchangeTransitionConfigurationV1`

### DIFF
--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -389,7 +389,7 @@ The payload build process is specified as follows:
 
 4. Consensus Layer client software **MAY** poll this endpoint every 60 seconds.
 
-5. Execution Layer client software **SHOULD NOT** surface an error to the user if it does not recieve a request on this endpoint at least once every 120 seconds.
+5. Execution Layer client software **MUST NOT** surface an error to the user if it does not recieve a request on this endpoint at least once every 120 seconds.
 
 6. Considering the absence of the `TERMINAL_BLOCK_NUMBER` setting, Consensus Layer client software **MAY** use `0` value for the `terminalBlockNumber` field in the input parameters of this call.
 

--- a/src/engine/specification.md
+++ b/src/engine/specification.md
@@ -387,9 +387,9 @@ The payload build process is specified as follows:
 
 3. Consensus Layer client software **SHOULD** surface an error to the user if local configuration settings mismatch corresponding values obtained from the response to the call of this method.
 
-4. Consensus Layer client software **SHOULD** poll this endpoint every 60 seconds.
+4. Consensus Layer client software **MAY** poll this endpoint every 60 seconds.
 
-5. Execution Layer client software **SHOULD** surface an error to the user if it does not recieve a request on this endpoint at least once every 120 seconds.
+5. Execution Layer client software **SHOULD NOT** surface an error to the user if it does not recieve a request on this endpoint at least once every 120 seconds.
 
 6. Considering the absence of the `TERMINAL_BLOCK_NUMBER` setting, Consensus Layer client software **MAY** use `0` value for the `terminalBlockNumber` field in the input parameters of this call.
 


### PR DESCRIPTION
`engine_exchangeTransitionConfigurationV1` is not necessary anymore, so compatibly begin de-emphasizing it. This approach allows a staging whereby it becomes more optional for both CLs and ELs, but that both CLs and ELs should converge to neither sending nor requiring `engine_exchangeTransitionConfigurationV1`.

A future PR, once this has progressed, can remove the requirement for ELs to process this message in any particular, way, but that currently creates compatibility challenges within the existing ecosystem.