### PR TITLE
engine: Rename DepositRequest to DepositReceipts

### DIFF
--- a/src/engine/openrpc/schemas/payload.yaml
+++ b/src/engine/openrpc/schemas/payload.yaml
@@ -264,7 +264,7 @@ ExecutionPayloadV4:
     - withdrawals
     - blobGasUsed
     - excessBlobGas
-    - depositRequests
+    - depositReceipts
     - withdrawalRequests
   properties:
     parentHash:
@@ -301,11 +301,11 @@ ExecutionPayloadV4:
       $ref: '#/components/schemas/ExecutionPayloadV3/properties/blobGasUsed'
     excessBlobGas:
       $ref: '#/components/schemas/ExecutionPayloadV3/properties/excessBlobGas'
-    depositRequests:
-      title: Deposit requests
+    depositReceipts:
+      title: Deposit receipts
       type: array
       items:
-        $ref: '#/components/schemas/DepositRequestV1'
+        $ref: '#/components/schemas/DepositReceiptV1'
     withdrawalRequests:
       title: Withdrawals requests
       type: array
@@ -349,8 +349,8 @@ BlobsBundleV1:
       type: array
       items:
         $ref: '#/components/schemas/bytes'
-DepositRequestV1:
-  title: Deposit request object V1
+DepositReceiptV1:
+  title: Deposit receipt object V1
   type: object
   required:
     - pubkey

--- a/src/engine/prague.md
+++ b/src/engine/prague.md
@@ -12,7 +12,7 @@ This specification is based on and extends [Engine API - Cancun](./cancun.md) sp
 - [Engine API -- Prague](#engine-api----prague)
   - [Table of contents](#table-of-contents)
   - [Structures](#structures)
-    - [DepositRequestV1](#depositrequestv1)
+    - [DepositReceiptV1](#depositreceiptv1)
     - [WithdrawalRequestV1](#withdrawalrequestv1)
     - [ExecutionPayloadV4](#executionpayloadv4)
   - [Methods](#methods)
@@ -29,7 +29,7 @@ This specification is based on and extends [Engine API - Cancun](./cancun.md) sp
 
 ## Structures
 
-### DepositRequestV1
+### DepositReceiptV1
 This structure maps onto the deposit object from [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
 The fields are encoded as follows:
 
@@ -53,7 +53,7 @@ The fields are encoded as follows:
 
 ### ExecutionPayloadV4
 
-This structure has the syntax of [`ExecutionPayloadV3`](./cancun.md#executionpayloadv3) and appends the new fields: `depositRequests` and `withdrawalRequests`.
+This structure has the syntax of [`ExecutionPayloadV3`](./cancun.md#executionpayloadv3) and appends the new fields: `depositReceipts` and `withdrawalRequests`.
 
 - `parentHash`: `DATA`, 32 Bytes
 - `feeRecipient`:  `DATA`, 20 Bytes
@@ -72,7 +72,7 @@ This structure has the syntax of [`ExecutionPayloadV3`](./cancun.md#executionpay
 - `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
 - `blobGasUsed`: `QUANTITY`, 64 Bits
 - `excessBlobGas`: `QUANTITY`, 64 Bits
-- `depositRequests`: `Array of DepositRequestV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositRequestV1` structure.
+- `depositReceipts`: `Array of DepositReceiptV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositReceiptV1` structure.
 - `withdrawalRequests`: `Array of WithdrawalRequestV1` - Array of withdrawal requests, each object is an `OBJECT` containing the fields of a `WithdrawalRequestV1` structure.
 
 ## Methods


### PR DESCRIPTION
Renames DepositRequest to DepositReceipt for the purpose of devnet-0.

The recent change introduced in https://github.com/ethereum/execution-apis/pull/535 to align with the EIP-7685 requests created a slight discrepancy between the CL spec and implementations which still uses `DepositReceipt` and the Engine API server implementation on EL side. This renaming is a temporal quick fix to facilitate interop between CL and EL clients during planned devnet-0. The decision is to do a proper renaming after the devnet-0 launch and to incorporate it into further devnets.