### PR TITLE
eth: remove methods to retrieve uncle counts

### DIFF
--- a/src/eth/block.yaml
+++ b/src/eth/block.yaml
@@ -50,23 +50,3 @@
     name: Transaction count
     schema:
       $ref: '#/components/schemas/uint'
-- name: eth_getUncleCountByBlockHash
-  summary: Returns the number of uncles in a block from a block matching the given block hash.
-  params:
-    - name: Block hash
-      schema:
-        $ref: '#/components/schemas/hash32'
-  result:
-    name: Uncle count
-    schema:
-      $ref: '#/components/schemas/uint'
-- name: eth_getUncleCountByBlockNumber
-  summary: Returns the number of transactions in a block matching the given block number.
-  params:
-    - name: Block
-      schema:
-        $ref: '#/components/schemas/BlockNumberOrTag'
-  result:
-    name: Uncle count
-    schema:
-      $ref: '#/components/schemas/uint'


### PR DESCRIPTION
fixes (by avoidance) #114 

Removes the following methods related to uncle counts:
* eth_getUncleCountByBlockHash
* eth_getUncleCountByBlockNumber

Post-merge, methods related to uncles don't make much sense since per EIP-3675 it is not possible for a block to have ommers (uncles).