### PR TITLE
Fixed duplicate schemas/titles

### DIFF
--- a/src/eth/execute.yaml
+++ b/src/eth/execute.yaml
@@ -27,7 +27,7 @@
   result:
     name: Gas used
     schema:
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasUsed'
 - name: eth_createAccessList
   summary: Generates an access list for a transaction.
   params:
@@ -52,5 +52,4 @@
           title: "error"
           type: string
         gasUsed:
-          title: Gas used
-          $ref: '#/components/schemas/uint'
+          $ref: '#/components/schemas/GasUsed'

--- a/src/eth/fee_market.yaml
+++ b/src/eth/fee_market.yaml
@@ -4,16 +4,14 @@
   result:
     name: Gas price
     schema:
-      title: Gas price
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasPrice'
 - name: eth_maxPriorityFeePerGas
   summary: Returns the current maxPriorityFeePerGas per gas in wei.
   params: []
   result:
     name: Max priority fee per gas
     schema:
-      title: Max priority fee per gas
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/MaxPriorityFeePerGas'
 - name: eth_feeHistory
   summary: Transaction fee history
   description: Returns transaction base fee per gas and effective priority fee per gas for the requested/supported block range.

--- a/src/eth/mining.yaml
+++ b/src/eth/mining.yaml
@@ -26,8 +26,7 @@
           $ref: '#/components/schemas/bytes32'
         - title: seed hash
           $ref: '#/components/schemas/bytes32'
-        - title: difficulty
-          $ref: '#/components/schemas/bytes32'
+        - $ref: '#/components/schemas/Difficulty'
 - name: eth_submitWork
   summary: Used for submitting a proof-of-work solution.
   params:

--- a/src/schemas/block.yaml
+++ b/src/schemas/block.yaml
@@ -30,8 +30,7 @@ Block:
       title: Coinbase
       $ref: '#/components/schemas/address'
     stateRoot:
-      title: State root
-      $ref: '#/components/schemas/hash32'
+      $ref: '#/components/schemas/StateRoot'
     transactionsRoot:
       title: Transactions root
       $ref: '#/components/schemas/hash32'
@@ -42,17 +41,14 @@ Block:
       title: Bloom filter
       $ref: '#/components/schemas/bytes256'
     difficulty:
-      title: Difficulty
-      $ref: '#/components/schemas/bytes'
+      $ref: '#/components/schemas/Difficulty'
     number:
       title: Number
       $ref: '#/components/schemas/uint'
     gasLimit:
-      title: Gas limit
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasLimit'
     gasUsed:
-      title: Gas used
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasUsed'
     timestamp:
       title: Timestamp
       $ref: '#/components/schemas/uint'
@@ -63,10 +59,9 @@ Block:
       title: Mix hash
       $ref: '#/components/schemas/hash32'
     nonce:
-      title: Nonce
-      $ref: '#/components/schemas/bytes8'
+      $ref: '#/components/schemas/Nonce'
     totalDifficulty:
-      title: Total difficult
+      title: Total difficulty
       $ref: '#/components/schemas/uint'
     baseFeePerGas:
       title: Base fee per gas
@@ -102,17 +97,13 @@ BlockTag:
 BlockNumberOrTag:
   title: Block number or tag
   oneOf:
-    - title: Block number
-      $ref: '#/components/schemas/uint'
-    - title: Block tag
-      $ref: '#/components/schemas/BlockTag'
+    - $ref: '#/components/schemas/BlockNumber'
+    - $ref: '#/components/schemas/BlockTag'
 BlockNumberOrTagOrHash:
   title: Block number, tag, or block hash
   anyOf:
-    - title: Block number
-      $ref: '#/components/schemas/uint'
-    - title: Block tag
-      $ref: '#/components/schemas/BlockTag'
+    - $ref: '#/components/schemas/BlockNumber'
+    - $ref: '#/components/schemas/BlockTag'
     - title: Block hash
       $ref: '#/components/schemas/hash32'
 BadBlock:
@@ -132,3 +123,13 @@ BadBlock:
     rlp:
       title: RLP
       $ref: '#/components/schemas/bytes'
+Difficulty:
+  title: Difficulty
+  $ref: '#/components/schemas/bytes'
+GasUsed:
+  title: Gas used
+  description: The amount of gas used for this specific transaction alone.
+  $ref: '#/components/schemas/uint'
+StateRoot:
+  title: State root
+  $ref: '#/components/schemas/hash32'

