### PR TITLE
Engine API: validate blob versioned hashes

### DIFF
--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -9,8 +9,8 @@
   - [Methods](#methods)
     - [engine_newPayloadV3](#engine_newpayloadv3)
       - [Request](#request)
-      - [Specification](#specification)
       - [Response](#response)
+      - [Specification](#specification)
     - [engine_getPayloadV3](#engine_getpayloadv3)
       - [Request](#request-1)
       - [Response](#response-1)
@@ -67,14 +67,17 @@ The fields are encoded as follows:
       - `ExecutionPayloadV2` **MUST** be used if the `timestamp` value is greater or equal to the Shanghai and lower than the EIP-4844 activation timestamp,
       - `ExecutionPayloadV3` **MUST** be used if the `timestamp` value is greater or equal to the EIP-4844 activation timestamp,
       - Client software **MUST** return `-32602: Invalid params` error if the wrong version of the structure is used in the method call.
-
-#### Specification
-
-Refer to the specification for `engine_newPayloadV2`.
+  2. `Array of DATA`, 32 Bytes - Array of blob versioned hashes to validate.
 
 #### Response
 
 Refer to the response for `engine_newPayloadV2`.
+
+#### Specification
+
+This method follows the same specification as `engine_newPayloadV2` with the addition of the following:
+
+1. Client software **MUST** validate blob versioned hashes array as being equal to the corresponding array obtained from transactions of the [`BLOB_TX_TYPE`](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) type contained by the payload respecting the order of their inclusion. Client software **MUST** run this validation in all cases even if this branch or any other branches of the block tree are in an active sync process and return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if it fails.
 
 ### engine_getPayloadV3
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -77,7 +77,11 @@ Refer to the response for `engine_newPayloadV2`.
 
 This method follows the same specification as `engine_newPayloadV2` with the addition of the following:
 
-1. Client software **MUST** validate blob versioned hashes array as being equal to the corresponding array obtained by concatenating versioned hashes from transactions of the [`BLOB_TX_TYPE`](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) type contained by the payload respecting the order of their block and transaction inclusion. Client software **MUST** run this validation in all cases even if this branch or any other branches of the block tree are in an active sync process and return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if it fails.
+1. Given array of blob versioned hashes client software **MUST** run its validation by taking the following steps:
+    1. Obtain an expected array by concatenating blob versioned hashes lists (`tx.blob_versioned_hashes`) of each [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) included in the payload, respecting the order of inclusion. If the payload has no blob transactions the expected array **MUST** be `[]`.
+    1. Return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the given and the expected arrays don't match.
+
+    This validation **MUST** be instantly run in all cases even during active sync process.
 
 ### engine_getPayloadV3
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -79,7 +79,7 @@ This method follows the same specification as `engine_newPayloadV2` with the add
 
 1. Given the expected array of blob versioned hashes client software **MUST** run its validation by taking the following steps:
     1. Obtain an actual array by concatenating blob versioned hashes lists (`tx.blob_versioned_hashes`) of each [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) included in the payload, respecting the order of inclusion. If the payload has no blob transactions the expected array **MUST** be `[]`.
-    1. Return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the expected and the actual arrays don't match.
+    2. Return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the expected and the actual arrays don't match.
 
     This validation **MUST** be instantly run in all cases even during active sync process.
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -77,7 +77,7 @@ Refer to the response for `engine_newPayloadV2`.
 
 This method follows the same specification as `engine_newPayloadV2` with the addition of the following:
 
-1. Client software **MUST** validate blob versioned hashes array as being equal to the corresponding array obtained from transactions of the [`BLOB_TX_TYPE`](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) type contained by the payload respecting the order of their inclusion. Client software **MUST** run this validation in all cases even if this branch or any other branches of the block tree are in an active sync process and return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if it fails.
+1. Client software **MUST** validate blob versioned hashes array as being equal to the corresponding array obtained by concatenating versioned hashes from transactions of the [`BLOB_TX_TYPE`](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) type contained by the payload respecting the order of their block and transaction inclusion. Client software **MUST** run this validation in all cases even if this branch or any other branches of the block tree are in an active sync process and return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if it fails.
 
 ### engine_getPayloadV3
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -77,9 +77,9 @@ Refer to the response for `engine_newPayloadV2`.
 
 This method follows the same specification as `engine_newPayloadV2` with the addition of the following:
 
-1. Given array of blob versioned hashes client software **MUST** run its validation by taking the following steps:
-    1. Obtain an expected array by concatenating blob versioned hashes lists (`tx.blob_versioned_hashes`) of each [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) included in the payload, respecting the order of inclusion. If the payload has no blob transactions the expected array **MUST** be `[]`.
-    1. Return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the given and the expected arrays don't match.
+1. Given the expected array of blob versioned hashes client software **MUST** run its validation by taking the following steps:
+    1. Obtain an actual array by concatenating blob versioned hashes lists (`tx.blob_versioned_hashes`) of each [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) included in the payload, respecting the order of inclusion. If the payload has no blob transactions the expected array **MUST** be `[]`.
+    1. Return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the expected and the actual arrays don't match.
 
     This validation **MUST** be instantly run in all cases even during active sync process.
 


### PR DESCRIPTION
Adds blob versioned hashes as a second parameter to `engine_newPayloadV3` as a follow up to https://github.com/ethereum/consensus-specs/pull/3345#issuecomment-1547327209