### PR TITLE
engine: clarify order of operation for fcu v3

### DIFF
--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -122,9 +122,11 @@ Refer to the response for [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_fo
 
 This method follows the same specification as [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_forkchoiceupdatedv2) with addition of the following:
 
-1. Client software **MUST** check that provided set of parameters and their fields strictly matches the expected one and return `-32602: Invalid params` error if this check fails. Any field having `null` value **MUST** be considered as not provided.
+1. Client software **MUST** validate and apply the forkchoice state before validating `payloadAttributes`. If `forkchoiceState` does not match the expected fields, clients must return `-32602: Invalid params`.
 
-2. Client software **MUST** return `-38005: Unsupported fork` error if the `payloadAttributes` is set and the `payloadAttributes.timestamp` does not fall within the time frame of the Cancun fork.
+2. Client software **MUST** check that `payloadAttributes` strictly matches the expected fields and return `-38003: Invalid payload attributes` error if this check fails. Any field having `null` value **MUST** be considered as not provided.
+
+3. Client software **MUST** return `-38005: Unsupported fork` error if the `payloadAttributes` is set and the `payloadAttributes.timestamp` does not fall within the time frame of the Cancun fork.
 
 ### engine_getPayloadV3
 

--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -122,7 +122,7 @@ Refer to the response for [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_fo
 
 This method follows the same specification as [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_forkchoiceupdatedv2) with addition of the following:
 
-1. Client software **MUST** validate and apply the forkchoice state before validating `payloadAttributes`. If `forkchoiceState` does not match the expected fields, clients must return `-32602: Invalid params`.
+1. Client software **MUST** validate and apply the forkchoice state before validating `payloadAttributes`. If `forkchoiceState` does not match the expected fields, clients must return `-32602: Invalid params`. If the client is `SYNCING` it **MUST** skip the validation of `payloadAttributes`.
 
 2. Client software **MUST** check that `payloadAttributes` strictly matches the expected fields and return `-38003: Invalid payload attributes` error if this check fails. Any field having `null` value **MUST** be considered as not provided.
 

--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -128,6 +128,8 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV2`](./s
 
 3. Client software **MUST** return `-38005: Unsupported fork` error if the `payloadAttributes` is set and the `payloadAttributes.timestamp` does not fall within the time frame of the Cancun fork.
 
+4. Client software **MUST** return `-38003: Invalid payload attributes` if the `payloadAttributes.timestamp` is less or equal to the timestamp of a block referenced by `forkchoiceState.headBlockHash`.
+
 ### engine_getPayloadV3
 
 The response of this method is extended with [`BlobsBundleV1`](#blobsbundlev1) containing the blobs, their respective KZG commitments


### PR DESCRIPTION
I took a stab at making change c) as described by @mkalinin in this comment: https://github.com/ethereum/execution-apis/pull/476#discussion_r1353990085

A few random thoughts I have on this:
* On the surface seems good, however depending on implementation **MUST** may cause a fair bit of additional complexity (at least for geth). If a request is missing the required V1 param fields, we will fail early in the json-rpc handling due to unmarshal failure. In fact, I don't think we have ever returned the correct error for that. It's only if new non-V1-required fields where we do the checks in the actual method handling. Not sure how it is for others, but I have to imagine that an extremely malformed `payloadAttributes` will cause problems for most clients early on in the method handling (before applying fcu).
* Is this clarification even that useful? It is probably a bit more optimal, but even if forkchoice isn't applied when there are invalid payload attributes, it will be applied on the next block. And the CL should never even send this malformed data in the first place.