--- a/src/schemas/filter.yaml
+++ b/src/schemas/filter.yaml
@@ -26,12 +26,9 @@ Filter:
     address:
       title: Address(es)
       oneOf:
-        - title: Address
-          $ref: '#/components/schemas/address'
-        - title: Addresses
-          $ref: '#/components/schemas/addresses'
+        - $ref: '#/components/schemas/address'
+        - $ref: '#/components/schemas/addresses'
     topics:
-      title: Topics
       $ref: '#/components/schemas/FilterTopics'
 FilterTopics:
   title: Filter Topics

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -17,11 +17,9 @@ Log:
       title: transaction hash
       $ref: '#/components/schemas/hash32'
     blockHash:
-      title: block hash
-      $ref: '#/components/schemas/hash32'
+      $ref: '#/components/schemas/BlockHash'
     blockNumber:
-      title: block number
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/BlockNumber'
     address:
       title: address
       $ref: '#/components/schemas/address'
@@ -33,6 +31,11 @@ Log:
       type: array
       items:
         $ref: '#/components/schemas/bytes32'
+BlockNumber:
+  title: block number
+  $ref: '#/components/schemas/uint'
+BlockHash:
+  $ref: '#/components/schemas/hash32'
 ReceiptInfo:
   type: object
   title: Receipt info
@@ -55,11 +58,9 @@ ReceiptInfo:
       title: transaction index
       $ref: '#/components/schemas/uint'
     blockHash:
-      title: block hash
-      $ref: '#/components/schemas/hash32'
+      $ref: '#/components/schemas/BlockHash'
     blockNumber:
-      title: block number
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/BlockNumber'
     from:
       title: from
       $ref: '#/components/schemas/address'
@@ -72,9 +73,7 @@ ReceiptInfo:
       description: The sum of gas used by this transaction and all preceding transactions in the same block.
       $ref: '#/components/schemas/uint'
     gasUsed:
-      title: gas used
-      description: The amount of gas used for this specific transaction alone.
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasUsed'
     contractAddress:
       title: contract address
       description: The contract address created, if the transaction was a contract creation, otherwise null.
@@ -91,9 +90,7 @@ ReceiptInfo:
       title: logs bloom
       $ref: '#/components/schemas/bytes256'
     root:
-      title: state root
-      description: The post-transaction state root. Only specified for transactions included before the Byzantium upgrade.
-      $ref: '#/components/schemas/hash32'
+      $ref: '#/components/schemas/StateRoot'
     status:
       title: status
       description: Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade.

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -21,7 +21,6 @@ Log:
     blockNumber:
       $ref: '#/components/schemas/BlockNumber'
     address:
-      title: address
       $ref: '#/components/schemas/address'
     data:
       title: data

--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -24,8 +24,7 @@ AccountProof:
       title: codeHash
       $ref: '#/components/schemas/hash32'
     nonce:
-      title: nonce
-      $ref: '#/components/schemas/uint64'
+      $ref: '#/components/schemas/Nonce'
     storageHash:
       title: storageHash
       $ref: '#/components/schemas/hash32'

--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -11,7 +11,6 @@ AccountProof:
     - storageProof
   properties:
     address:
-      title: address
       $ref: '#/components/schemas/address'
     accountProof:
       title: Account proofs

--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -14,7 +14,7 @@ AccountProof:
       title: address
       $ref: '#/components/schemas/address'
     accountProof:
-      title: accountProof
+      title: Account proofs
       type: array
       items:
         $ref: '#/components/schemas/bytes'

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -281,5 +281,5 @@ GenericTransaction:
 Nonce:
   title: nonce
   description: Only Used Once
-  $ref: '#/components/schemas/bytes8'
+  $ref: '#/components/schemas/uint64'
 

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -31,14 +31,12 @@ Transaction1559Unsigned:
       title: type
       $ref: '#/components/schemas/byte'
     nonce:
-      title: nonce
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/Nonce'
     to:
       title: to address
       $ref: '#/components/schemas/address'
     gas:
-      title: gas limit
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasLimit'
     value:
       title: value
       $ref: '#/components/schemas/uint'
@@ -46,9 +44,7 @@ Transaction1559Unsigned:
       title: input data
       $ref: '#/components/schemas/bytes'
     maxPriorityFeePerGas:
-      title: max priority fee per gas
-      description: Maximum fee per gas the sender is willing to pay to miners in wei
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/MaxPriorityFeePerGas'
     maxFeePerGas:
       title: max fee per gas
       description: The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei
