### PR TITLE
Merge `getPayloadV3` and `getBlobsBundleV1`

### DIFF
--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -107,9 +107,9 @@ and proofs corresponding to the `versioned_hashes` included in the blob transact
 
 Refer to the specification for `engine_getPayloadV2` with addition of the following:
 
-1. The call **MUST** return empty `blobs`, `kzgs` and `proofs` if the paylaod doesn't contain any blob transactions.
+1. The call **MUST** return empty `blobs`, `commitments` and `proofs` if the paylaod doesn't contain any blob transactions.
 
-2. The call **MUST** return `kzgs` matching the versioned hashes of the transactions list of the execution payload, in the same order,
-   i.e. `assert verify_kzgs_against_transactions(payload.transactions, bundle.kzgs)` (see EIP-4844 consensus-specs).
+2. The call **MUST** return `commitments` matching the versioned hashes of the transactions list of the execution payload, in the same order,
+   i.e. `assert verify_kzgs_against_transactions(payload.transactions, bundle.commitments)` (see EIP-4844 consensus-specs).
 
-3. The call **MUST** return `blobs` and `proofs` that match the `kzgs` list, i.e. `assert len(kzgs) == len(blobs) == len(proofs)` and `assert verify_blob_kzg_proof_batch(bundle.blobs, bundle.kzgs, bundle.proofs)`.
+3. The call **MUST** return `blobs` and `proofs` that match the `commitments` list, i.e. `assert len(commitments) == len(blobs) == len(proofs)` and `assert verify_blob_kzg_proof_batch(bundle.blobs, bundle.commitments, bundle.proofs)`.

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -54,7 +54,7 @@ This structure has the syntax of `ExecutionPayloadV2` and appends a single field
 
 The fields are encoded as follows:
 
-- `kzgs`: `Array of DATA` - Array of `KZGCommitment` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), 48 bytes each (`DATA`).
+- `commitments`: `Array of DATA` - Array of `KZGCommitment` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), 48 bytes each (`DATA`).
 - `proofs`: `Array of DATA` - Array of `KZGProof` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), 48 bytes each (`DATA`).
 - `blobs`: `Array of DATA` - Array of blobs, each blob is `FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT = 4096 * 32 = 131072` bytes (`DATA`) representing a SSZ-encoded `Blob` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -110,6 +110,6 @@ Refer to the specification for `engine_getPayloadV2` with addition of the follow
 1. The call **MUST** return empty `blobs`, `commitments` and `proofs` if the paylaod doesn't contain any blob transactions.
 
 2. The call **MUST** return `commitments` matching the versioned hashes of the transactions list of the execution payload, in the same order,
-   i.e. `assert verify_kzgs_against_transactions(payload.transactions, bundle.commitments)` (see EIP-4844 consensus-specs).
+   i.e. `assert verify_kzg_commitments_against_transactions(payload.transactions, bundle.commitments)` (see EIP-4844 consensus-specs).
 
 3. The call **MUST** return `blobs` and `proofs` that match the `commitments` list, i.e. `assert len(commitments) == len(blobs) == len(proofs)` and `assert verify_blob_kzg_proof_batch(bundle.blobs, bundle.commitments, bundle.proofs)`.


### PR DESCRIPTION
As per decision made on [EIP-4844 Implementers' Call #20](https://github.com/ethereum/pm/issues/755) adds `blobsBundle` field to the `getPayloadV3` response getting rid of `blockHash` field in `BlobsBundleV1` data type and statements enforcing consistency between `getPayloadV3` and corresponding `getBlobsBundleV1` calls.