### PR TITLE
Syncing EL client may not serve block bodies

### DIFF
--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -187,6 +187,8 @@ This method follows the same specification as [`engine_getPayloadV1`](./paris.md
 
 1. This request maps to [`BeaconBlocksByRoot`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beaconblocksbyroot) in the consensus layer `p2p` specification. Callers must be careful to use the execution block hash, instead of the beacon block root.
 
+1. Callers must consider that syncing Execution Layer client may not serve any block bodies, including those that were supplied by `engine_newPayload` calls.
+
 ### engine_getPayloadBodiesByRangeV1
 
 #### Request
@@ -223,3 +225,5 @@ This method follows the same specification as [`engine_getPayloadV1`](./paris.md
 1. Callers must be careful to not confuse `start` with a slot number, instead mapping the slot to a block number. Callers must also be careful to request non-finalized blocks by hash in order to avoid race conditions around the current view of the canonical chain.
 
 1. Callers must be careful to verify the hash of the received blocks when requesting non-finalized parts of the chain since the response is prone to being re-orged.
+
+1. Callers must consider that syncing Execution Layer client may not serve any block bodies, including those that were supplied by `engine_newPayload` calls.

--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -187,7 +187,7 @@ This method follows the same specification as [`engine_getPayloadV1`](./paris.md
 
 1. This request maps to [`BeaconBlocksByRoot`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beaconblocksbyroot) in the consensus layer `p2p` specification. Callers must be careful to use the execution block hash, instead of the beacon block root.
 
-1. Callers must consider that syncing Execution Layer client may not serve any block bodies, including those that were supplied by `engine_newPayload` calls.
+1. Callers must consider that syncing execution layer client may not serve any block bodies, including those that were supplied by `engine_newPayload` calls.
 
 ### engine_getPayloadBodiesByRangeV1
 
@@ -226,4 +226,4 @@ This method follows the same specification as [`engine_getPayloadV1`](./paris.md
 
 1. Callers must be careful to verify the hash of the received blocks when requesting non-finalized parts of the chain since the response is prone to being re-orged.
 
-1. Callers must consider that syncing Execution Layer client may not serve any block bodies, including those that were supplied by `engine_newPayload` calls.
+1. Callers must consider that syncing execution layer client may not serve any block bodies, including those that were supplied by `engine_newPayload` calls.


### PR DESCRIPTION
Notes that syncing EL may not serve any block bodies even for blocks recently submitted via Engine API