### PR TITLE
Engine API: make engine_getPayloadVN fork agnostic

### DIFF
--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -92,7 +92,10 @@ Refer to the response for `engine_newPayloadV2`.
 #### Response
 
 * result: `object`
-  - `executionPayload`: [`ExecutionPayloadV3`](#ExecutionPayloadV3)
+  - `executionPayload`: [`ExecutionPayloadV1`](#../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](#../shanghai.md#ExecutionPayloadV2) |  [`ExecutionPayloadV3`](#ExecutionPayloadV3) where:
+    - `ExecutionPayloadV1` **MUST** be returned if the payload `timestamp` is lower than the Shanghai timestamp
+    - `ExecutionPayloadV2` **MUST** be returned if the payload `timestamp` is greater or equal to the Shanghai timestamp and lower than the EIP-4844 activation timestamp
+    - `ExecutionPayloadV3` **MUST** be returned if the payload `timestamp` is greater or equal to the EIP-4844 activation timestamp
   - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei
 * error: code and message set in case an exception happens while getting the payload.
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -92,7 +92,7 @@ Refer to the response for `engine_newPayloadV2`.
 #### Response
 
 * result: `object`
-  - `executionPayload`: [`ExecutionPayloadV1`](#../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](#../shanghai.md#ExecutionPayloadV2) |  [`ExecutionPayloadV3`](#ExecutionPayloadV3) where:
+  - `executionPayload`: [`ExecutionPayloadV1`](../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](../shanghai.md#ExecutionPayloadV2) |  [`ExecutionPayloadV3`](#ExecutionPayloadV3) where:
     - `ExecutionPayloadV1` **MUST** be returned if the payload `timestamp` is lower than the Shanghai timestamp
     - `ExecutionPayloadV2` **MUST** be returned if the payload `timestamp` is greater or equal to the Shanghai timestamp and lower than the EIP-4844 activation timestamp
     - `ExecutionPayloadV3` **MUST** be returned if the payload `timestamp` is greater or equal to the EIP-4844 activation timestamp

--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -134,7 +134,7 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV1`](./p
 #### Response
 
 * result: `object`
-  - `executionPayload`: [`ExecutionPayloadV1`](#./paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](#ExecutionPayloadV2) where:
+  - `executionPayload`: [`ExecutionPayloadV1`](./paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](#ExecutionPayloadV2) where:
       - `ExecutionPayloadV1` **MUST** be returned if the payload `timestamp` is lower than the Shanghai timestamp
       - `ExecutionPayloadV2` **MUST** be returned if the payload `timestamp` is greater or equal to the Shanghai timestamp
   - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei

--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -134,7 +134,9 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV1`](./p
 #### Response
 
 * result: `object`
-  - `executionPayload`: [`ExecutionPayloadV2`](#ExecutionPayloadV2)
+  - `executionPayload`: [`ExecutionPayloadV1`](#./paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](#ExecutionPayloadV2) where:
+      - `ExecutionPayloadV1` **MUST** be returned if the payload `timestamp` is lower than the Shanghai timestamp
+      - `ExecutionPayloadV2` **MUST** be returned if the payload `timestamp` is greater or equal to the Shanghai timestamp
   - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei
 * error: code and message set in case an exception happens while getting the payload.
 


### PR DESCRIPTION
This is how the spec is implied to work and how it already does work on many clients but it needs to be made explicit. Later versions of methods replace earlier versions and must return the appropriate object depending on the fork.