### PR TITLE
Allow EL to suggest local execution

### DIFF
--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -157,6 +157,7 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV1`](./p
       - `ExecutionPayloadV1` **MUST** be returned if the payload `timestamp` is lower than the Shanghai timestamp
       - `ExecutionPayloadV2` **MUST** be returned if the payload `timestamp` is greater or equal to the Shanghai timestamp
   - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei
+  - `shouldOverrideBuilder` : `BOOLEAN` - Suggestion from the EL to use this `executionPayload` instead of an externally provided one
 * error: code and message set in case an exception happens while getting the payload.
 
 #### Specification
@@ -164,6 +165,7 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV1`](./p
 This method follows the same specification as [`engine_getPayloadV1`](./paris.md#engine_getpayloadv1) with the addition of the following:
 
   1. Client software **SHOULD** use the sum of the block's priority fees or any other algorithm to determine `blockValue`.
+  2. Client software **MAY** use any heuristics to decide `shouldOverrideBuilder`.
 
 ### engine_getPayloadBodiesByHashV1
 


### PR DESCRIPTION
This PR adds a boolean field `shouldOverrideBuilder` to `engine_getPayload`. This provides a way for the EL to indicate that the CL should consider using this payload and not rely in any externally provided one. Arbitrary heuristics are allowed, and the CL may or may not use this information. 

**Rationale**: We have currently a circuit breaker to prevent using a relayer in case blocks are missing under certain scenarios. These scenarios are purely based on consensus data. I propose that we let the EL weigh in this decision based on its local view of execution data. Examples of this are

- A particular transaction, paying much more than the usual priority fee, has not been included for several slots
- A particular transaction has been included in many blocks and those have been reorged out systematically. 
- A particular transaction has been included in blocks that have been invalid systematically. 

EL clients that do not want to implement any changes can simply return `false` in this field and behavior would be as before. 