### PR TITLE
Specify Client Versions on Engine API

### DIFF
--- a/src/engine/common.md
+++ b/src/engine/common.md
@@ -44,11 +44,6 @@ the client **MUST** also expose the following subset of `eth` methods:
 * `eth_sendRawTransaction`
 * `eth_syncing`
 
-To facilitate a more accurate measurement of execution layer client diversity statistics, the client **SHOULD** also expose
-the following `web3` method:
-
-* `web3_clientVersion`
-
 These methods are described in [Ethereum JSON-RPC Specification][json-rpc-spec].
 
 ### Authentication

--- a/src/engine/common.md
+++ b/src/engine/common.md
@@ -44,6 +44,11 @@ the client **MUST** also expose the following subset of `eth` methods:
 * `eth_sendRawTransaction`
 * `eth_syncing`
 
+To facilitate a more accurate measurement of execution layer client diversity statistics, the client **SHOULD** also expose
+the following `web3` method:
+
+* `web3_clientVersion`
+
 These methods are described in [Ethereum JSON-RPC Specification][json-rpc-spec].
 
 ### Authentication

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -12,7 +12,7 @@ Engine API structures and methods specified for client version specification.
   - [ClientCode](#clientcode)
   - [ClientVersionV1](#clientversionv1)
 - [Methods](#methods)
-  - [engine_clientVersionV1](#engine_clientversionv1)
+  - [engine_getClientVersionV1](#engine_getclientversionv1)
     - [Request](#request)
     - [Response](#response)
     - [Specification](#specification)
@@ -55,20 +55,22 @@ Rationale: Human-readable fields like `clientName` and `version` are useful for 
 
 ## Methods
 
-### engine_clientVersionV1
+### engine_getClientVersionV1
 
 #### Request
 
-* method: `engine_clientVersionV1`
+* method: `engine_getClientVersionV1`
 * params:
   1. [`ClientVersionV1`](#ClientVersionV1) - identifies the consensus client
 * timeout: 1s
 
 #### Response
-
-* result: [`ClientVersionV1`](#ClientVersionV1) - identifies the execution client
+* result: `Array of ClientVersionV1` - Array of [`ClientVersionV1`](#ClientVersionV1)
 
 #### Specification
 
 1. Consensus and execution layer clients **MAY** exchange `ClientVersionV1` objects. Execution clients **MUST NOT** log any error messages if this method has either never been called or hasn't been called for a significant amount of time.
-2. Clients **MUST** accomodate receiving any two-letter `ClientCode`, even if they are not reserved in the list above. Clients **MAY** log messages upon receiving an unlisted client code. 
+2. Clients **MUST** accommodate receiving any two-letter `ClientCode`, even if they are not reserved in the list above. Clients **MAY** log messages upon receiving an unlisted client code.
+3. When connected to a single execution client, the consensus client **MUST** receieve an array with a single
+`ClientVersionV1` object. When connected to multiple execution clients via a multiplexer, the multiplexer **MUST** concatenate the responses from each execution client into a single, flat array before returning the
+response to the consensus client.

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -44,7 +44,7 @@ This enum defines a standard for specifying a client with just two letters. Clie
  
 ### ClientVersionV1
 
-This structure contains information which identifies a client implementatiopn. The fields are encoded as follows:
+This structure contains information which identifies a client implementation. The fields are encoded as follows:
 
 - `code`: `ClientCode`, e.g. `NB` or `BU`
 - `clientName`: `string`, Human-readable name of the client, e.g. `Lighthouse` or `go-ethereum`

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -71,6 +71,6 @@ Rationale: Human-readable fields like `clientName` and `version` are useful for 
 
 1. Consensus and execution layer clients **MAY** exchange `ClientVersionV1` objects. Execution clients **MUST NOT** log any error messages if this method has either never been called or hasn't been called for a significant amount of time.
 2. Clients **MUST** accommodate receiving any two-letter `ClientCode`, even if they are not reserved in the list above. Clients **MAY** log messages upon receiving an unlisted client code.
-3. When connected to a single execution client, the consensus client **MUST** receieve an array with a single
+3. When connected to a single execution client, the consensus client **MUST** receive an array with a single
 `ClientVersionV1` object. When connected to multiple execution clients via a multiplexer, the multiplexer **MUST** concatenate the responses from each execution client into a single, flat array before returning the
 response to the consensus client.

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -1,0 +1,73 @@
+# Engine API -- Client Identification
+
+Engine API structures and methods specified for client identification.
+
+## Table of contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Client Identification](#client-identification)
+- [Structures](#structures)
+  - [ClientCode](#clientcode)
+  - [ClientIdentificationV1](#clientidentificationv1)
+- [Methods](#methods)
+  - [engine_clientIdentificationV1](#engine_clientidentificationv1)
+    - [Request](#request)
+    - [Response](#response)
+    - [Specification](#specification)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Client Identification
+
+To facilitate a more accurate measurement of execution layer client diversity statistics, execution clients **SHOULD** support the methods described in this document.
+
+## Structures
+
+### ClientCode
+
+This enum defines a standard for specifying a client with just two letters. Clients teams which have a code reserved in this list **MUST** use this code when identifying themselves. The code is specified here only to facilitate standardization and NOT to imply that these are the only supported Ethereum clients. Any clients not listed here are free to use any two letters which don't collide with an existing client code. They are encouraged to make a PR to this repo to reserve their own code. Existing codes are as follows:
+
+ - `BU`: besu
+ - `EJ`: ethereumJS
+ - `EG`: erigon
+ - `GE`: go-ethereum
+ - `LH`: lighthouse
+ - `LS`: lodestar
+ - `NM`: nethermind
+ - `NB`: nimbus
+ - `TK`: teku
+ - `PM`: prysm
+ - `RH`: reth
+ 
+### ClientIdentificationV1
+
+This structure contains information which identifies a client implementatiopn. The fields are encoded as follows:
+
+- `code`: `ClientCode`, e.g. `NB` or `BU`
+- `clientName`: `string`, Human-readable name of the client, e.g. `Lighthouse` or `go-ethereum`
+- `version`: `string`, the standard semantic version string of the current implementation e.g. `v4.6.0` or `1.0.0-alpha.1` or `1.0.0+20130313144700`
+- `commit`: `string`, the hex of the first 4 bytes of the latest commit hash of this build e.g. `fa4ff922`
+
+Rationale: Human-readable fields like `clientName` and `version` are useful for log messages while fields like `code` and `commit` are useful for uniquely specifying clients within a limited space (e.g. in block `graffiti`).
+
+## Methods
+
+### engine_clientIdentificationV1
+
+#### Request
+
+* method: `engine_clientIdentificationV1`
+* params:
+  1. [`ClientIdentificationV1`](#ClientIdentificationV1) - identifies the consensus client
+* timeout: 1s
+
+#### Response
+
+* result: [`ClientIdentificationV1`](#ClientIdentificationV1) - identifies the execution client
+
+#### Specification
+
+1. Consensus and execution layer clients **MAY** exchange `ClientIdentificationV1` objects. Execution clients **MUST NOT** log any error messages if this method has either never been called or hasn't been called for a significant amount of time.
+2. Clients **MUST** accomodate receiving any two-letter `ClientCode`, even if they are not reserved in the list above. Clients **MAY** log messages upon receiving an unlisted client code. 

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -1,6 +1,6 @@
-# Engine API -- Client Identification
+# Engine API -- Client Version Specification
 
-Engine API structures and methods specified for client identification.
+Engine API structures and methods specified for client version specification.
 
 ## Table of contents
 
@@ -10,16 +10,16 @@ Engine API structures and methods specified for client identification.
 - [Client Identification](#client-identification)
 - [Structures](#structures)
   - [ClientCode](#clientcode)
-  - [ClientIdentificationV1](#clientidentificationv1)
+  - [ClientVersionV1](#clientversionv1)
 - [Methods](#methods)
-  - [engine_clientIdentificationV1](#engine_clientidentificationv1)
+  - [engine_clientVersionV1](#engine_clientversionv1)
     - [Request](#request)
     - [Response](#response)
     - [Specification](#specification)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## Client Identification
+## Client Version Specification
 
 To facilitate a more accurate measurement of execution layer client diversity statistics, execution clients **SHOULD** support the methods described in this document.
 
@@ -33,6 +33,7 @@ This enum defines a standard for specifying a client with just two letters. Clie
  - `EJ`: ethereumJS
  - `EG`: erigon
  - `GE`: go-ethereum
+ - `GR`: grandine
  - `LH`: lighthouse
  - `LS`: lodestar
  - `NM`: nethermind
@@ -41,33 +42,33 @@ This enum defines a standard for specifying a client with just two letters. Clie
  - `PM`: prysm
  - `RH`: reth
  
-### ClientIdentificationV1
+### ClientVersionV1
 
 This structure contains information which identifies a client implementatiopn. The fields are encoded as follows:
 
 - `code`: `ClientCode`, e.g. `NB` or `BU`
 - `clientName`: `string`, Human-readable name of the client, e.g. `Lighthouse` or `go-ethereum`
-- `version`: `string`, the standard semantic version string of the current implementation e.g. `v4.6.0` or `1.0.0-alpha.1` or `1.0.0+20130313144700`
+- `version`: `string`, the version string of the current implementation e.g. `v4.6.0` or `1.0.0-alpha.1` or `1.0.0+20130313144700`
 - `commit`: `string`, the hex of the first 4 bytes of the latest commit hash of this build e.g. `fa4ff922`
 
 Rationale: Human-readable fields like `clientName` and `version` are useful for log messages while fields like `code` and `commit` are useful for uniquely specifying clients within a limited space (e.g. in block `graffiti`).
 
 ## Methods
 
-### engine_clientIdentificationV1
+### engine_clientVersionV1
 
 #### Request
 
-* method: `engine_clientIdentificationV1`
+* method: `engine_clientVersionV1`
 * params:
-  1. [`ClientIdentificationV1`](#ClientIdentificationV1) - identifies the consensus client
+  1. [`ClientVersionV1`](#ClientVersionV1) - identifies the consensus client
 * timeout: 1s
 
 #### Response
 
-* result: [`ClientIdentificationV1`](#ClientIdentificationV1) - identifies the execution client
+* result: [`ClientVersionV1`](#ClientVersionV1) - identifies the execution client
 
 #### Specification
 
-1. Consensus and execution layer clients **MAY** exchange `ClientIdentificationV1` objects. Execution clients **MUST NOT** log any error messages if this method has either never been called or hasn't been called for a significant amount of time.
+1. Consensus and execution layer clients **MAY** exchange `ClientVersionV1` objects. Execution clients **MUST NOT** log any error messages if this method has either never been called or hasn't been called for a significant amount of time.
 2. Clients **MUST** accomodate receiving any two-letter `ClientCode`, even if they are not reserved in the list above. Clients **MAY** log messages upon receiving an unlisted client code. 

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -47,7 +47,7 @@ This enum defines a standard for specifying a client with just two letters. Clie
 This structure contains information which identifies a client implementation. The fields are encoded as follows:
 
 - `code`: `ClientCode`, e.g. `NB` or `BU`
-- `clientName`: `string`, Human-readable name of the client, e.g. `Lighthouse` or `go-ethereum`
+- `name`: `string`, Human-readable name of the client, e.g. `Lighthouse` or `go-ethereum`
 - `version`: `string`, the version string of the current implementation e.g. `v4.6.0` or `1.0.0-alpha.1` or `1.0.0+20130313144700`
 - `commit`: `string`, the hex of the first 4 bytes of the latest commit hash of this build e.g. `fa4ff922`
 

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -49,7 +49,7 @@ This structure contains information which identifies a client implementation. Th
 - `code`: `ClientCode`, e.g. `NB` or `BU`
 - `name`: `string`, Human-readable name of the client, e.g. `Lighthouse` or `go-ethereum`
 - `version`: `string`, the version string of the current implementation e.g. `v4.6.0` or `1.0.0-alpha.1` or `1.0.0+20130313144700`
-- `commit`: `string`, the hex of the first 4 bytes of the latest commit hash of this build e.g. `fa4ff922`
+- `commit`: `DATA`, 4 bytes - first four bytes of the latest commit hash of this build e.g. `fa4ff922`
 
 Rationale: Human-readable fields like `clientName` and `version` are useful for log messages while fields like `code` and `commit` are useful for uniquely specifying clients within a limited space (e.g. in block `graffiti`).
 

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -41,7 +41,7 @@ This enum defines a standard for specifying a client with just two letters. Clie
  - `TK`: teku
  - `PM`: prysm
  - `RH`: reth
- 
+
 ### ClientVersionV1
 
 This structure contains information which identifies a client implementation. The fields are encoded as follows:

--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -7,7 +7,7 @@ Engine API structures and methods specified for client version specification.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Client Identification](#client-identification)
+- [Client Version Specification](#client-version-specification)
 - [Structures](#structures)
   - [ClientCode](#clientcode)
   - [ClientVersionV1](#clientversionv1)

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -4,6 +4,7 @@ bodyv
 bodiesbyrangev
 bodiesbyhashv
 bytecode
+clientversionv
 configurationv
 crypto
 eip
@@ -11,6 +12,9 @@ endian
 enum
 eth
 ethereum
+ethereumjs
+erigon
+getclientversionv
 interop
 json
 mempool
@@ -29,6 +33,7 @@ secp
 statev
 statusv
 sha
+teku
 uint
 updatedv
 url


### PR DESCRIPTION
By analyzing the structure of beacon blocks on the network, we are able to obtain [fairly accurate data](https://blockprint.sigp.io/) on consensus layer client diversity. Unfortunately, do to the fact that the **overwhelming majority** of validators use `mev-boost`, their execution clients do not leave *any* fingerprint behind in block proposals. Thus we are forced to rely on limited [self-reporting](https://execution-diversity.info/) data from staking pools. Many pools do not participate, and we often have outdated statistics for the pools that do. Worse yet, we have **no** data on client diversity for home stakers.

This PR can change that by allowing consensus clients to learn which execution client they are connected with.

Consensus clients can then embed this in their `graffiti` field by default when the user doesn't bother to set it. A quick survey of recent proposal graffiti reveals that:

* [lighthouse](https://beaconcha.in/slot/8284047)
* [teku](https://beaconcha.in/slot/8284056)
* [nimbus](https://beaconcha.in/slot/8284082)
* [lodestar](https://beaconcha.in/slot/8284121)

already embed their client and version by default. It would be great to add the execution client to this. Perhaps prysm could be convinced to join as well.

An analysis of ~2000 recent blocks indicated that nearly half of all validators don't bother to change their graffiti from the default so the potential to gather data here is huge.