### PR TITLE
Engine API: Cancun specification 

### DIFF
--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -1,0 +1,106 @@
+# Engine API -- Cancun
+
+Engine API changes introduced in Cancun.
+
+This specificaiton is based on and extends [Engine API - Shanghai](./shanghai.md) specification.
+
+## Table of contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+### ExecutionPayloadV3
+
+This structure has the syntax of `ExecutionPayloadV2` and append two new fields: `dataGasUsed` and `excessDataGas`.
+
+- `parentHash`: `DATA`, 32 Bytes
+- `feeRecipient`:  `DATA`, 20 Bytes
+- `stateRoot`: `DATA`, 32 Bytes
+- `receiptsRoot`: `DATA`, 32 Bytes
+- `logsBloom`: `DATA`, 256 Bytes
+- `prevRandao`: `DATA`, 32 Bytes
+- `blockNumber`: `QUANTITY`, 64 Bits
+- `gasLimit`: `QUANTITY`, 64 Bits
+- `gasUsed`: `QUANTITY`, 64 Bits
+- `timestamp`: `QUANTITY`, 64 Bits
+- `extraData`: `DATA`, 0 to 32 Bytes
+- `baseFeePerGas`: `QUANTITY`, 256 Bits
+- `blockHash`: `DATA`, 32 Bytes
+- `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
+- `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
+- `dataGasUsed`: `QUANTITY`, 64 bits
+- `excessDataGas`: `QUANTITY`, 64 Bits
+
+### BlobsBundleV1
+
+The fields are encoded as follows:
+
+- `commitments`: `Array of DATA` - Array of `KZGCommitment` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), 48 bytes each (`DATA`).
+- `proofs`: `Array of DATA` - Array of `KZGProof` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), 48 bytes each (`DATA`).
+- `blobs`: `Array of DATA` - Array of blobs, each blob is `FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT = 4096 * 32 = 131072` bytes (`DATA`) representing a SSZ-encoded `Blob` as defined in [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
+
+All of the above three arrays **MUST** be of same length.
+
+## Methods
+
+### engine_newPayloadV3
+
+#### Request
+
+* method: `engine_newPayloadV3`
+* params:
+  1. [`ExecutionPayloadV3`](#ExecutionPayloadV3).
+  2. `Array of DATA`, 32 Bytes - Array of blob versioned hashes to validate.
+
+Client software **MUST** return `-32602: Invalid params` error unless all parameters and their fields are provided with non-`null` values.
+
+#### Response
+
+Refer to the response for [`engine_newPayloadV2`](./shanghai.md#engine_newpayloadv2).
+
+#### Specification
+
+This method follows the same specification as [`engine_newPayloadV2`](./shanghai.md#engine_newpayloadv2) with the addition of the following:
+
+1. Given the expected array of blob versioned hashes client software **MUST** run its validation by taking the following steps:
+    1. Obtain an actual array by concatenating blob versioned hashes lists (`tx.blob_versioned_hashes`) of each [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#new-transaction-type) included in the payload, respecting the order of inclusion. If the payload has no blob transactions the expected array **MUST** be `[]`.
+    2. Return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` if the expected and the actual arrays don't match.
+
+    This validation **MUST** be instantly run in all cases even during active sync process.
+
+2. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the payload is less than the Cancun activation timestamp.
+
+### engine_getPayloadV3
+
+The response of this method is extended with [`BlobsBundleV1`](#blobsbundlev1) containing the blobs, their respective KZG commitments
+and proofs corresponding to the `versioned_hashes` included in the blob transactions of the execution payload.
+
+#### Request
+
+* method: `engine_getPayloadV3`
+* params:
+  1. `payloadId`: `DATA`, 8 Bytes - Identifier of the payload build process
+* timeout: 1s
+
+#### Response
+
+* result: `object`
+  - `executionPayload`: [`ExecutionPayloadV3`](#ExecutionPayloadV3)
+  - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei
+  - `blobsBundle`: [`BlobsBundleV1`](#BlobsBundleV1) - Bundle with data corresponding to blob transactions included into `executionPayload`
+* error: code and message set in case an exception happens while getting the payload.
+
+#### Specification
+
+Refer to the specification for [`engine_getPayloadV2`](./shanghai.md#engine_getpayloadv2) with addition of the following:
+
+1. The call **MUST** return empty `blobs`, `commitments` and `proofs` if the payload doesn't contain any blob transactions.
+
+2. The call **MUST** return `commitments` matching the versioned hashes of the transactions list of the execution payload, in the same order,
+   i.e. `assert verify_kzg_commitments_against_transactions(payload.transactions, blobsBundle.commitments)` (see EIP-4844 consensus-specs).
+
+3. The call **MUST** return `blobs` and `proofs` that match the `commitments` list, i.e. `assert len(blobsBundle.commitments) == len(blobsBundle.blobs) == len(blobsBundle.proofs)` and `assert verify_blob_kzg_proof_batch(blobsBundle.blobs, blobsBundle.commitments, blobsBundle.proofs)`.
+
+4. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the built payload is less than the Cancun activation timestamp.

--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -13,7 +13,7 @@ This specificaiton is based on and extends [Engine API - Shanghai](./shanghai.md
 
 ### ExecutionPayloadV3
 
-This structure has the syntax of `ExecutionPayloadV2` and append two new fields: `dataGasUsed` and `excessDataGas`.
+This structure has the syntax of [`ExecutionPayloadV2`](./shanghai.md#executionpayloadv2) and append two new fields: `dataGasUsed` and `excessDataGas`.
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
@@ -96,7 +96,7 @@ and proofs corresponding to the `versioned_hashes` included in the blob transact
 
 Refer to the specification for [`engine_getPayloadV2`](./shanghai.md#engine_getpayloadv2) with addition of the following:
 
-1. The call **MUST** return empty `blobs`, `commitments` and `proofs` if the payload doesn't contain any blob transactions.
+1. The call **MUST** return `blobsBundle` with empty `blobs`, `commitments` and `proofs` if the payload doesn't contain any blob transactions.
 
 2. The call **MUST** return `commitments` matching the versioned hashes of the transactions list of the execution payload, in the same order,
    i.e. `assert verify_kzg_commitments_against_transactions(payload.transactions, blobsBundle.commitments)` (see EIP-4844 consensus-specs).

--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -9,7 +9,22 @@ This specificaiton is based on and extends [Engine API - Shanghai](./shanghai.md
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+- [Structures](#structures)
+  - [ExecutionPayloadV3](#executionpayloadv3)
+  - [BlobsBundleV1](#blobsbundlev1)
+- [Methods](#methods)
+  - [engine_newPayloadV3](#engine_newpayloadv3)
+    - [Request](#request)
+    - [Response](#response)
+    - [Specification](#specification)
+  - [engine_getPayloadV3](#engine_getpayloadv3)
+    - [Request](#request-1)
+    - [Response](#response-1)
+    - [Specification](#specification-1)
+
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Structures
 
 ### ExecutionPayloadV3
 


### PR DESCRIPTION
Introduces Cancun specification with the scope of changes defined in [`blob-extension.md`](https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md).

TODO:
* [ ] Add `engine_exchangeTransitionConfigurationV1` deprecation notice
* [ ] Add new methods to schema