### PR TITLE
State that `payloadId` should be unique for each `PayloadAttributes` instance

### DIFF
--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -136,6 +136,8 @@ The payload build process is specified as follows:
 
 4. Client software **SHOULD** stop the updating process when either a call to `engine_getPayload` with the build process's `payloadId` is made or [`SECONDS_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#time-parameters-1) (12s in the Mainnet configuration) have passed since the point in time identified by the `timestamp` parameter.
 
+5. A `payloadId` value returned by the client software **SHOULD** uniquely identify an instance of `PayloadAttributes` passed into the build process, i.e. `payloadId` values for two distinct `PayloadAttributes` objects **SHOULD** be different.
+
 ## Methods
 
 ### engine_newPayloadV1

--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -136,8 +136,8 @@ The payload build process is specified as follows:
 
 4. Client software **SHOULD** stop the updating process when either a call to `engine_getPayload` with the build process's `payloadId` is made or [`SECONDS_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#time-parameters-1) (12s in the Mainnet configuration) have passed since the point in time identified by the `timestamp` parameter.
 
-5. Client software **MUST** begin new build process if given `PayloadAttributes` doesn't match payload attributes of existing build process.
-   Every new build process **MUST** be uniquely identified by the `payloadId` value.
+5. Client software **MUST** begin a new build process if given `PayloadAttributes` doesn't match payload attributes of an existing build process.
+   Every new build process **MUST** be uniquely identified by the returned `payloadId` value.
 
 6. If a build process with given `PayloadAttributes` already exists, client software **SHOULD NOT** restart it.
 

--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -136,7 +136,10 @@ The payload build process is specified as follows:
 
 4. Client software **SHOULD** stop the updating process when either a call to `engine_getPayload` with the build process's `payloadId` is made or [`SECONDS_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#time-parameters-1) (12s in the Mainnet configuration) have passed since the point in time identified by the `timestamp` parameter.
 
-5. Client software **MUST** initiate new payload build process for every distinct `PayloadAttributes` instance. A `payloadId` value **MUST** uniquely identify every new build process.
+5. Client software **MUST** begin new build process if given `PayloadAttributes` doesn't match payload attributes of existing build process.
+   Every new build process **MUST** be uniquely identified by the `payloadId` value.
+
+6. If a build process with given `PayloadAttributes` already exists, client software **SHOULD NOT** restart it.
 
 ## Methods
 

--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -136,7 +136,7 @@ The payload build process is specified as follows:
 
 4. Client software **SHOULD** stop the updating process when either a call to `engine_getPayload` with the build process's `payloadId` is made or [`SECONDS_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#time-parameters-1) (12s in the Mainnet configuration) have passed since the point in time identified by the `timestamp` parameter.
 
-5. A `payloadId` value returned by the client software **MUST** uniquely identify an instance of `PayloadAttributes` passed into the build process, i.e. `payloadId` values for two distinct `PayloadAttributes` objects ** MUST** be different.
+5. Client software **MUST** initiate new payload build process for every distinct `PayloadAttributes` instance. A `payloadId` value **MUST** uniquely identify every new build process.
 
 ## Methods
 

--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -136,7 +136,7 @@ The payload build process is specified as follows:
 
 4. Client software **SHOULD** stop the updating process when either a call to `engine_getPayload` with the build process's `payloadId` is made or [`SECONDS_PER_SLOT`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#time-parameters-1) (12s in the Mainnet configuration) have passed since the point in time identified by the `timestamp` parameter.
 
-5. A `payloadId` value returned by the client software **SHOULD** uniquely identify an instance of `PayloadAttributes` passed into the build process, i.e. `payloadId` values for two distinct `PayloadAttributes` objects **SHOULD** be different.
+5. A `payloadId` value returned by the client software **MUST** uniquely identify an instance of `PayloadAttributes` passed into the build process, i.e. `payloadId` values for two distinct `PayloadAttributes` objects ** MUST** be different.
 
 ## Methods
 


### PR DESCRIPTION
Adds a statement that `payloadId` value returned EL client software should be different for two distinct `PayloadAttributes` objects