### PR TITLE
engine: rename for 7002 partial withdrawals and 7685 requests

### DIFF
--- a/src/engine/openrpc/schemas/payload.yaml
+++ b/src/engine/openrpc/schemas/payload.yaml
@@ -264,8 +264,8 @@ ExecutionPayloadV4:
     - withdrawals
     - blobGasUsed
     - excessBlobGas
-    - depositReceipts
-    - exits
+    - depositRequests
+    - withdrawalRequests
   properties:
     parentHash:
       $ref: '#/components/schemas/ExecutionPayloadV3/properties/parentHash'
@@ -301,16 +301,16 @@ ExecutionPayloadV4:
       $ref: '#/components/schemas/ExecutionPayloadV3/properties/blobGasUsed'
     excessBlobGas:
       $ref: '#/components/schemas/ExecutionPayloadV3/properties/excessBlobGas'
-    depositReceipts:
-      title: Deposit receipts
+    depositRequests:
+      title: Deposit requests
       type: array
       items:
-        $ref: '#/components/schemas/DepositReceiptV1'
-    exits:
-      title: Exits
+        $ref: '#/components/schemas/DepositRequestV1'
+    withdrawalRequests:
+      title: Withdrawals requests
       type: array
       items:
-        $ref: '#/components/schemas/ExitV1'
+        $ref: '#/components/schemas/WithdrawalRequestV1'
 ExecutionPayloadBodyV1:
   title: Execution payload body object V1
   type: object
@@ -349,8 +349,8 @@ BlobsBundleV1:
       type: array
       items:
         $ref: '#/components/schemas/bytes'
-DepositReceiptV1:
-  title: Deposit receipt object V1
+DepositRequestV1:
+  title: Deposit request object V1
   type: object
   required:
     - pubkey
@@ -374,8 +374,8 @@ DepositReceiptV1:
     index:
       title: Deposit index
       $ref: '#/components/schemas/uint64'
-ExitV1:
-  title: Exit object V1
+WithdrawalRequestV1:
+  title: Withdrawal request object V1
   type: object
   required:
     - sourceAddress

--- a/src/engine/prague.md
+++ b/src/engine/prague.md
@@ -43,7 +43,7 @@ The fields are encoded as follows:
 
 ### WithdrawalRequestV1
 
-This structure represents an execution layer triggered exit operation.
+This structure represents an execution layer triggered withdrawal request.
 The fields are encoded as follows:
 
 - `sourceAddress`: `DATA`, 20 Bytes
@@ -74,7 +74,7 @@ This structure has the syntax of [`ExecutionPayloadV3`](./cancun.md#executionpay
 - `blobGasUsed`: `QUANTITY`, 64 Bits
 - `excessBlobGas`: `QUANTITY`, 64 Bits
 - `depositRequests`: `Array of DepositRequestV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositRequestV1` structure.
-- `withdrawalRequests`: `Array of WithdrawalRequestV1` - Array of exits, each object is an `OBJECT` containing the fields of a `WithdrawalRequestV1` structure.
+- `withdrawalRequests`: `Array of WithdrawalRequestV1` - Array of withdrawal requests, each object is an `OBJECT` containing the fields of a `WithdrawalRequestV1` structure.
 
 ## Methods
 

--- a/src/engine/prague.md
+++ b/src/engine/prague.md
@@ -12,8 +12,8 @@ This specification is based on and extends [Engine API - Cancun](./cancun.md) sp
 - [Engine API -- Prague](#engine-api----prague)
   - [Table of contents](#table-of-contents)
   - [Structures](#structures)
-    - [DepositReceiptV1](#depositreceiptv1)
-    - [ExitV1](#exitv1)
+    - [DepositRequestV1](#depositrequestv1)
+    - [WithdrawalRequestV1](#withdrawalrequestv1)
     - [ExecutionPayloadV4](#executionpayloadv4)
   - [Methods](#methods)
     - [engine\_newPayloadV4](#engine_newpayloadv4)
@@ -29,7 +29,7 @@ This specification is based on and extends [Engine API - Cancun](./cancun.md) sp
 
 ## Structures
 
-### DepositReceiptV1
+### DepositRequestV1
 This structure maps onto the deposit object from [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
 The fields are encoded as follows:
 
@@ -41,7 +41,7 @@ The fields are encoded as follows:
 
 *Note:* The `amount` value is represented in Gwei.
 
-### ExitV1
+### WithdrawalRequestV1
 
 This structure represents an execution layer triggered exit operation.
 The fields are encoded as follows:
@@ -54,7 +54,7 @@ The fields are encoded as follows:
 
 ### ExecutionPayloadV4
 
-This structure has the syntax of [`ExecutionPayloadV3`](./cancun.md#executionpayloadv3) and appends the new fields: `depositReceipts` and `exits`.
+This structure has the syntax of [`ExecutionPayloadV3`](./cancun.md#executionpayloadv3) and appends the new fields: `depositRequests` and `withdrawalRequests`.
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
@@ -73,8 +73,8 @@ This structure has the syntax of [`ExecutionPayloadV3`](./cancun.md#executionpay
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
 - `blobGasUsed`: `QUANTITY`, 64 Bits
 - `excessBlobGas`: `QUANTITY`, 64 Bits
-- `depositReceipts`: `Array of DepositReceiptV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositReceiptV1` structure.
-- `exits`: `Array of ExitV1` - Array of exits, each object is an `OBJECT` containing the fields of a `ExitV1` structure.
+- `depositRequests`: `Array of DepositRequestV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositRequestV1` structure.
+- `withdrawalRequests`: `Array of WithdrawalRequestV1` - Array of exits, each object is an `OBJECT` containing the fields of a `WithdrawalRequestV1` structure.
 
 ## Methods
 


### PR DESCRIPTION
This PR makes good on some pending changes to 6110 and 7002. It was discussed a roughly accepted in [CL call 132](https://github.com/ethereum/pm/issues/1010).

These three in particular:

* https://github.com/ethereum/EIPs/pull/8440
* https://github.com/ethereum/EIPs/pull/8406
* https://github.com/ethereum/EIPs/pull/8469

The result is `DepositReceiptV1` -> `DepositRequestV1` and `ExitV1` -> `WithdrawalRequestV1`.