### PR TITLE
Changed storage proof array title to be plural

### DIFF
--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -31,7 +31,7 @@ AccountProof:
       title: storageHash
       $ref: '#/components/schemas/hash32'
     storageProof:
-      title: storageProof
+      title: Storage proofs
       type: array
       items:
         $ref: '#/components/schemas/StorageProof'


### PR DESCRIPTION
Changed title of storage proof array to be plural. It was a bit confusing them being essentially the same name when one is an array.