### PR TITLE
Move parentBeaconBlockRoot to execution payload

### DIFF
--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -53,6 +53,7 @@ This structure has the syntax of [`ExecutionPayloadV2`](./shanghai.md#executionp
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
 - `dataGasUsed`: `QUANTITY`, 64 bits
 - `excessDataGas`: `QUANTITY`, 64 Bits
+- `parentBeaconBlockRoot`: `DATA`, 32 Bytes
 
 ### BlobsBundleV1
 
@@ -84,7 +85,6 @@ This structure has the syntax of [`PayloadAttributesV2`](./shanghai.md#payloadat
 * params:
   1. `executionPayload`: [`ExecutionPayloadV3`](#ExecutionPayloadV3).
   2. `expectedBlobVersionedHashes`: `Array of DATA`, 32 Bytes - Array of expected blob versioned hashes to validate.
-  3. `parentBeaconBlockRoot`: `DATA`, 32 Bytes - Root of the parent beacon block.
 
 Client software **MUST** return `-32602: Invalid params` error unless all parameters and their fields are provided with non-`null` values.
 


### PR DESCRIPTION
a simplification which allows execution block to be reconstructed entirely based on execution payload

 ref: - https://github.com/ethereum/consensus-specs/pull/3454