### PR TITLE
Assert array items in BlobsBundleV1 to be of same length

### DIFF
--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -55,6 +55,8 @@ The fields are encoded as follows:
 - `proofs`: `Array of DATA` - Array of `KZGProof` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), 48 bytes each (`DATA`).
 - `blobs`: `Array of DATA` - Array of blobs, each blob is `FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT = 4096 * 32 = 131072` bytes (`DATA`) representing a SSZ-encoded `Blob` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
 
+All of the above three arrays **MUST** be of same length but having no more than `MAX_BLOBS_PER_BLOCK` (see EIP-4844 consensus-specs).
+
 ## Methods
 
 ### engine_newPayloadV3

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -55,7 +55,7 @@ The fields are encoded as follows:
 - `proofs`: `Array of DATA` - Array of `KZGProof` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), 48 bytes each (`DATA`).
 - `blobs`: `Array of DATA` - Array of blobs, each blob is `FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT = 4096 * 32 = 131072` bytes (`DATA`) representing a SSZ-encoded `Blob` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
 
-All of the above three arrays **MUST** be of same length but having no more than `MAX_BLOBS_PER_BLOCK` (see EIP-4844 consensus-specs).
+All of the above three arrays **MUST** be of same length.
 
 ## Methods
 


### PR DESCRIPTION
UPDATE:
This PR proposed two things

i. Arrays are of the same length.
ii. The length is limited by MAX_BLOBS_PER_BLOCK .

Consensus to keep (i) and let CL handle (ii) in process block ops (where the MAX_BLOBS_PER_BLOCK check has already been placed)

-------------------------------------

In consensus specs, the blob limit it can handle is defined by `MAX_BLOBS_PER_BLOCK` and this check in apis will make the EL aware of this limit in CL and have mitigations (like perform min(MAX_DATA_GAS_PER_BLOCK / DATA_GAS_PER_BLOB,MAX_BLOBS_PER_BLOCK) to get  actual blob limit for the block to return in execution apis