### PR TITLE
Add EIP-4844 transaction and receipt

### DIFF
--- a/src/eth/submit.yaml
+++ b/src/eth/submit.yaml
@@ -10,7 +10,9 @@
     schema:
       $ref: '#/components/schemas/hash32'
 - name: eth_sendRawTransaction
-  summary: Submits a raw transaction.
+  summary: Submits a raw transaction. For EIP-4844 transactions, the raw form
+    must be the network form. This means it includes the blobs, KZG
+    commitments, and KZG proofs.
   params:
     - name: Transaction
       required: true

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -86,7 +86,7 @@ ReceiptInfo:
       $ref: '#/components/schemas/uint'
     dataGasUsed:
       title: data gas used
-      description: The amount of data gas used for this specification transaction
+      description: The amount of data gas used for this specification transaction. Only specified for blob transactions as defined by EIP-4844.
       $ref: '#/components/schemas/uint'  
     contractAddress:
       title: contract address
@@ -115,3 +115,7 @@ ReceiptInfo:
       title: effective gas price
       description: The actual value per gas deducted from the senders account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas).
       $ref: '#/components/schemas/uint'
+    dataGasPrice:
+      title: data gas price
+      description: The actual value per gas deducted from the senders account for data gas. Only specified for blob transactions as defined by EIP-4844.
+      $ref: '#/components/schemas/uint'      

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -48,7 +48,6 @@ ReceiptInfo:
     - transactionHash
     - transactionIndex
     - effectiveGasPrice
-    - dataGasUsed
   additionalProperties: false
   properties:
     type:
@@ -87,11 +86,8 @@ ReceiptInfo:
       $ref: '#/components/schemas/uint'
     dataGasUsed:
       title: data gas used
-      description: The amount of data gas used for this specification transaction alone
-      oneOf:
-        - $ref: '#/components/schemas/uint'
-        - name: Null
-          type: "null"
+      description: The amount of data gas used for this specification transaction
+      $ref: '#/components/schemas/uint'  
     contractAddress:
       title: contract address
       description: The contract address created, if the transaction was a contract creation, otherwise null.

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -84,9 +84,9 @@ ReceiptInfo:
       title: gas used
       description: The amount of gas used for this specific transaction alone.
       $ref: '#/components/schemas/uint'
-    dataGasUsed:
-      title: data gas used
-      description: The amount of data gas used for this specific transaction. Only specified for blob transactions as defined by EIP-4844.
+    blobGasUsed:
+      title: blob gas used
+      description: The amount of blob gas used for this specific transaction. Only specified for blob transactions as defined by EIP-4844.
       $ref: '#/components/schemas/uint'  
     contractAddress:
       title: contract address
@@ -115,7 +115,7 @@ ReceiptInfo:
       title: effective gas price
       description: The actual value per gas deducted from the sender's account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas).
       $ref: '#/components/schemas/uint'
-    dataGasPrice:
-      title: data gas price
-      description: The actual value per gas deducted from the sender's account for data gas. Only specified for blob transactions as defined by EIP-4844.
+    blobGasPrice:
+      title: blob gas price
+      description: The actual value per gas deducted from the sender's account for blob gas. Only specified for blob transactions as defined by EIP-4844.
       $ref: '#/components/schemas/uint'      

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -113,7 +113,7 @@ ReceiptInfo:
       $ref: '#/components/schemas/uint'
     effectiveGasPrice:
       title: effective gas price
-      description: The actual value per gas deducted from the senders account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas).
+      description: The actual value per gas deducted from the sender's account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas).
       $ref: '#/components/schemas/uint'
     dataGasPrice:
       title: data gas price

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -48,6 +48,7 @@ ReceiptInfo:
     - transactionHash
     - transactionIndex
     - effectiveGasPrice
+    - dataGasUsed
   additionalProperties: false
   properties:
     type:
