### PR TITLE
eth: block difficulty should be uint

### DIFF
--- a/src/schemas/block.yaml
+++ b/src/schemas/block.yaml
@@ -48,7 +48,7 @@ Block:
       $ref: '#/components/schemas/bytes256'
     difficulty:
       title: Difficulty
-      $ref: '#/components/schemas/bytes'
+      $ref: '#/components/schemas/uint'
     number:
       title: Number
       $ref: '#/components/schemas/uint'


### PR DESCRIPTION
(partially) fixes #102

Currently specified to be `bytes`, but the original spec listed it as `QUANTITY`.