### PR TITLE
Engine API: CL must switch to V2 methods since Shanghai

### DIFF
--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -111,6 +111,7 @@ This method follows the same specification as [`engine_newPayloadV1`](./paris.md
 
 1. Client software **MAY NOT** validate terminal PoW block conditions during payload validation (point (2) in the [Payload validation](./paris.md#payload-validation) routine).
 2. Client software **MUST** return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the `blockHash` validation has failed.
+3. Consensus layer client **MUST** call this method instead of `engine_newPayloadV1` if `timestamp` value of a payload is greater or equal to the Shanghai timestamp.
 
 ### engine_forkchoiceUpdatedV2
 
@@ -134,8 +135,11 @@ Refer to the response for [`engine_forkchoiceUpdatedV1`](./paris.md#engine_forkc
 This method follows the same specification as [`engine_forkchoiceUpdatedV1`](./paris.md#engine_forkchoiceupdatedv1) with the exception of the following:
 
 1. Client software **MAY NOT** validate terminal PoW block conditions in the following places:
-  - during payload validation (point (2) in the [Payload validation](./paris.md#payload-validation) routine specification),
-  - when updating the forkchoice state (point (3) in the [`engine_forkchoiceUpdatedV1`](./paris.md#engine_forkchoiceupdatedv1) method specification).
+    - during payload validation (point (2) in the [Payload validation](./paris.md#payload-validation) routine specification),
+    - when updating the forkchoice state (point (3) in the [`engine_forkchoiceUpdatedV1`](./paris.md#engine_forkchoiceupdatedv1) method specification).
+2. Consensus layer client **MUST** call this method instead of `engine_forkchoiceUpdatedV1` under any of the following conditions:
+    - `headBlockHash` references a block which `timestamp` is greater or equal to the Shanghai timestamp,
+    - `payloadAttributes` is not `null` and `payloadAttributes.timestamp` is greater or equal to the Shanghai timestamp.
 
 ### engine_getPayloadV2
 


### PR DESCRIPTION
Explicitly require CL clients to switch `newPayload` and `forkchoiceUpdated` to `V2` starting from Shanghai.

Summary of a problem: https://github.com/ethereum/hive/pull/706#issue-1574839378
Hive tests checking this requirement: https://github.com/ethereum/hive/pull/712

cc @marioevz