### PR TITLE
EIP-6110: re-use V2 methods instead of defining new ones

### DIFF
--- a/src/engine/experimental/eip6110.md
+++ b/src/engine/experimental/eip6110.md
@@ -1,6 +1,6 @@
 # Engine API -- EIP-6110
 
-Engine API changes introduced in EIP-6110.
+Engine API changes introduced in EIP-6110, based on [Shanghai](../shanghai.md).
 
 ## Table of contents
 
@@ -11,11 +11,11 @@ Engine API changes introduced in EIP-6110.
   - [DepositV1](#depositv1)
   - [ExecutionPayloadV6110](#executionpayloadv6110)
 - [Methods](#methods)
-  - [engine_newPayloadV6110](#engine_newpayloadv6110)
+  - [Modified `engine_newPayloadV2`](#modified-engine_newpayloadv2)
     - [Request](#request)
     - [Response](#response)
     - [Specification](#specification)
-  - [engine_getPayloadV6110](#engine_getpayloadv6110)
+  - [Modified `engine_getPayloadV2`](#modified-engine_getpayloadv2)
     - [Request](#request-1)
     - [Response](#response-1)
     - [Specification](#specification-1)
@@ -59,41 +59,29 @@ This structure has the syntax of [`ExecutionPayloadV2`](../shanghai.md#execution
 
 ## Methods
 
-### engine_newPayloadV6110
+### Modified `engine_newPayload2`
+
+*Note:* Extending the input parameter type with [`ExecutionPayloadV6110`](#ExecutionPayloadV6110) is the only modification of this method.
 
 #### Request
 
-* method: `engine_newPayloadV6110`
+* method: `engine_newPayload2`
 * params:
-  1. [`ExecutionPayloadV2`](../shanghai.md#ExecutionPayloadV2) | [`ExecutionPayloadV6110`](#ExecutionPayloadV6110), where:
-      - `ExecutionPayloadV1` **MUST** be used if the `timestamp` value is lower than the EIP-6110 activation timestamp,
-      - `ExecutionPayloadV6110` **MUST** be used if the `timestamp` value is greater or equal to the EIP-6110 activation timestamp,
+  1. [`ExecutionPayloadV1`](../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](../shanghai.md#ExecutionPayloadV2) | [`ExecutionPayloadV6110`](#ExecutionPayloadV6110), where:
+      - `ExecutionPayloadV1` **MUST** be used if the `timestamp` value is lower than the Shanghai timestamp,
+      - `ExecutionPayloadV2` **MUST** be used if the `timestamp` value is lower than the EIP-6110 activation timestamp,
+      - `ExecutionPayloadV6110` **MUST** be used if the `timestamp` value is greater than or equal to the EIP-6110 activation timestamp,
       - Client software **MUST** return `-32602: Invalid params` error if the wrong version of the structure is used in the method call.
-* timeout: 8s
+
+### Modified `engine_getPayloadV2`
+
+*Note:* Extending the response type with [`ExecutionPayloadV6110`](#ExecutionPayloadV6110) is the only modification of this method.
 
 #### Response
 
-Refer to the response for [`engine_newPayloadV2`](../shanghai.md#engine_newpayloadv2).
-
-#### Specification
-
-This method follows the same specification as [`engine_newPayloadV2`](../shanghai.md#engine_newpayloadv2).
-
-### engine_getPayloadV6110
-
-#### Request
-
-* method: `engine_getPayloadV6110`
-* params:
-  1. `payloadId`: `DATA`, 8 Bytes - Identifier of the payload build process
-* timeout: 1s
-
-#### Response
-
-Refer to the response for [`engine_getPayloadV2`](../shanghai.md#engine_getpayloadv2) with the following change:
-* `executionPayload` data structure is changed to [`ExecutionPayloadV6110`](#ExecutionPayloadV6110).
-
-#### Specification
-
-Refer to the specification for [`engine_getPayloadV2`](../shanghai.md#engine_getpayloadv2).
-
+* result: `object`
+  - `executionPayload`: [`ExecutionPayloadV1`](../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](../shanghai.md#ExecutionPayloadV2) | [`ExecutionPayloadV6110`](#ExecutionPayloadV6110) where:
+      - `ExecutionPayloadV1` **MUST** be returned if the payload `timestamp` is lower than the Shanghai timestamp,
+      - `ExecutionPayloadV2` **MUST** be returned if the payload `timestamp` is lower than the EIP-6110 activation timestamp,
+      - `ExecutionPayloadV6110` **MUST** be returned if the payload `timestamp` is greater than or equal to the EIP-6110 activation timestamp.
+  - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei


### PR DESCRIPTION
It is experimental change to `eip6110` experimental feature implementing proposal described in https://github.com/ethereum/execution-apis/issues/376.

A summary of the proposal: re-use previous method version instead of adding a new one when there is no change or addition to method's semantics, and the only modification is datatype of either input parameter or response.