### PR TITLE
eth: add eth_fillTransaction, fix result of eth_signTransaction

### DIFF
--- a/src/eth/fill.yaml
+++ b/src/eth/fill.yaml
@@ -1,0 +1,11 @@
+- name: eth_fillTransaction
+  summary: Fills in missing transaction fields to be signed and submitted.
+  params:
+    - name: Transaction
+      required: true
+      schema:
+        $ref: '#/components/schemas/GenericTransaction'
+  result:
+    name: Transaction result
+    schema:
+      $ref: '#/components/schemas/FillTransactionResult'

--- a/src/eth/sign.yaml
+++ b/src/eth/sign.yaml
@@ -21,6 +21,6 @@
       schema:
         $ref: '#/components/schemas/GenericTransaction'
   result:
-    name: Encoded transaction
+    name: Transaction result
     schema:
-      $ref: '#/components/schemas/bytes'
+      $ref: '#/components/schemas/SignTransactionResult'

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -59,6 +59,33 @@ Transaction4844Unsigned:
       title: chainId
       description: Chain ID that this transaction is valid on.
       $ref: '#/components/schemas/uint'
+Transaction4844UnsignedWithSidecar:
+  title: Unsigned 4844 transaction with sidecar
+  type: object
+  allOf:
+    - $ref: '#/components/schemas/Transaction4844Unsigned'
+    - title: EIP-4844 transaction signature properties.
+      required:
+        - blobs
+        - commitments
+        - proofs
+      properties:
+        blobs:
+          title: blobs
+          description: Raw blob data.
+          type: array
+          items:
+            $ref: '#/components/schemas/bytes'
+        commitments:
+          title: Blob commitments.
+          type: array
+          items:
+            $ref: '#/components/schemas/bytes'
+        proofs:
+          title: Blob proofs.
+          type: array
+          items:
+            $ref: '#/components/schemas/bytes'
 AccessListEntry:
   title: Access list entry
   type: object
@@ -417,6 +444,18 @@ GenericTransaction:
       type: array
       items:
         $ref: '#/components/schemas/bytes'
+    commitments:
+      title: commitments
+      description: List of blob commitments as per EIP-4844.
+      type: array
+      items:
+        $ref: '#/components/schemas/bytes'
+    proofs:
+      title: proofs
+      description: List of blob proofs as per EIP-4844.
+      type: array
+      items:
+        $ref: '#/components/schemas/bytes'
     chainId:
       title: chainId
       description: Chain ID that this transaction is valid on.
@@ -434,6 +473,13 @@ SignTransactionResult:
     tx:
       title: tx
       $ref: '#/components/schemas/TransactionSigned'
+FilledTransaction:
+  oneOf:
+    - $ref: '#/components/schemas/Transaction4844UnsignedWithSidecar'
+    - $ref: '#/components/schemas/Transaction4844Unsigned'
+    - $ref: '#/components/schemas/Transaction1559Unsigned'
+    - $ref: '#/components/schemas/Transaction2930Unsigned'
+    - $ref: '#/components/schemas/TransactionLegacyUnsigned'
 FillTransactionResult:
   type: object
   title: Encoded and raw unsigned transaction object.
@@ -446,4 +492,4 @@ FillTransactionResult:
       $ref: '#/components/schemas/byte'
     tx:
       title: tx
-      $ref: '#/components/schemas/TransactionUnsigned'
+      $ref: '#/components/schemas/FilledTransaction'

--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -421,3 +421,29 @@ GenericTransaction:
       title: chainId
       description: Chain ID that this transaction is valid on.
       $ref: '#/components/schemas/uint'
+SignTransactionResult:
+  type: object
+  title: Encoded and raw signed transaction object.
+  required:
+    - raw
+    - tx
+  properties:
+    raw:
+      title: raw
+      $ref: '#/components/schemas/byte'
+    tx:
+      title: tx
+      $ref: '#/components/schemas/TransactionSigned'
+FillTransactionResult:
+  type: object
+  title: Encoded and raw unsigned transaction object.
+  required:
+    - raw
+    - tx
+  properties:
+    raw:
+      title: raw
+      $ref: '#/components/schemas/byte'
+    tx:
+      title: tx
+      $ref: '#/components/schemas/TransactionUnsigned'


### PR DESCRIPTION
Fixes https://github.com/ethereum/execution-apis/issues/508

While adding spec for eth_fillTransaction I noticed that the spec for eth_signTransaction deviates from the geth implementation. I'm not sure yet how other clients implement this.