@@ -84,6 +85,13 @@ ReceiptInfo:
       title: gas used
       description: The amount of gas used for this specific transaction alone.
       $ref: '#/components/schemas/uint'
+    dataGasUsed:
+      title: data gas used
+      description: The amount of data gas used for this specification transaction alone
+      oneOf:
+        - $ref: '#/components/schemas/uint'
+        - name: Null
+          type: "null"
     contractAddress:
       title: contract address
       description: The contract address created, if the transaction was a contract creation, otherwise null.

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -87,7 +87,7 @@ ReceiptInfo:
     blobGasUsed:
       title: blob gas used
       description: The amount of blob gas used for this specific transaction. Only specified for blob transactions as defined by EIP-4844.
-      $ref: '#/components/schemas/uint'  
+      $ref: '#/components/schemas/uint'
     contractAddress:
       title: contract address
       description: The contract address created, if the transaction was a contract creation, otherwise null.
@@ -118,4 +118,4 @@ ReceiptInfo:
     blobGasPrice:
       title: blob gas price
       description: The actual value per gas deducted from the sender's account for blob gas. Only specified for blob transactions as defined by EIP-4844.
-      $ref: '#/components/schemas/uint'      
+      $ref: '#/components/schemas/uint'

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -117,5 +117,5 @@ ReceiptInfo:
       $ref: '#/components/schemas/uint'
     dataGasPrice:
       title: data gas price
-      description: The actual value per gas deducted from the senders account for data gas. Only specified for blob transactions as defined by EIP-4844.
+      description: The actual value per gas deducted from the sender's account for data gas. Only specified for blob transactions as defined by EIP-4844.
       $ref: '#/components/schemas/uint'      

--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -86,7 +86,7 @@ ReceiptInfo:
       $ref: '#/components/schemas/uint'
     dataGasUsed:
       title: data gas used
-      description: The amount of data gas used for this specification transaction. Only specified for blob transactions as defined by EIP-4844.
+      description: The amount of data gas used for this specific transaction. Only specified for blob transactions as defined by EIP-4844.
       $ref: '#/components/schemas/uint'  
     contractAddress:
       title: contract address

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -4,7 +4,7 @@ Transaction4844Unsigned:
   required:
     - type
     - nonce
-    - address
+    - to
     - gas
     - value
     - input
@@ -12,6 +12,7 @@ Transaction4844Unsigned:
     - maxFeePerGas
     - maxFeePerBlobGas
     - accessList
+    - blobVersionedHashes
     - chainId
   properties:
     type:

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -43,7 +43,7 @@ Transaction4844Unsigned:
     maxFeePerBlobGas:
       title: max fee per blob gas
       description: The maximum total fee per gas the sender is willing to pay for blob gas in wei
-      $ref: '#components/schemas/uint'
+      $ref: '#/components/schemas/uint'
     accessList:
       title: accessList
       description: EIP-2930 access list
@@ -399,7 +399,7 @@ GenericTransaction:
     maxFeePerBlobGas:
       title: max fee per blob gas
       description: The maximum total fee per gas the sender is willing to pay for blob gas in wei
