### PR TITLE
Engine API: deprecate exchangeTransitionConfiguration

### DIFF
--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -250,6 +250,8 @@ The payload build process is specified as follows:
 
 ### engine_exchangeTransitionConfigurationV1
 
+This method is **DEPRECATED**.
+
 #### Request
 
 * method: `engine_exchangeTransitionConfigurationV1`


### PR DESCRIPTION
An alternative to https://github.com/ethereum/execution-apis/pull/320. This PR deprecates `engine_exchangeTransitionConfiguration` by marking the method as deprecated rather than making a change into its specification.

There are two ways to deprecate the call on Mainnet:
1. As a part of Capella/Shanghai deployment process. Shanghai compliant EL clients don't expect this call to be made (may be entirely removed) and Capella compliant CL clients stop making this call. There could be a hiccup in this process when a user upgrades one layer but leave the other one not upgraded yet and start seeing worrisome messages in logs.
2. In an uncoordinated fashion. CL keeps calling this method but adds a check that this method does exist, and if EL responds with this method doesn't exist message CL doesn't make any noise in logs. This allows for EL to remove the method support, and once every EL client removes it then CL is free to do the same.

The first option looks simpler to me but I am fine either way.