### PR TITLE
engine: clarify `payloadAttributes` checks and fcu v3 processing flow

### DIFF
--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -120,11 +120,19 @@ Refer to the response for [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_fo
 
 #### Specification
 
-This method follows the same specification as [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_forkchoiceupdatedv2) with addition of the following:
+This method follows the same specification as [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_forkchoiceupdatedv2) with the following changes to the processing flow:
 
-1. Client software **MUST** check that provided set of parameters and their fields strictly matches the expected one and return `-32602: Invalid params` error if this check fails. Any field having `null` value **MUST** be considered as not provided.
+1. Client software **MUST** verify that `forkchoiceState` matches the expected fields and return `-32602: Invalid params` on failure.
 
-2. Client software **MUST** return `-38005: Unsupported fork` error if the `payloadAttributes` is set and the `payloadAttributes.timestamp` does not fall within the time frame of the Cancun fork.
+2. Extend point (7) of the `engine_forkchoiceUpdatedV1` [specification](./paris.md#specification-1) by defining the following sequence of checks that **MUST** be run over `payloadAttributes`:
+
+    1. `payloadAttributes` matches the expected fields, return `-38003: Invalid payload attributes` on failure.
+
+    2. `payloadAttributes.timestamp` falls within the time frame of the Cancun fork, return `-38005: Unsupported fork` on failure.
+
+    3. `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by `forkchoiceState.headBlockHash`, return `-38003: Invalid payload attributes` on failure.
+
+    4. If any of the above checks fails, the `forkchoiceState` update **MUST NOT** be rolled back.
 
 ### engine_getPayloadV3
 

--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -122,11 +122,11 @@ Refer to the response for [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_fo
 
 This method follows the same specification as [`engine_forkchoiceUpdatedV2`](./shanghai.md#engine_forkchoiceupdatedv2) with the following changes to the processing flow:
 
-1. Client software **MUST** verify that `forkchoiceState` matches the expected fields and return `-32602: Invalid params` on failure.
+1. Client software **MUST** verify that `forkchoiceState` matches the [`ForkchoiceStateV1`](./paris.md#ForkchoiceStateV1) structure and return `-32602: Invalid params` on failure.
 
 2. Extend point (7) of the `engine_forkchoiceUpdatedV1` [specification](./paris.md#specification-1) by defining the following sequence of checks that **MUST** be run over `payloadAttributes`:
 
-    1. `payloadAttributes` matches the expected fields, return `-38003: Invalid payload attributes` on failure.
+    1. `payloadAttributes` matches the [`PayloadAttributesV3`](#payloadattributesv3) structure, return `-38003: Invalid payload attributes` on failure.
 
     2. `payloadAttributes.timestamp` falls within the time frame of the Cancun fork, return `-38005: Unsupported fork` on failure.
 

--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -216,11 +216,15 @@ The payload build process is specified as follows:
 
 6. Client software **MUST** return `-38002: Invalid forkchoice state` error if the payload referenced by `forkchoiceState.headBlockHash` is `VALID` and a payload referenced by either `forkchoiceState.finalizedBlockHash` or `forkchoiceState.safeBlockHash` does not belong to the chain defined by `forkchoiceState.headBlockHash`.
 
-7. Client software **MUST** ensure that `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by `forkchoiceState.headBlockHash`. If this condition isn't held client software **MUST** respond with `-38003: Invalid payload attributes` and **MUST NOT** begin a payload build process. In such an event, the `forkchoiceState` update **MUST NOT** be rolled back.
+7. Client software **MUST** process provided `payloadAttributes` after successfully applying the `forkchoiceState` and only if the payload referenced by `forkchoiceState.headBlockHash` is `VALID`. The processing flow is as follows:
 
-8. Client software **MUST** begin a payload build process building on top of `forkchoiceState.headBlockHash` and identified via `buildProcessId` value if `payloadAttributes` is not `null` and the forkchoice state has been updated successfully. The build process is specified in the [Payload building](#payload-building) section.
+    1. Verify that `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by `forkchoiceState.headBlockHash` and return `-38003: Invalid payload attributes` on failure.
 
-9. Client software **MUST** respond to this method call in the following way:
+    2. If `payloadAttributes` passes all valdiation steps, begin a payload build process building on top of `forkchoiceState.headBlockHash` and identified via `buildProcessId` value. The build process is specified in the [Payload building](#payload-building) section.
+
+    3. If `payloadAttributes` validation fails, the `forkchoiceState` update **MUST NOT** be rolled back.
+
+8. Client software **MUST** respond to this method call in the following way:
   * `{payloadStatus: {status: SYNCING, latestValidHash: null, validationError: null}, payloadId: null}` if `forkchoiceState.headBlockHash` references an unknown payload or a payload that can't be validated because requisite data for the validation is missing
   * `{payloadStatus: {status: INVALID, latestValidHash: validHash, validationError: errorMessage | null}, payloadId: null}` obtained from the [Payload validation](#payload-validation) process if the payload is deemed `INVALID`
   * `{payloadStatus: {status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000, validationError: errorMessage | null}, payloadId: null}` obtained either from the [Payload validation](#payload-validation) process or as a result of validating a terminal PoW block referenced by `forkchoiceState.headBlockHash`


### PR DESCRIPTION
This PR incorporates changes proposed by https://github.com/ethereum/execution-apis/pull/476, https://github.com/ethereum/execution-apis/pull/479 and results from the conversations happening in-person during the DevConnect and in the Discord after the event.

The list of proposed changes:
1. Update fcu v1 spec to explicitly state that `payloadAttributes` validations and build process can only be run after `forkchoiceState` is processed and only if the `head` is `VALID` implying that if a client is `SYNCING` no `payloadAttributes` validations are run.
2. State that `forkchoiceState` fields must be validated before any processing starts with the corresponding error on failure.
3. Define a new sequence of `payloadAttributes` checks that must be run *after applying the fork choice state*.
  The first step of this sequence is to verify that `payloadAttributes` matches the expected fields and return `-38003: Invalid payload attributes` on failure. This step is what can cause additional engineering efforts on EL side. The problem here is that EL clients define `PayloadAttributesV1` fields as required and if any of them is missed then the method will return with an error before processing the `forkchoiceState`, this behaviour would contradict the proposed change. cc @jflo @lightclient @MarekM25 @yperbasis

Hive test scenarios covering `forkchoiceState` and `payloadAttributes` checks should be validated when this PR gets merged. cc @marioevz 

Supersedes https://github.com/ethereum/execution-apis/pull/476 https://github.com/ethereum/execution-apis/pull/479