### PR TITLE
Add EIP-7251 to Prague

### DIFF
--- a/src/engine/openrpc/schemas/payload.yaml
+++ b/src/engine/openrpc/schemas/payload.yaml
@@ -380,6 +380,7 @@ ExitV1:
   required:
     - sourceAddress
     - validatorPublicKey
+    - amount
   properties:
     sourceAddress:
       title: Source address
@@ -387,3 +388,6 @@ ExitV1:
     validatorPublicKey:
       title: Validator public key
       $ref: '#/components/schemas/bytes48'
+    amount:
+      title: Withdrawal amount
+      $ref: '#/components/schemas/uint64'

--- a/src/engine/openrpc/schemas/payload.yaml
+++ b/src/engine/openrpc/schemas/payload.yaml
@@ -389,5 +389,5 @@ ExitV1:
       title: Validator public key
       $ref: '#/components/schemas/bytes48'
     amount:
-      title: Withdrawal amount
+      title: Withdraw amount
       $ref: '#/components/schemas/uint64'

--- a/src/engine/prague.md
+++ b/src/engine/prague.md
@@ -48,6 +48,9 @@ The fields are encoded as follows:
 
 - `sourceAddress`: `DATA`, 20 Bytes
 - `validatorPublicKey`: `DATA`, 48 Bytes
+- `amount`: `DATA`, 64 Bits
+
+*Note:* The `amount` value is represented in Gwei.
 
 ### ExecutionPayloadV4
 

--- a/src/engine/prague.md
+++ b/src/engine/prague.md
@@ -48,7 +48,7 @@ The fields are encoded as follows:
 
 - `sourceAddress`: `DATA`, 20 Bytes
 - `validatorPublicKey`: `DATA`, 48 Bytes
-- `amount`: `DATA`, 64 Bits
+- `amount`: `QUANTITY`, 64 Bits
 
 *Note:* The `amount` value is represented in Gwei.
 


### PR DESCRIPTION
Since EIP-7251 is included into Pectra fork. We should consider including it in the Engine API spec.

One of the features of EIP-7251 is to integrate EIP-7002 to support execution layer triggerable **partial** withdrawals via `ExitV1`.

This PR adds `amount` to `ExitV1` such that it supports partial withdrawals on top of full exits.


A point of discussion is the use of word `exit`. Originally EIP-7002 only considers full withdrawals (exits). With the newly added responsibility, one may consider renaming `exit` to `executionLayerWithdraw` for more precise description and to be distinguishable from the current withdrawal mechanism (consensus layer triggered). 