### PR TITLE
Clarify the place of payloadAttributes check against Cancun timeframes

### DIFF
--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -124,7 +124,7 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV2`](./s
 
 1. Client software **MUST** check that provided set of parameters and their fields strictly matches the expected one and return `-32602: Invalid params` error if this check fails. Any field having `null` value **MUST** be considered as not provided.
 
-2. Client software **MUST** return `-38005: Unsupported fork` error if the `payloadAttributes` is set and the `payloadAttributes.timestamp` does not fall within the time frame of the Cancun fork.
+2. Client software **MUST** return `-38005: Unsupported fork` error if the `payloadAttributes` is set and the `payloadAttributes.timestamp` does not fall within the time frame of the Cancun fork. Client software **MUST** run this check after applying the forkchoice state and, if the check fails, the forkchoice state update **MUST NOT** be rolled back.
 
 ### engine_getPayloadV3
 


### PR DESCRIPTION
Explicitly state that checking `payloadAttributes.timestamp` against Cancun time frames must be run after applying the forkchoice state and the result of the check must not affect the forkchoice update.

cc @LukaszRozmej @marioevz 