### PR TITLE
EIP4844: move excess data gas field to align with consensus spec

### DIFF
--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -50,7 +50,6 @@ This structure has the syntax of `ExecutionPayloadV2` and appends a single field
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
 - `excessDataGas`: `QUANTITY`, 256 bits
 
-
 ### BlobsBundleV1
 
 The fields are encoded as follows:

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -45,10 +45,11 @@ This structure has the syntax of `ExecutionPayloadV2` and appends a single field
 - `timestamp`: `QUANTITY`, 64 Bits
 - `extraData`: `DATA`, 0 to 32 Bytes
 - `baseFeePerGas`: `QUANTITY`, 256 Bits
-- `excessDataGas`: `QUANTITY`, 256 bits
 - `blockHash`: `DATA`, 32 Bytes
 - `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
+- `excessDataGas`: `QUANTITY`, 256 bits
+
 
 ### BlobsBundleV1
 


### PR DESCRIPTION
Syncing with https://github.com/ethereum/consensus-specs/pull/3218