### PR TITLE
graphql: specify Long input and output formats

### DIFF
--- a/graphql.json
+++ b/graphql.json
@@ -272,7 +272,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Long",
               "ofType": null
             },
             "isDeprecated": false,
@@ -495,7 +495,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Long",
               "ofType": null
             },
             "isDeprecated": false,
@@ -529,7 +529,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "Long",
                     "ofType": null
                   }
                 },
@@ -592,7 +592,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "Int",
+                    "name": "Long",
                     "ofType": null
                   }
                 },
@@ -1127,7 +1127,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Long",
                 "ofType": null
               }
             },
@@ -1289,7 +1289,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Long",
                 "ofType": null
               }
             },
@@ -1754,7 +1754,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Long",
               "ofType": null
             },
             "isDeprecated": false,
@@ -2067,7 +2067,7 @@
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Int",
+              "name": "Long",
               "ofType": null
             },
             "isDeprecated": false,

--- a/graphql.json
+++ b/graphql.json
@@ -1226,7 +1226,7 @@
       {
         "kind": "SCALAR",
         "name": "Long",
-        "description": "Long is a 64 bit unsigned integer.",
+        "description": "Long is a 64 bit unsigned integer. Input is accepted as either a JSON number or as a string.\nStrings may be either decimal or 0x-prefixed hexadecimal. Output values are all\n0x-prefixed hexadecimal.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,

--- a/schema.graphqls
+++ b/schema.graphqls
@@ -67,7 +67,7 @@ type Block {
   TransactionCount is the number of transactions in this block. if
   transactions are not available for this block, this field will be null.
   """
-  transactionCount: Int
+  transactionCount: Long
 
   """
   StateRoot is the keccak256 hash of the state trie after this block was processed.
@@ -130,7 +130,7 @@ type Block {
   OmmerCount is the number of ommers (AKA uncles) associated with this
   block. If ommers are unavailable, this field will be null.
   """
-  ommerCount: Int
+  ommerCount: Long
 
   """
   Ommers is a list of ommer (AKA uncle) blocks associated with this block.
@@ -144,7 +144,7 @@ type Block {
   OmmerAt returns the ommer (AKA uncle) at the specified index. If ommers
   are unavailable, or the index is out of bounds, this field will be null.
   """
-  ommerAt(index: Int!): Block
+  ommerAt(index: Long!): Block
 
   """
   OmmerHash is the keccak256 hash of all the ommers (AKA uncles)
@@ -163,7 +163,7 @@ type Block {
   transactions are unavailable for this block, or if the index is out of
   bounds, this field will be null.
   """
-  transactionAt(index: Int!): Transaction
+  transactionAt(index: Long!): Transaction
 
   """Logs returns a filtered set of logs from this block."""
   logs(filter: BlockFilterCriteria!): [Log!]!
@@ -306,7 +306,7 @@ input FilterCriteria {
 """Log is an Ethereum event log."""
 type Log {
   """Index is the index of this log in the block."""
-  index: Int!
+  index: Long!
 
   """
   Account is the account which generated this log - this will always
@@ -339,7 +339,7 @@ type Mutation {
 """Pending represents the current pending state."""
 type Pending {
   """TransactionCount is the number of transactions in the pending state."""
-  transactionCount: Int!
+  transactionCount: Long!
 
   """Transactions is a list of transactions in the current pending state."""
   transactions: [Transaction!]
@@ -426,7 +426,7 @@ type Transaction {
   Index is the index of this transaction in the parent block. This will
   be null if the transaction has not yet been mined.
   """
-  index: Int
+  index: Long
 
   """
   From is the account that sent this transaction - this will always be
@@ -521,7 +521,7 @@ type Transaction {
   v: BigInt!
 
   """Envelope transaction support"""
-  type: Int
+  type: Long
   accessList: [AccessTuple!]
 
   """

--- a/schema.graphqls
+++ b/schema.graphqls
@@ -324,7 +324,11 @@ type Log {
   transaction: Transaction!
 }
 
-"""Long is a 64 bit unsigned integer."""
+"""
+Long is a 64 bit unsigned integer. Input is accepted as either a JSON number or as a string.
+Strings may be either decimal or 0x-prefixed hexadecimal. Output values are all
+0x-prefixed hexadecimal.
+"""
 scalar Long
 
 type Mutation {


### PR DESCRIPTION
**TL;DR** After this PR every number field will be hex-formatted. Numeric inputs are flexible and can be provided as number or string.

The spec is vague in defining which inputs are accepted for `Long` and how outputs are formatted. I suggest that `Long` behave similar to `BigInt`s in this sense. I.e. be flexible when taking input, but output hex-encoded values. My reasoning is that:

- JSON-RPC API returns all the long values as hex.
- Even though BigInt is a thing in JS-land, parsing a big uint64 literal in JS will still be inaccurate. Case in point this happens also in the GraphiQL UI which both Besu and Geth use this issue exists. There's a [proposal](https://github.com/tc39/proposal-json-parse-with-source) which will help with this however it is not accepted for being included into the EcmaScript spec.
- That said we can improve UX by accepting number literals as well as strings for inputs.

Every field with type `Int` has been changed to be a `Long` for consistency.

Hive tests: https://github.com/ethereum/hive/pull/746