### PR TITLE
EIP4844: Use `BYTES_PER_FIELD_ELEMENT`

### DIFF
--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -56,7 +56,7 @@ The fields are encoded as follows:
 
 - `blockHash`: `DATA`, 32 Bytes
 - `kzgs`: `Array of DATA` - Array of `KZGCommitment` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), 48 bytes each (`DATA`).
-- `blobs`: `Array of DATA` - Array of blobs, each blob is `FIELD_ELEMENTS_PER_BLOB * size_of(BLSFieldElement) = 4096 * 32 = 131072` bytes (`DATA`) representing a SSZ-encoded `Blob` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
+- `blobs`: `Array of DATA` - Array of blobs, each blob is `FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT = 4096 * 32 = 131072` bytes (`DATA`) representing a SSZ-encoded `Blob` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
 
 ## Methods
 


### PR DESCRIPTION
Use `BYTES_PER_FIELD_ELEMENT` instead of `size_of(BLSFieldElement)` as defined in: https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md#constants. I think the formal is more idiomatic?  