### PR TITLE
Engine API: employ one method one structure approach for V3

### DIFF
--- a/src/engine/common.md
+++ b/src/engine/common.md
@@ -98,6 +98,7 @@ The list of error codes introduced by this specification can be found below.
 | -38002 | Invalid forkchoice state | Forkchoice state is invalid / inconsistent. |
 | -38003 | Invalid payload attributes | Payload attributes are invalid / inconsistent. |
 | -38004 | Too large request | Number of requested entities is too large. |
+| -38005 | Unsupported fork | Payload belongs to a fork that is not supported. |
 
 Each error returns a `null` `data` value, except `-32000` which returns the `data` object with a `err` member that explains the error encountered.
 

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -66,9 +66,7 @@ The fields are encoded as follows:
   1. [`ExecutionPayloadV3`](#ExecutionPayloadV3).
   2. `Array of DATA`, 32 Bytes - Array of blob versioned hashes to validate.
 
-Client software **MUST** enforce the following checks on the parameter set of this call and return `-32602: Invalid params` error if any of them fails:
-* All parameters and their fields are provided with non-`null` values.
-* The payload `timestamp` is greater or equal to the EIP-4844 activation timestamp.
+Client software **MUST** return `-32602: Invalid params` error unless all parameters and their fields are provided with non-`null` values.
 
 #### Response
 
@@ -83,6 +81,8 @@ This method follows the same specification as `engine_newPayloadV2` with the add
     2. Return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the expected and the actual arrays don't match.
 
     This validation **MUST** be instantly run in all cases even during active sync process.
+
+2. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the payload is less than the EIP-4844 activation timestamp.
 
 ### engine_getPayloadV3
 
@@ -115,4 +115,4 @@ Refer to the specification for `engine_getPayloadV2` with addition of the follow
 
 3. The call **MUST** return `blobs` and `proofs` that match the `commitments` list, i.e. `assert len(commitments) == len(blobs) == len(proofs)` and `assert verify_blob_kzg_proof_batch(bundle.blobs, bundle.commitments, bundle.proofs)`.
 
-4. Client software **MUST** return `-32602: Invalid params` error if the `timestamp` of the built payload is less than the EIP-4844 activation timestamp.
+4. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the built payload is less than the EIP-4844 activation timestamp.

--- a/src/engine/experimental/blob-extension.md
+++ b/src/engine/experimental/blob-extension.md
@@ -63,12 +63,12 @@ The fields are encoded as follows:
 
 * method: `engine_newPayloadV3`
 * params:
-  1. [`ExecutionPayloadV1`](../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](../shanghai.md#ExecutionPayloadV2) | [`ExecutionPayloadV3`](#ExecutionPayloadV3), where:
-      - `ExecutionPayloadV1` **MUST** be used if the `timestamp` value is lower than the Shanghai timestamp,
-      - `ExecutionPayloadV2` **MUST** be used if the `timestamp` value is greater or equal to the Shanghai and lower than the EIP-4844 activation timestamp,
-      - `ExecutionPayloadV3` **MUST** be used if the `timestamp` value is greater or equal to the EIP-4844 activation timestamp,
-      - Client software **MUST** return `-32602: Invalid params` error if the wrong version of the structure is used in the method call.
+  1. [`ExecutionPayloadV3`](#ExecutionPayloadV3).
   2. `Array of DATA`, 32 Bytes - Array of blob versioned hashes to validate.
+
+Client software **MUST** enforce the following checks on the parameter set of this call and return `-32602: Invalid params` error if any of them fails:
+* All parameters and their fields are provided with non-`null` values.
+* The payload `timestamp` is greater or equal to the EIP-4844 activation timestamp.
 
 #### Response
 
@@ -99,10 +99,7 @@ and proofs corresponding to the `versioned_hashes` included in the blob transact
 #### Response
 
 * result: `object`
-  - `executionPayload`: [`ExecutionPayloadV1`](../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](../shanghai.md#ExecutionPayloadV2) |  [`ExecutionPayloadV3`](#ExecutionPayloadV3) where:
-    - `ExecutionPayloadV1` **MUST** be returned if the payload `timestamp` is lower than the Shanghai timestamp
-    - `ExecutionPayloadV2` **MUST** be returned if the payload `timestamp` is greater or equal to the Shanghai timestamp and lower than the EIP-4844 activation timestamp
-    - `ExecutionPayloadV3` **MUST** be returned if the payload `timestamp` is greater or equal to the EIP-4844 activation timestamp
+  - `executionPayload`: [`ExecutionPayloadV3`](#ExecutionPayloadV3)
   - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei
   - `blobsBundle`: [`BlobsBundleV1`](#BlobsBundleV1) - Bundle with data corresponding to blob transactions included into `executionPayload`
 * error: code and message set in case an exception happens while getting the payload.
@@ -117,3 +114,5 @@ Refer to the specification for `engine_getPayloadV2` with addition of the follow
    i.e. `assert verify_kzg_commitments_against_transactions(payload.transactions, bundle.commitments)` (see EIP-4844 consensus-specs).
 
 3. The call **MUST** return `blobs` and `proofs` that match the `commitments` list, i.e. `assert len(commitments) == len(blobs) == len(proofs)` and `assert verify_blob_kzg_proof_batch(bundle.blobs, bundle.commitments, bundle.proofs)`.
+
+4. Client software **MUST** return `-32602: Invalid params` error if the `timestamp` of the built payload is less than the EIP-4844 activation timestamp.


### PR DESCRIPTION
This change switched `V3` methods to one method - one structure approach that we have agreed upon in the recent ACDC.

This PR enforces EL client to check that parameters and their fields in `newPayloadV3` aren't `null` and makes the client to respond with error otherwise. Also, a similar validation is applied to the `timestamp` being greater or equal to 4844 activation. This enforcement can protect us from bugs like when CL attempts to send an old payload structure and EL accepts it. Happy to hear more inputs on that.

EDIT: A new `-38005: Unsupported fork` error is introduced to surface the case when a payload is from a fork that is not supported by a method e.g. Shanghai payload is submitted via `newPayloadV3` which minimal supported fork is Cancun.