### PR TITLE
Define eth_account

### DIFF
--- a/src/eth/state.yaml
+++ b/src/eth/state.yaml
@@ -84,3 +84,18 @@
     name: Account
     schema:
       $ref: '#/components/schemas/AccountProof'
+- name: eth_getAccount
+  summary: Returns the account at given address, or 'null' if the account does not exist in the state.
+  params:
+    - name: Address
+      required: true
+      schema:
+        $ref: '#/components/schemas/address'
+    - name: Block
+      required: false
+      schema:
+        $ref: '#/components/schemas/BlockNumberOrTag'
+  result:
+    name: Account
+    schema:
+      $ref: '#/components/schemas/Account'

--- a/src/eth/state.yaml
+++ b/src/eth/state.yaml
@@ -98,4 +98,8 @@
   result:
     name: Account
     schema:
-      $ref: '#/components/schemas/Account'
+      oneOf:
+        - $ref: '#/components/schemas/Account'
+        - name: Null
+          type: "null"
+

--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -63,7 +63,7 @@ Account:
     - nonce
     - codeHash
   properties:
-    root:
+    storageRoot:
       title: storage root
       $ref: '#/components/schemas/hash32'
     balance:

--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -58,7 +58,7 @@ Account:
   title: Account
   type: object
   required:
-    - root
+    - storageRoot
     - balance
     - nonce
     - codeHash

--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -54,3 +54,24 @@ StorageProof:
       type: array
       items:
         $ref: '#/components/schemas/bytes'
+Account:
+  title: Account
+  type: object
+  required:
+    - root
+    - balance
+    - nonce
+    - codeHash
+  properties:
+    root:
+      title: storage root
+      $ref: '#/components/schemas/hash32'
+    balance:
+      title: balance
+      $ref: '#/components/schemas/uint256'
+    codeHash:
+      title: codeHash
+      $ref: '#/components/schemas/hash32'
+    nonce:
+      title: nonce
+      $ref: '#/components/schemas/uint64'

--- a/tests/eth_getAccount/get-account.io
+++ b/tests/eth_getAccount/get-account.io
@@ -1,6 +1,6 @@
 >> {"jsonrpc":"2.0","id":9,"method":"eth_getAccount","params":["0x000000000000000000000000000000000000dead","latest"]}
 << {"jsonrpc":"2.0","id":9,"result": null}
 >> {"jsonrpc":"2.0","id":10,"method":"eth_getAccount","params":["0xaa00000000000000000000000000000000000000","latest"]}
-<< {"jsonrpc":"2.0","id":10,"result": { "codeHash": "0xce92c756baff35fa740c3557c1a971fd24d2d35b7c8e067880d50cd86bb0bc99", "root": "0x8afc95b7d18a226944b9c2070b6bda1c3a36afcc3730429d47579c94b9fe5850", "balance": "0x1", "nonce": "0x1"}}
+<< {"jsonrpc":"2.0","id":10,"result": { "codeHash": "0xce92c756baff35fa740c3557c1a971fd24d2d35b7c8e067880d50cd86bb0bc99", "storageRoot": "0x8afc95b7d18a226944b9c2070b6bda1c3a36afcc3730429d47579c94b9fe5850", "balance": "0x1", "nonce": "0x1"}}
 >> {"jsonrpc":"2.0","id":11,"method":"eth_getAccount","params":["0xaa00000000000000000000000000000000000000","0xffff"]}
 << {"jsonrpc":"2.0","id":11,"error":{"code":-32000,"message":"header not found"}}

--- a/tests/eth_getAccount/get-account.io
+++ b/tests/eth_getAccount/get-account.io
@@ -1,0 +1,6 @@
+>> {"jsonrpc":"2.0","id":9,"method":"eth_getAccount","params":["0x000000000000000000000000000000000000dead","latest"]}
+<< {"jsonrpc":"2.0","id":9,"result": null}
+>> {"jsonrpc":"2.0","id":10,"method":"eth_getAccount","params":["0xaa00000000000000000000000000000000000000","latest"]}
+<< {"jsonrpc":"2.0","id":10,"result": { "codeHash": "0xce92c756baff35fa740c3557c1a971fd24d2d35b7c8e067880d50cd86bb0bc99", "root": "0x8afc95b7d18a226944b9c2070b6bda1c3a36afcc3730429d47579c94b9fe5850", "balance": "0x1", "nonce": "0x1"}}
+>> {"jsonrpc":"2.0","id":11,"method":"eth_getAccount","params":["0xaa00000000000000000000000000000000000000","0xffff"]}
+<< {"jsonrpc":"2.0","id":11,"error":{"code":-32000,"message":"header not found"}}


### PR DESCRIPTION
This PR adds a new method to the `eth` namespace: `eth_getAccount`. 
The new method returns either

- The account, if it exists in the state trie, or
- `null` if the account does not exist in the state trie at the given block/state root. 

The definition of `account` is the trie-leaf-definition: `balance`, `nonce`, ~~`root`~~ `storageRoot` (storage root), and `codeHash`. It does _not_ contain `address`, since that is not necessarily available in a node which has the state but not out-of-state metadata (such as preimages). 

~~Consideration: maybe `root` should be renamed `storageRoot` for clarity.~~ Doone

Original discussion
https://github.com/ethereum/go-ethereum/pull/26231#issuecomment-1326330515