### PR TITLE
Engine API: deprecate exchangeTransitionConfiguration

### DIFF
--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -231,3 +231,9 @@ This method follows the same specification as [`engine_getPayloadV1`](./paris.md
 1. Callers must be careful to verify the hash of the received blocks when requesting non-finalized parts of the chain since the response is prone to being re-orged.
 
 1. Callers must consider that syncing execution layer client may not serve any block bodies, including those that were supplied by `engine_newPayload` calls.
+
+### Deprecate `engine_exchangeTransitionConfigurationV1`
+
+#### Specification
+
+1. Consensus layer client software **MUST NOT** surface an error to the user if this method call fails with any error including `-32601: Method not found`.

--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -236,6 +236,6 @@ This method follows the same specification as [`engine_getPayloadV1`](./paris.md
 
 #### Specification
 
-1. Consensus layer client software **MUST NOT** surface an error to the user if this method call fails with any error including `-32601: Method not found`.
+1. Consensus layer client software **MUST NOT** surface an error to the user if this method call fails with any error including `-32601: Method not found`. Consensus layer client software **MUST** still call this method.
 
 1. Execution layer client software **MUST NOT** surface an error to the user if this method is not called.

--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -237,3 +237,5 @@ This method follows the same specification as [`engine_getPayloadV1`](./paris.md
 #### Specification
 
 1. Consensus layer client software **MUST NOT** surface an error to the user if this method call fails with any error including `-32601: Method not found`.
+
+1. Execution layer client software **MUST NOT** surface an error to the user if this method is not called.


### PR DESCRIPTION
Alternative to https://github.com/ethereum/execution-apis/pull/339 which deprecates `engine_exchangeTransitionConfigurationV1`.

In discussion with @lightclient we came to decision that we should make the spec more explicit about deprecation path of this method.

The change proposed by this PR requires CL clients to not surface any error if a call of this method returns error, particularly, method not found. EL must either not surface an error if it doesn't receive calls to this method.

After these changes adhered by clients they will be able to remove support of this method entirely in uncoordinated fashion.

Note: these changes are similar to the ones proposed by https://github.com/ethereum/execution-apis/pull/320, with a slight difference in CL client's behaviour which allows to break the dependency on both ends.