### PR TITLE
eth: add gas price field to 1559 txs

### DIFF
--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -25,6 +25,7 @@ Transaction1559Unsigned:
     - input
     - maxFeePerGas
     - maxPriorityFeePerGas
+    - gasPrice
     - chainId
     - accessList
   properties:
@@ -55,6 +56,9 @@ Transaction1559Unsigned:
       title: max fee per gas
       description: The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei
       $ref: '#/components/schemas/uint'
+    gasPrice:
+      title: gas price
+      description: The effective gas price paid by the sender in wei. For transactions not yet mined, this value should be set equal to the max fee cap per gas. This field is DEPRECATED, please transition to using effectiveGasPrice in the receipt object going forward.
     accessList:
       title: accessList
       description: EIP-2930 access list

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -58,7 +58,7 @@ Transaction1559Unsigned:
       $ref: '#/components/schemas/uint'
     gasPrice:
       title: gas price
-      description: The effective gas price paid by the sender in wei. For transactions not yet included in a block, this value should be set equal to the max fee cap per gas. This field is DEPRECATED, please transition to using effectiveGasPrice in the receipt object going forward.
+      description: The effective gas price paid by the sender in wei. For transactions not yet included in a block, this value should be set equal to the max fee per gas. This field is DEPRECATED, please transition to using effectiveGasPrice in the receipt object going forward.
     accessList:
       title: accessList
       description: EIP-2930 access list

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -58,7 +58,7 @@ Transaction1559Unsigned:
       $ref: '#/components/schemas/uint'
     gasPrice:
       title: gas price
-      description: The effective gas price paid by the sender in wei. For transactions not yet mined, this value should be set equal to the max fee cap per gas. This field is DEPRECATED, please transition to using effectiveGasPrice in the receipt object going forward.
+      description: The effective gas price paid by the sender in wei. For transactions not yet included in a block, this value should be set equal to the max fee cap per gas. This field is DEPRECATED, please transition to using effectiveGasPrice in the receipt object going forward.
     accessList:
       title: accessList
       description: EIP-2930 access list


### PR DESCRIPTION
fixes #80 

Before the spec moved to this repository, we agreed to include `gasPrice` for EIP-1559 txs as a deprecated field to aid in the transition for tooling. I believe most clients have implemented it this way. Geth has [here](https://github.com/ethereum/go-ethereum/blob/d4d88f9bce13ca9310bf28f5f26ea9f1915ba90d/internal/ethapi/api.go#L1422-L1428).