### PR TITLE
add eth_getReceiptProof

### DIFF
--- a/src/eth/transaction.yaml
+++ b/src/eth/transaction.yaml
@@ -49,3 +49,14 @@
     name: Receipt Information
     schema:
       $ref: '#/components/schemas/ReceiptInfo'
+- name: eth_getReceiptProof
+  summary: Returns the merkle proof for a given transaction receipt.
+  params:
+    - name: Transaction hash
+      required: true
+      schema:
+        $ref: '#/components/schemas/hash32'
+  result:
+    name: Receipt proof
+    schema:
+      $ref: '#/components/schemas/ReceiptProof'

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -102,3 +102,18 @@ ReceiptInfo:
       title: effective gas price
       description: The actual value per gas deducted from the senders account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas).
       $ref: '#/components/schemas/uint'
+ReceiptProof:
+  title: Receipt proof
+  type: object
+  required:
+    - receipt
+    - proof
+  properties:
+    value:
+      title: receipt
+      $ref: '#/components/schemas/ReceiptInfo'
+    proof:
+      title: proof
+      type: array
+      items:
+        $ref: '#/components/schemas/bytes'


### PR DESCRIPTION
Adds a new method, `eth_getReceiptProof`. This method takes in a transaction hash as input, and returns both a receipt, and a merkle proof of the receipt rooted at the receipt root.

The main use case I have in mind for this is light clients that utilize an RPC to prove state. Right now, the most efficient way to verify a given receipt is to download every receipt in the block, reconstruct the merkle tree, and check that the root of it matches. This method can instead be used, and significantly reduces the amount of data the light client must consume.

Both Helios and Kevlar want to make use of this method, and I imagine other light clients would as well.