### PR TITLE
eth: add optional v value for 2930 and 1559 txs

### DIFF
--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -165,6 +165,10 @@ Transaction1559Signed:
           title: yParity
           description: The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.
           $ref: '#/components/schemas/uint'
+        v:
+          title: v
+          description: For backwards compatibility, `v` is also optionally provided. This field is DEPRECATED and all use of it should migrate to `yParity`.
+          $ref: '#/components/schemas/uint'
         r:
           title: r
           $ref: '#/components/schemas/uint'
@@ -185,6 +189,10 @@ Transaction2930Signed:
         yParity:
           title: yParity
           description: The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.
+          $ref: '#/components/schemas/uint'
+        v:
+          title: v
+          description: For backwards compatibility, `v` is also optionally provided. This field is DEPRECATED and all use of it should migrate to `yParity`.
           $ref: '#/components/schemas/uint'
         r:
           title: r

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -167,7 +167,7 @@ Transaction1559Signed:
           $ref: '#/components/schemas/uint'
         v:
           title: v
-          description: For backwards compatibility, `v` is also optionally provided. This field is DEPRECATED and all use of it should migrate to `yParity`.
+          description: For backwards compatibility, `v` is optionally provided as an alternative to `yParity`. This field is DEPRECATED and all use of it should migrate to `yParity`.
           $ref: '#/components/schemas/uint'
         r:
           title: r
@@ -192,7 +192,7 @@ Transaction2930Signed:
           $ref: '#/components/schemas/uint'
         v:
           title: v
-          description: For backwards compatibility, `v` is also optionally provided. This field is DEPRECATED and all use of it should migrate to `yParity`.
+          description: For backwards compatibility, `v` is optionally provided as an alternative to `yParity`. This field is DEPRECATED and all use of it should migrate to `yParity`.
           $ref: '#/components/schemas/uint'
         r:
           title: r


### PR DESCRIPTION
It looks like many clients are currently either not returning `yParity` or returning both `v` and `yParity`. To align the spec with this, I'm proposing we add an optional (but deprected) `v` value for 2930 and 1559 txs. This way clients can continue use it and tooling can have some space to upgrade to `yParity`.