### PR TITLE
add eth_subscribe and eth_unsubscribe

### DIFF
--- a/src/eth/subscribe.yaml
+++ b/src/eth/subscribe.yaml
@@ -1,0 +1,22 @@
+- name: eth_subscribe
+  summary: Subscribe to specific events. The node will return a subscription id. For each event that matches the subscription a notification with relevant data is send together with the subscription id.
+  params:
+    - name: Subscription
+      required: true
+      schema:
+        $ref: '#/components/schemas/SupportedSubscriptions'
+  result:
+    name: Subscription ID
+    schema:
+      $ref: '#/components/schemas/uint256'
+- name: eth_unsubscribe
+  summary: Cancel a subscription for specific events. It returns a boolean indicating if the subscription was cancelled successfully.
+  params:
+    - name: Subscription ID
+      required: true
+      schema:
+        $ref: '#/components/schemas/bytes'
+  result:
+    name: Cancellation status
+    schema:
+      type: boolean

--- a/src/schemas/subscribe.yaml
+++ b/src/schemas/subscribe.yaml
@@ -1,0 +1,44 @@
+LogSubscription:
+  type: array
+  description: Notify about logs that are included in new imported blocks and match the given filter criteria
+  prefixItems:
+    - type: string
+      const: logs
+    - type: object
+      properties:
+        address:
+          description: Either an address or an array of addresses. Only logs that are created from these addresses are returned
+          oneOf:
+            - $ref: '#/components/schemas/address'
+            - $ref: '#/components/schemas/addresses'
+        topics:
+          title: topics
+          type: array
+          items:
+            $ref: '#/components/schemas/bytes32'
+      additionalProperties: false
+
+PendingTxnSubscription:
+  type: array
+  description: Notify about pending transactions added to the transaction pool
+  prefixItems:
+    - type: string
+      const: newPendingTransactions
+    - type: object
+      properties:
+        includeTransactions:
+          description: Setting this to true ensures that the raw transaction data is included
+          type: boolean
+      additionalProperties: false
+
+SupportedSubscriptions:
+  title: Supported Subscriptions
+  oneOf:
+    - const: newHeads
+      description: Notify each time a new header is appended to the chain, including chain reorganizations
+    - const: syncing
+      description: Notify about synchronization progress
+    - title: Log Subscription
+      $ref: '#/components/schemas/LogSubscription'
+    - title: Pending Transactions Subscription
+      $ref: '#/components/schemas/PendingTxnSubscription'


### PR DESCRIPTION
This is implemented and supported by the most execution clients. For example:
- [Geth](https://geth.ethereum.org/docs/rpc/pubsub)
- [Nethermind](https://docs.nethermind.io/nethermind/ethereum-client/json-rpc/subscribe#eth_subscribe)

I could not find the EIP or other document where this was discussed. 