### PR TITLE
fix: incorrect hex EIP-191 regex length

### DIFF
--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -34,7 +34,7 @@ bytes256:
 bytes65:
   title: 65 hex encoded bytes
   type: string
-  pattern: ^0x[0-9a-f]{65}$
+  pattern: ^0x[0-9a-f]{130}$
 uint:
   title: hex encoded unsigned integer
   type: string


### PR DESCRIPTION
## Reasoning

65 bytes is represented as a 130 character hex, not 65 characters.

### Changelog

Before:
![Screenshot 2023-06-13 at 9 50 08 PM](https://github.com/ethereum/execution-apis/assets/14638987/f0c325c7-c7ec-4d18-b722-91133a409587)

After:
![Screenshot 2023-06-13 at 9 49 05 PM](https://github.com/ethereum/execution-apis/assets/14638987/18f284cc-c00f-4582-ada9-ff130ae312e8)


