### PR TITLE
feat: add returndata to tx receipts

### DIFF
--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -119,3 +119,7 @@ ReceiptInfo:
       title: blob gas price
       description: The actual value per gas deducted from the sender's account for blob gas. Only specified for blob transactions as defined by EIP-4844.
       $ref: '#/components/schemas/uint'
+    returnData:
+      title: returndata
+      description: The returndata from the call. This is an optional field that the client is not required to return if the returndata is not available. If it is not available, it should return `nil`.
+      $ref: '#/components/schemas/bytes'


### PR DESCRIPTION
right now, returndata is not part of the tx receipt. this means that consumers of the API need to find alternative ways to fetch the returndata from a transaction, the most common being `debug_traceTransaction`. however, this is non-standard and not universally supported. it would be helpful if the returndata were simply part of the transaction receipt.