-      $ref: '#components/schemas/uint'
+      $ref: '#/components/schemas/uint'
     accessList:
       title: accessList
       description: EIP-2930 access list

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -1,3 +1,63 @@
+Transaction4844Unsigned:
+  type: object
+  title: EIP-4844 transaction.
+  required:
+    - type
+    - nonce
+    - address
+    - gas
+    - value
+    - input
+    - maxPriorityFeePerGas
+    - maxFeePerGas
+    - maxFeePerBlobGas
+    - accessList
+    - chainId
+  properties:
+    type:
+      title: type
+      $ref: '#/components/schemas/byte'
+    nonce:
+      title: nonce
+      $ref: '#/components/schemas/uint'
+    to:
+      title: to address
+      $ref: '#/components/schemas/address'
+    gas:
+      title: gas limit
+      $ref: '#/components/schemas/uint'
+    value:
+      title: value
+      $ref: '#/components/schemas/uint'
+    input:
+      title: input data
+      $ref: '#/components/schemas/bytes'
+    maxPriorityFeePerGas:
+      title: max priority fee per gas
+      description: Maximum fee per gas the sender is willing to pay to miners in wei
+      $ref: '#/components/schemas/uint'
+    maxFeePerGas:
+      title: max fee per gas
+      description: The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei
+      $ref: '#/components/schemas/uint'
+    maxFeePerBlobGas:
+      title: max fee per blob gas
+      description: The maximum total fee per gas the sender is willing to pay for blob gas in wei
+      $ref: '#components/schemas/uint'
+    accessList:
+      title: accessList
+      description: EIP-2930 access list
+      $ref: '#/components/schemas/AccessList'
+    blobVersionedHashes:
+      title: blobVersionedHashes
+      description: List of versioned blob hashes associated with the transaction's EIP-4844 data blobs.
+      type: array
+      items:
+        $ref: '#/components/schemas/hash32'
+    chainId:
+      title: chainId
+      description: Chain ID that this transaction is valid on.
+      $ref: '#/components/schemas/uint'
 AccessListEntry:
   title: Access list entry
   type: object
@@ -164,9 +224,31 @@ TransactionLegacyUnsigned:
       $ref: '#/components/schemas/uint'
 TransactionUnsigned:
   oneOf:
+    - $ref: '#/components/schemas/Transaction4844Unsigned'
     - $ref: '#/components/schemas/Transaction1559Unsigned'
     - $ref: '#/components/schemas/Transaction2930Unsigned'
     - $ref: '#/components/schemas/TransactionLegacyUnsigned'
+Transaction4844Signed:
+  title: Signed 4844 Transaction
+  type: object
+  allOf:
+    - $ref: '#/components/schemas/Transaction4844Unsigned'
+    - title: EIP-4844 transaction signature properties.
+      required:
+        - yParity
+        - r
+        - s
+      properties:
+        yParity:
+          title: yParity
+          description: The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.
+          $ref: '#/components/schemas/uint'
+        r:
+          title: r
+          $ref: '#/components/schemas/uint'
+        s:
+          title: s
+          $ref: '#/components/schemas/uint'
 Transaction1559Signed:
   title: Signed 1559 Transaction
   type: object
@@ -239,6 +321,7 @@ TransactionLegacySigned:
           $ref: '#/components/schemas/uint'
 TransactionSigned:
   oneOf:
+    - $ref: '#/components/schemas/Transaction4844Signed'
     - $ref: '#/components/schemas/Transaction1559Signed'
     - $ref: '#/components/schemas/Transaction2930Signed'
     - $ref: '#/components/schemas/TransactionLegacySigned'

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -396,10 +396,26 @@ GenericTransaction:
       title: max fee per gas
       description: The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei
       $ref: '#/components/schemas/uint'
+    maxFeePerBlobGas:
+      title: max fee per blob gas
+      description: The maximum total fee per gas the sender is willing to pay for blob gas in wei
+      $ref: '#components/schemas/uint'
     accessList:
       title: accessList
       description: EIP-2930 access list
       $ref: '#/components/schemas/AccessList'
+    blobVersionedHashes:
+      title: blobVersionedHashes
+      description: List of versioned blob hashes associated with the transaction's EIP-4844 data blobs.
+      type: array
+      items:
+        $ref: '#/components/schemas/hash32'
+    blobs:
+      title: blobs
+      description: Raw blob data.
+      type: array
+      items:
+        $ref: '#/components/schemas/bytes'
     chainId:
       title: chainId
       description: Chain ID that this transaction is valid on.


### PR DESCRIPTION
As discussed in recent 4844 implementers calls, this proposes to add optional fields for `blobGasUsed` and `blobGasPrice` to the transaction receipt object specific to 4844 blob transactions.