### PR TITLE
remove unevaluatedProperties

### DIFF
--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -337,7 +337,6 @@ TransactionInfo:
         - from
         - hash
         - transactionIndex
-      unevaluatedProperties: false
       properties:
         blockHash:
           title: block hash


### PR DESCRIPTION
getting this error when using this JSON Schema and `ajv`.

`unevaluatedProperties` is part of JSON Schema 2019, we shouldn't use it anyways in an [OpenRPC document since the spec points out using JSON Schema 07](https://spec.open-rpc.org/#meta-json-schema).

`strict mode: unknown keyword: "unevaluatedProperties"`

are we sure we need `unevaluatedProperties` here?