@@ -61,6 +57,18 @@ Transaction1559Unsigned:
       title: chainId
       description: Chain ID that this transaction is valid on.
       $ref: '#/components/schemas/uint'
+GasLimit:
+  title: gas limit
+  $ref: '#/components/schemas/uint'
+GasPrice:
+  title: gas price
+  description: The gas price willing to be paid by the sender in wei
+  $ref: '#/components/schemas/uint'
+MaxPriorityFeePerGas:
+  title: max priority fee per gas
+  description: Maximum fee per gas the sender is willing to pay to miners in wei
+  $ref: '#/components/schemas/uint'
+
 Transaction2930Unsigned:
   type: object
   title: EIP-2930 transaction.
@@ -78,14 +86,12 @@ Transaction2930Unsigned:
       title: type
       $ref: '#/components/schemas/byte'
     nonce:
-      title: nonce
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/Nonce'
     to:
       title: to address
       $ref: '#/components/schemas/address'
     gas:
-      title: gas limit
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasLimit'
     value:
       title: value
       $ref: '#/components/schemas/uint'
@@ -93,9 +99,7 @@ Transaction2930Unsigned:
       title: input data
       $ref: '#/components/schemas/bytes'
     gasPrice:
-      title: gas price
-      description: The gas price willing to be paid by the sender in wei
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasPrice'
     accessList:
       title: accessList
       description: EIP-2930 access list
@@ -119,14 +123,12 @@ TransactionLegacyUnsigned:
       title: type
       $ref: '#/components/schemas/byte'
     nonce:
-      title: nonce
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/Nonce'
     to:
       title: to address
       $ref: '#/components/schemas/address'
     gas:
-      title: gas limit
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasLimit'
     value:
       title: value
       $ref: '#/components/schemas/uint'
@@ -134,9 +136,7 @@ TransactionLegacyUnsigned:
       title: input data
       $ref: '#/components/schemas/bytes'
     gasPrice:
-      title: gas price
-      description: The gas price willing to be paid by the sender in wei
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasPrice'
     chainId:
       title: chainId
       description: Chain ID that this transaction is valid on.
@@ -226,11 +226,9 @@ TransactionInfo:
         - transactionIndex
       properties:
         blockHash:
-          title: block hash
-          $ref: '#/components/schemas/hash32'
+          $ref: '#/components/schemas/BlockHash'
         blockNumber:
-          title: block number
-          $ref: '#/components/schemas/uint'
+          $ref: '#/components/schemas/BlockNumber'
         from:
           title: from address
           $ref: '#/components/schemas/address'
@@ -249,8 +247,7 @@ GenericTransaction:
       title: type
       $ref: '#/components/schemas/byte'
     nonce:
-      title: nonce
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/Nonce'
     to:
       title: to address
       $ref: '#/components/schemas/address'
@@ -258,8 +255,7 @@ GenericTransaction:
       title: from address
       $ref: '#/components/schemas/address'
     gas:
-      title: gas limit
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasLimit'
     value:
       title: value
       $ref: '#/components/schemas/uint'
@@ -267,13 +263,9 @@ GenericTransaction:
       title: input data
       $ref: '#/components/schemas/bytes'
     gasPrice:
-      title: gas price
-      description: The gas price willing to be paid by the sender in wei
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/GasPrice'
     maxPriorityFeePerGas:
-      title: max priority fee per gas
-      description: Maximum fee per gas the sender is willing to pay to miners in wei
-      $ref: '#/components/schemas/uint'
+      $ref: '#/components/schemas/MaxPriorityFeePerGas'
     maxFeePerGas:
       title: max fee per gas
       description: The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei
@@ -286,4 +278,8 @@ GenericTransaction:
       title: chainId
       description: Chain ID that this transaction is valid on.
       $ref: '#/components/schemas/uint'
+Nonce:
+  title: nonce
+  title: Only Used Once
+  $ref: '#/components/schemas/uint'
 

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -281,5 +281,5 @@ GenericTransaction:
 Nonce:
   title: nonce
   description: Only Used Once
-  $ref: '#/components/schemas/uint'
+  $ref: '#/components/schemas/bytes8'
 

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -280,6 +280,6 @@ GenericTransaction:
       $ref: '#/components/schemas/uint'
 Nonce:
   title: nonce
-  title: Only Used Once
+  description: Only Used Once
   $ref: '#/components/schemas/uint'
 


### PR DESCRIPTION
this pulls out some schemas that have dupe titles to be their own reusable schemas.

one thing to note is that with `nonce` one of them had `bytes8`, I just made them all `uint64`.