### PR TITLE
disallow `VALID` <-> `INVALID` equivocation

### DIFF
--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -111,7 +111,7 @@ Payload validation process consists of validating a payload with respect to the 
       payload satisfying the above conditions.
   * Client software **MUST NOT** surface an `INVALID` payload over any API endpoint and p2p interface.
 
-4. Client software **MUST** not classify the same payload as either both `INVALID` and `VALID` or `INVALID_BLOCK_HASH` and `VALID`.
+4. Payload validation process **MUST** be idempotent with respect to payload's validity status (`VALID | INVALID`), i.e. a payload which validity status is `INVALID (INVALID_BLOCK_HASH)` **MUST NOT** become `VALID` and vice versa at any point in time when it subsequently runs through the validation process. Client software **MAY** change payload status from `INVALID` to `SYNCING | ACCEPTED` as long as the payload remains `INVALID` as a result of any further run of the validation process.
 
 5. Client software **MAY** provide additional details on the validation error if a payload is deemed `INVALID` by assigning the corresponding message to the `validationError` field.
 

--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -111,9 +111,11 @@ Payload validation process consists of validating a payload with respect to the 
       payload satisfying the above conditions.
   * Client software **MUST NOT** surface an `INVALID` payload over any API endpoint and p2p interface.
 
-4. Client software **MAY** provide additional details on the validation error if a payload is deemed `INVALID` by assigning the corresponding message to the `validationError` field.
+4. Client software **MUST** not classify the same payload as either both `INVALID` and `VALID` or `INVALID_BLOCK_HASH` and `VALID`.
 
-5. The process of validating a payload on the canonical chain **MUST NOT** be affected by an active sync process on a side branch of the block tree. For example, if side branch `B` is `SYNCING` but the requisite data for validating a payload from canonical branch `A` is available, client software **MUST** run full validation of the payload and respond accordingly.
+5. Client software **MAY** provide additional details on the validation error if a payload is deemed `INVALID` by assigning the corresponding message to the `validationError` field.
+
+6. The process of validating a payload on the canonical chain **MUST NOT** be affected by an active sync process on a side branch of the block tree. For example, if side branch `B` is `SYNCING` but the requisite data for validating a payload from canonical branch `A` is available, client software **MUST** run full validation of the payload and respond accordingly.
 
 ### Sync
 


### PR DESCRIPTION
This essentially copies over https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/sync/optimistic.md#transitioning-from-valid---invalidated-or-invalidated---valid into more execution-layer specs.

The current specs don't use a verb much to describe the specific process of determination of `VALID`, et cetera, but more the whole response construction. The one time I could find they unambiguously do, that verb is "classify", so went with that.

The intent here is to disallow this equivocation even over time, i.e. for any given `newPayload` or fcU, by construction it can't equivocate, and simply being incorrect indefinitely is not great either, but then that EL is just broken, in more significant ways.

The harm/fallout/externality that's resulting from this is exactly that for basically ephemeral reasons, ELs are responding `INVALID`, then `VALID`, but by then from a CL perspective it can be too late.

Phrasing it this way avoids reference to some ground truth state, requiring only relative comparisons and constraints.