### PR TITLE
Engine API: a bunch of cleanups

### DIFF
--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -79,10 +79,13 @@ This structure has the syntax of `PayloadAttributesV1` and appends a single fiel
 * method: `engine_newPayloadV2`
 * params:
   1. [`ExecutionPayloadV2`](#ExecutionPayloadV2)
+* timeout: 8s
 
 #### Response
 
-Refer to the response for [`engine_newPayloadV1`](./paris.md#engine_newpayloadv1).
+* result: [`PayloadStatusV1`](./paris.md#payloadstatusv1), values of the `status` field are restricted in the following way:
+  - `INVALID_BLOCK_HASH` status value is supplanted by `INVALID`.
+* error: code and message set in case an exception happens while processing the payload.
 
 #### Specification
 
@@ -92,6 +95,8 @@ This method follows the same specification as [`engine_newPayloadV1`](./paris.md
    Similarly, if the functionality is not activated, client software **MUST** return an `INVALID` status with the appropriate `latestValidHash` if `payloadAttributes.withdrawals` is not `null`.
    Blocks without withdrawals **MUST** be expressed with an explicit empty list `[]` value.
    Refer to the validity conditions for [`engine_newPayloadV1`](./paris.md#engine_newpayloadv1) to specification of the appropriate `latestValidHash` value.
+2. Client software **MAY NOT** validate terminal PoW block conditions during payload validation (point (2) in the [Payload validation](./paris.md#payload-validation) routine).
+3. Client software **MUST** return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the `blockHash` validation has failed.
 
 ### engine_forkchoiceUpdatedV2
 
@@ -101,6 +106,7 @@ This method follows the same specification as [`engine_newPayloadV1`](./paris.md
 * params:
   1. `forkchoiceState`: `Object` - instance of [`ForkchoiceStateV1`](./paris.md#ForkchoiceStateV1)
   2. `payloadAttributes`: `Object|null` - instance of [`PayloadAttributesV2`](#PayloadAttributesV2) or `null`
+* timeout: 8s
 
 #### Response
 
@@ -113,6 +119,9 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV1`](./p
 1. If withdrawal functionality is activated, client software **MUST** return error `-38003: Invalid payload attributes` if `payloadAttributes.withdrawals` is `null`.
    Similarly, if the functionality is not activated, client software **MUST** return error `-38003: Invalid payload attributes` if `payloadAttributes.withdrawals` is not `null`.
    Blocks without withdrawals **MUST** be expressed with an explicit empty list `[]` value.
+2. Client software **MAY NOT** validate terminal PoW block conditions in the following places:
+  - during payload validation (point (2) in the [Payload validation](./paris.md#payload-validation) routine specification),
+  - when updating the forkchoice state (point (3) in the [`engine_forkchoiceUpdatedV1`](./paris.md#engine_forkchoiceupdatedv1) method specification).
 
 ### engine_getPayloadV2
 
@@ -121,6 +130,7 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV1`](./p
 * method: `engine_getPayloadV2`
 * params:
   1. `payloadId`: `DATA`, 8 Bytes - Identifier of the payload build process
+* timeout: 1s
 
 #### Response
 


### PR DESCRIPTION
This PR proposes the following cleanups to the Shanghai part of the spec:
* Sets timeouts whenever missed
* Makes validation of terminal PoW block conditions optional, so, client devs may remove it if they want
* Requires EL clients to stop using `INVALID_BLOCK_HASH` status and supplant it with `INVALID`, see https://github.com/ethereum/execution-apis/issues/270 for details (should be a one liner, if not let's debate)

If EL client implementations use the same piece of code for both `V1` and `V2` the latter two changes may become a problem as they seem to be backwards incompatible with `V1`. Though, practically it isn't that true as the transition has happened quite long time ago and having no TTD validation should not break anything except for Hive tests (though we should probably remove transition tests from Hive). All CL clients handle `status: INVALID, latestValidHash: null` in the same way as `status: INVALID_BLOCK_HASH, latestValidHash: null`, replacing the latter with the former must not change anything.