### PR TITLE
remove comma from base types pattern

### DIFF
--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -1,7 +1,7 @@
 address:
   title: hex encoded address
   type: string
-  pattern: ^0x[0-9,a-f,A-F]{40}$
+  pattern: ^0x[0-9a-fA-F]{40}$
 addresses:
   title: hex encoded address
   type: array
@@ -10,7 +10,7 @@ addresses:
 byte:
   title: hex encoded byte
   type: string
-  pattern: ^0x([0-9,a-f,A-F]?){1,2}$
+  pattern: ^0x([0-9a-fA-F]?){1,2}$
 bytes:
   title: hex encoded bytes
   type: string


### PR DESCRIPTION
im using this schema and json schema faker and this address schema pattern generates addresses with commas in them:

![image](https://github.com/ethereum/execution-apis/assets/364566/71036cf2-f0b4-42c1-9058-05f6cbf6b5c2)

also removed them from `byte` while I was in there
