### PR TITLE
Update of Spellcheck GitHub Action to version 0.29.0

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -7,5 +7,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.20.0
+    - uses: rojopolis/spellcheck-github-actions@0.29.0
       name: Spellcheck


### PR DESCRIPTION
Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am _sunsetting_ version 0.20.0 as by [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I have just released version 0.29.0, so this PR offers an update to the latest version.

Let me know if you have any issues with the proposed PR and I will try to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, alternatively there are [Renovate](https://github.com/marketplace/renovate), if you want a PR proposing a basic configuration for Dependabot, please let me know.

Happy new year

jonasbn
