### PR TITLE
Add `eth_checkMethodSupport`

### DIFF
--- a/src/eth/client.yaml
+++ b/src/eth/client.yaml
@@ -36,3 +36,19 @@
     name: Block number
     schema:
       $ref: '#/components/schemas/uint'
+- name: eth_checkMethodSupport
+  summary: Returns an object with data about supported methods
+  params:
+    - name: Method names
+      required: false
+      schema:
+        type: array
+        items :
+          $ref: '#/components/schemas/methodName'
+  result:
+    name: Method support object
+    schema:
+      type: object
+      patternProperties:
+        '^(eth_|debug_|engine_).*$':  boolean
+      additionalProperties: false

--- a/src/eth/client.yaml
+++ b/src/eth/client.yaml
@@ -52,3 +52,17 @@
       patternProperties:
         '^(eth_|debug_|engine_).*$':  boolean
       additionalProperties: false
+  examples:
+    - name: eth_checkMethodSupport example
+      params:
+        - name: Method names
+          value:
+            - 'eth_getBalance'
+            - 'eth_blockNumber'
+            - 'eth_sendTransaction'
+      result:
+        name: Method support object
+        value:
+          eth_getBalance: true
+          eth_blockNumber: true
+          eth_sendTransaction: false

--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -43,6 +43,10 @@ bytes65:
   title: 65 hex encoded bytes
   type: string
   pattern: ^0x[0-9a-f]{130}$
+methodName:
+  title: Name of a ETH JSON-RPC method
+  type: string
+  pattern: ^(eth_|debug_|engine_).*$
 ratio:
   title: normalized ratio
   type: number


### PR DESCRIPTION
Moves [EIP 7663](https://github.com/ethereum/EIPs/pull/8355) to this repo. Thie discussion about this addition's necessity and other details is available on [Ethereum magicians](https://ethereum-magicians.org/t/eip-7663-create-an-eth-supportsmethod-method-for-json-rpc/19247) .

I'm less familiar with yaml and JSON schema, so I did my best and feel free to help. Unsure if I should add tests, as it's not implemented in clients yet. Also, ideally, we should change the params from a `methodName` array to an enum of all existing methods, and the `result` should use that as well.