### PR TITLE
Constrain ByRange parameter values

### DIFF
--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -212,6 +212,8 @@ This method follows the same specification as [`engine_getPayloadV1`](./paris.md
 
 1. Client software **MUST** support `count` values of at least 32 blocks. The call **MUST** return `-38004: Too large request` error if the requested range is too large.
 
+1. Client software **MUST** return `-32602: Invalid params` error if either `start` or `count` value is less than `1`.
+
 1. Client software **MUST** place `null` in the response array for unavailable blocks which numbers are lower than a number of the latest known block. Client software **MUST NOT** return trailing `null` values if the request extends past the current latest known block. Execution Layer client software is expected to download and carry the full block history until EIP-4444 or a similar proposal takes into effect. Consider the following response examples:
     * `[B1.body, B2.body, ..., Bn.body]` -- entire requested range is filled with block bodies,
     * `[null, null, B3.body, ..., Bn.body]` -- first two blocks are unavailable (either pruned or not yet downloaded),


### PR DESCRIPTION
Fixes edge cases when requested `count` is zero or `start` points to a genesis block.

Thanks to @siladu for bringing this up.

cc @arnetheduck