### PR TITLE
define tx hash paramter as required for  eth_getTransactionReceipt

### DIFF
--- a/src/eth/transaction.yaml
+++ b/src/eth/transaction.yaml
@@ -4,48 +4,49 @@
     - name: Transaction hash
       required: true
       schema:
-        $ref: '#/components/schemas/hash32'
+        $ref: "#/components/schemas/hash32"
   result:
     name: Transaction information
     schema:
-      $ref: '#/components/schemas/TransactionInfo'
+      $ref: "#/components/schemas/TransactionInfo"
 - name: eth_getTransactionByBlockHashAndIndex
   summary: Returns information about a transaction by block hash and transaction index position.
   params:
     - name: Block hash
       required: true
       schema:
-        $ref: '#/components/schemas/hash32'
+        $ref: "#/components/schemas/hash32"
     - name: Transaction index
       required: true
       schema:
-        $ref: '#/components/schemas/uint'
+        $ref: "#/components/schemas/uint"
   result:
     name: Transaction information
     schema:
-      $ref: '#/components/schemas/TransactionInfo'
+      $ref: "#/components/schemas/TransactionInfo"
 - name: eth_getTransactionByBlockNumberAndIndex
   summary: Returns information about a transaction by block number and transaction index position.
   params:
     - name: Block
       required: true
       schema:
-        $ref: '#/components/schemas/BlockNumberOrTag'
+        $ref: "#/components/schemas/BlockNumberOrTag"
     - name: Transaction index
       required: true
       schema:
-        $ref: '#/components/schemas/uint'
+        $ref: "#/components/schemas/uint"
   result:
     name: Transaction information
     schema:
-      $ref: '#/components/schemas/TransactionInfo'
+      $ref: "#/components/schemas/TransactionInfo"
 - name: eth_getTransactionReceipt
   summary: Returns the receipt of a transaction by transaction hash.
   params:
     - name: Transaction hash
+      required: true
       schema:
-        $ref: '#/components/schemas/hash32'
+        $ref: "#/components/schemas/hash32"
   result:
     name: Receipt Information
     schema:
-      $ref: '#/components/schemas/ReceiptInfo'
+      $ref: "#/components/schemas/ReceiptInfo"

--- a/src/eth/transaction.yaml
+++ b/src/eth/transaction.yaml
@@ -4,49 +4,49 @@
     - name: Transaction hash
       required: true
       schema:
-        $ref: "#/components/schemas/hash32"
+        $ref: '#/components/schemas/hash32'
   result:
     name: Transaction information
     schema:
-      $ref: "#/components/schemas/TransactionInfo"
+      $ref: '#/components/schemas/TransactionInfo'
 - name: eth_getTransactionByBlockHashAndIndex
   summary: Returns information about a transaction by block hash and transaction index position.
   params:
     - name: Block hash
       required: true
       schema:
-        $ref: "#/components/schemas/hash32"
+        $ref: '#/components/schemas/hash32'
     - name: Transaction index
       required: true
       schema:
-        $ref: "#/components/schemas/uint"
+        $ref: '#/components/schemas/uint'
   result:
     name: Transaction information
     schema:
-      $ref: "#/components/schemas/TransactionInfo"
+      $ref: '#/components/schemas/TransactionInfo'
 - name: eth_getTransactionByBlockNumberAndIndex
   summary: Returns information about a transaction by block number and transaction index position.
   params:
     - name: Block
       required: true
       schema:
-        $ref: "#/components/schemas/BlockNumberOrTag"
+        $ref: '#/components/schemas/BlockNumberOrTag'
     - name: Transaction index
       required: true
       schema:
-        $ref: "#/components/schemas/uint"
+        $ref: '#/components/schemas/uint'
   result:
     name: Transaction information
     schema:
-      $ref: "#/components/schemas/TransactionInfo"
+      $ref: '#/components/schemas/TransactionInfo'
 - name: eth_getTransactionReceipt
   summary: Returns the receipt of a transaction by transaction hash.
   params:
     - name: Transaction hash
       required: true
       schema:
-        $ref: "#/components/schemas/hash32"
+        $ref: '#/components/schemas/hash32'
   result:
     name: Receipt Information
     schema:
-      $ref: "#/components/schemas/ReceiptInfo"
+      $ref: '#/components/schemas/ReceiptInfo'


### PR DESCRIPTION
### Changelog

- Sets the transaction hash param as required in the docs because it was shown as optional

Before:
![Screenshot from 2023-04-20 17-01-45](https://user-images.githubusercontent.com/42520800/233487789-380dcc9b-8739-44c4-9cf5-a469aa89b159.png)

After:
![Screenshot from 2023-04-20 17-01-51](https://user-images.githubusercontent.com/42520800/233487811-fc0e8058-a270-4ff9-a816-05adcbbd8303.png)

