### PR TITLE
Rename deposit fields

### DIFF
--- a/src/engine/experimental/eip6110.md
+++ b/src/engine/experimental/eip6110.md
@@ -29,7 +29,7 @@ This structure maps onto the deposit object from [EIP-6110](https://eips.ethereu
 The fields are encoded as follows:
 
 - `pubkey`: `DATA`, 48 Bytes
-- `withdrawal_credentials`: `DATA`, 32 Bytes
+- `withdrawalCredentials`: `DATA`, 32 Bytes
 - `amount`: `QUANTITY`, 64 Bits
 - `signature`: `DATA`, 96 Bytes
 - `index`: `QUANTITY`, 64 Bits


### PR DESCRIPTION
Rename deposit fields using camel case for the sake of consistency with withdrawal