### PR TITLE
engine: skip fcU only when the ancestor of the canonical head is VALID

### DIFF
--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -204,7 +204,7 @@ The payload build process is specified as follows:
 
 1. Client software **MAY** initiate a sync process if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because data that are requisite for the validation is missing. The sync process is specified in the [Sync](#sync) section.
 
-2. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` references an ancestor of the head of canonical chain. In the case of such an event, client software **MUST** return `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`.
+2. Client software **MAY** skip an update of the forkchoice state and **MUST NOT** begin a payload build process if `forkchoiceState.headBlockHash` references a `VALID` ancestor of the head of canonical chain, i.e. the ancestor passed [payload validation](#payload-validation) process and deemed `VALID`. In the case of such an event, client software **MUST** return `{payloadStatus: {status: VALID, latestValidHash: forkchoiceState.headBlockHash, validationError: null}, payloadId: null}`.
 
 3. If `forkchoiceState.headBlockHash` references a PoW block, client software **MUST** validate this block with respect to terminal block conditions according to [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#transition-block-validity). This check maps to the transition block validity section of the EIP. Additionally, if this validation fails, client software **MUST NOT** update the forkchoice state and **MUST NOT** begin a payload build process.
 


### PR DESCRIPTION
Clarifies EL’s behaviour in the following case mentioned by @potuz:
1) NewPayload 6 -> SYNCING
2) FCU 6 -> INVALID, LVH:5
Some CL MAY send FCU: 5 in this case. Edit: Prysm will send here in most cases too

EL must update its forkchoice state when FCU: 5 is sent.

The skip was originally introduced to handle a scenario when CL is syncing from scratch while EL was fully synced up to some moment in the past. This fix is related to the online mode when a node is fully sync and doesn’t affect the original scenario.

cc @marioevz it would be great to have a test covering this scenario some time after the PR gets merged
