### PR TITLE
Update `PayloadV3` with data gas used

### DIFF
--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -27,7 +27,7 @@ This extension is backwards-compatible, but not part of the initial Engine API.
 
 ### ExecutionPayloadV3
 
-This structure has the syntax of `ExecutionPayloadV2` and append two new fields: `excessDataGas` and `dataGasUsed`.
+This structure has the syntax of `ExecutionPayloadV2` and append two new fields: `dataGasUsed` and `excessDataGas`.
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -27,7 +27,7 @@ This extension is backwards-compatible, but not part of the initial Engine API.
 
 ### ExecutionPayloadV3
 
-This structure has the syntax of `ExecutionPayloadV2` and appends a single field: `excessDataGas`.
+This structure has the syntax of `ExecutionPayloadV2` and append two new fields: `excessDataGas` and `dataGasUsed`.
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
@@ -44,7 +44,8 @@ This structure has the syntax of `ExecutionPayloadV2` and appends a single field
 - `blockHash`: `DATA`, 32 Bytes
 - `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
-- `excessDataGas`: `QUANTITY`, 256 bits
+- `excessDataGas`: `QUANTITY`, 64 Bits
+- `dataGasUsed`: `QUANTITY`, 256 bits
 
 ### BlobsBundleV1
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -44,8 +44,8 @@ This structure has the syntax of `ExecutionPayloadV2` and append two new fields:
 - `blockHash`: `DATA`, 32 Bytes
 - `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
-- `excessDataGas`: `QUANTITY`, 64 Bits
 - `dataGasUsed`: `QUANTITY`, 64 bits
+- `excessDataGas`: `QUANTITY`, 64 Bits
 
 ### BlobsBundleV1
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -45,7 +45,7 @@ This structure has the syntax of `ExecutionPayloadV2` and append two new fields:
 - `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
 - `excessDataGas`: `QUANTITY`, 64 Bits
-- `dataGasUsed`: `QUANTITY`, 256 bits
+- `dataGasUsed`: `QUANTITY`, 64 bits
 
 ### BlobsBundleV1
 


### PR DESCRIPTION
Aligning Deneb blob spec on these two things:

- Add `data_gas_used` field to `ExecutionPayload` https://github.com/ethereum/consensus-specs/pull/3391
- Change `ExecutionPayload.excess_data_gas` type from `uint256` to `uint64` https://github.com/ethereum/consensus-specs/pull/3392