### PR TITLE
Rebase eip6110 to Cancun

### DIFF
--- a/src/engine/experimental/eip6110.md
+++ b/src/engine/experimental/eip6110.md
@@ -8,7 +8,7 @@ Engine API changes introduced in EIP-6110, based on [Cancun](../cancun.md).
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Structures](#structures)
-  - [DepositV1](#depositv1)
+  - [DepositReceiptV1](#depositreceiptv1)
   - [ExecutionPayloadV6110](#executionpayloadv6110)
 - [Methods](#methods)
   - [`engine_newPayloadV6110`](#engine_newpayloadv6110)
@@ -24,7 +24,7 @@ Engine API changes introduced in EIP-6110, based on [Cancun](../cancun.md).
 
 ## Structures
 
-### DepositV1
+### DepositReceiptV1
 This structure maps onto the deposit object from [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
 The fields are encoded as follows:
 
@@ -38,7 +38,7 @@ The fields are encoded as follows:
 
 ### ExecutionPayloadV6110
 
-This structure has the syntax of [`ExecutionPayloadV3`](../cancun.md#executionpayloadv2) and appends a single field: `deposits`.
+This structure has the syntax of [`ExecutionPayloadV3`](../cancun.md#executionpayloadv2) and appends a single field: `depositReceipts`.
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
@@ -57,7 +57,7 @@ This structure has the syntax of [`ExecutionPayloadV3`](../cancun.md#executionpa
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
 - `dataGasUsed`: `QUANTITY`, 64 bits
 - `excessDataGas`: `QUANTITY`, 64 Bits
-- `deposits`: `Array of DepositV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositV1` structure.
+- `depositReceipts`: `Array of DepositReceiptV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositReceiptV1` structure.
 
 ## Methods
 

--- a/src/engine/experimental/eip6110.md
+++ b/src/engine/experimental/eip6110.md
@@ -38,7 +38,7 @@ The fields are encoded as follows:
 
 ### ExecutionPayloadV6110
 
-This structure has the syntax of [`ExecutionPayloadV3`](../cancun.md#executionpayloadv2) and appends a single field: `depositReceipts`.
+This structure has the syntax of [`ExecutionPayloadV3`](../cancun.md#executionpayloadv3) and appends a single field: `depositReceipts`.
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes

--- a/src/engine/experimental/eip6110.md
+++ b/src/engine/experimental/eip6110.md
@@ -1,6 +1,6 @@
 # Engine API -- EIP-6110
 
-Engine API changes introduced in EIP-6110, based on [Shanghai](../shanghai.md).
+Engine API changes introduced in EIP-6110, based on [Cancun](../cancun.md).
 
 ## Table of contents
 
@@ -11,10 +11,14 @@ Engine API changes introduced in EIP-6110, based on [Shanghai](../shanghai.md).
   - [DepositV1](#depositv1)
   - [ExecutionPayloadV6110](#executionpayloadv6110)
 - [Methods](#methods)
-  - [Modified `engine_newPayloadV2`](#modified-engine_newpayloadv2)
+  - [`engine_newPayloadV6110`](#engine_newpayloadv6110)
     - [Request](#request)
-  - [Modified `engine_getPayloadV2`](#modified-engine_getpayloadv2)
     - [Response](#response)
+    - [Specification](#specification)
+  - [`engine_getPayloadV6110`](#engine_getpayloadv6110)
+    - [Request](#request-1)
+    - [Response](#response-1)
+    - [Specification](#specification-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -34,7 +38,7 @@ The fields are encoded as follows:
 
 ### ExecutionPayloadV6110
 
-This structure has the syntax of [`ExecutionPayloadV2`](../shanghai.md#executionpayloadv2) and appends a single field: `deposits`.
+This structure has the syntax of [`ExecutionPayloadV3`](../cancun.md#executionpayloadv2) and appends a single field: `deposits`.
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
@@ -51,35 +55,49 @@ This structure has the syntax of [`ExecutionPayloadV2`](../shanghai.md#execution
 - `blockHash`: `DATA`, 32 Bytes
 - `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
+- `dataGasUsed`: `QUANTITY`, 64 bits
+- `excessDataGas`: `QUANTITY`, 64 Bits
 - `deposits`: `Array of DepositV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositV1` structure.
 
 ## Methods
 
-### Modified `engine_newPayloadV2`
-
-*Note:* The input parameter type is extended with [`ExecutionPayloadV6110`](#ExecutionPayloadV6110),
-everything else remains identical to [`engine_newPayloadV2`](../shanghai.md#engine_newpayloadv2) specification.
+### `engine_newPayloadV6110`
 
 #### Request
 
-* method: `engine_newPayloadV2`
+* method: `engine_newPayloadV6110`
 * params:
-  1. [`ExecutionPayloadV1`](../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](../shanghai.md#ExecutionPayloadV2) | [`ExecutionPayloadV6110`](#ExecutionPayloadV6110), where:
-      - `ExecutionPayloadV1` **MUST** be used if the `timestamp` value is lower than the Shanghai timestamp,
-      - `ExecutionPayloadV2` **MUST** be used if the `timestamp` value is lower than the EIP-6110 activation timestamp,
-      - `ExecutionPayloadV6110` **MUST** be used if the `timestamp` value is greater than or equal to the EIP-6110 activation timestamp,
-      - Client software **MUST** return `-32602: Invalid params` error if the wrong version of the structure is used in the method call.
+  1. `executionPayload`: [`ExecutionPayloadV6110`](#ExecutionPayloadV6110).
+  2. `expectedBlobVersionedHashes`: `Array of DATA`, 32 Bytes - Array of expected blob versioned hashes to validate.
+  3. `parentBeaconBlockRoot`: `DATA`, 32 Bytes - Root of the parent beacon block.
+* timeout: 1s
 
-### Modified `engine_getPayloadV2`
+#### Response
 
-*Note:* The input parameter type is extended with [`ExecutionPayloadV6110`](#ExecutionPayloadV6110),
-everything else remains identical to [`engine_getPayloadV2`](../shanghai.md#engine_getpayloadv2) specification.
+Refer to the response for [`engine_newPayloadV3`](../cancun.md#engine_newpayloadv3).
+
+#### Specification
+
+This method follows the same specification as [`engine_newPayloadV3`](../cancun.md#engine_newpayloadv3) with the following changes:
+
+1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the payload is less than the timestamp of EIP-6110 activation.
+
+### `engine_getPayloadV6110`
+
+#### Request
+
+Refer to the request for [`engine_getPayloadV3`](../cancun.md#engine_getPayloadV3).
 
 #### Response
 
 * result: `object`
-  - `executionPayload`: [`ExecutionPayloadV1`](../paris.md#ExecutionPayloadV1) | [`ExecutionPayloadV2`](../shanghai.md#ExecutionPayloadV2) | [`ExecutionPayloadV6110`](#ExecutionPayloadV6110) where:
-      - `ExecutionPayloadV1` **MUST** be returned if the payload `timestamp` is lower than the Shanghai timestamp,
-      - `ExecutionPayloadV2` **MUST** be returned if the payload `timestamp` is lower than the EIP-6110 activation timestamp,
-      - `ExecutionPayloadV6110` **MUST** be returned if the payload `timestamp` is greater than or equal to the EIP-6110 activation timestamp.
+  - `executionPayload`: [`ExecutionPayloadV6110`](#ExecutionPayloadV6110)
   - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei
+  - `blobsBundle`: [`BlobsBundleV1`](../cancun.md#BlobsBundleV1) - Bundle with data corresponding to blob transactions included into `executionPayload`
+* error: code and message set in case an exception happens while getting the payload.
+
+#### Specification
+
+This method follows the same specification as [`engine_newPayloadV3`](../cancun.md#engine_newpayloadv3) with the following changes:
+
+1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the built payload is less than the timestamp of EIP-6110 activation.


### PR DESCRIPTION
* adjusts `ExecutionPayloadV6110`  with `ExecutionPayloadV3`
* adds `newPayloadV6110` and `getPayloadV6110` methods instead of modified `V2` methods