### PR TITLE
engine: Return and accept EL triggered requests as a sidecar

### DIFF
--- a/src/engine/prague.md
+++ b/src/engine/prague.md
@@ -12,8 +12,6 @@ This specification is based on and extends [Engine API - Cancun](./cancun.md) sp
 - [Structures](#structures)
   - [DepositRequestV1](#depositrequestv1)
   - [WithdrawalRequestV1](#withdrawalrequestv1)
-  - [ExecutionPayloadV4](#executionpayloadv4)
-  - [ExecutionPayloadBodyV2](#executionpayloadbodyv2)
 - [Methods](#methods)
   - [engine_newPayloadV4](#engine_newpayloadv4)
     - [Request](#request)
@@ -23,14 +21,6 @@ This specification is based on and extends [Engine API - Cancun](./cancun.md) sp
     - [Request](#request-1)
     - [Response](#response-1)
     - [Specification](#specification-1)
-  - [engine_getPayloadBodiesByHashV2](#engine_getpayloadbodiesbyhashv2)
-    - [Request](#request-2)
-    - [Response](#response-2)
-    - [Specification](#specification-2)
-  - [engine_getPayloadBodiesByRangeV2](#engine_getpayloadbodiesbyrangev2)
-    - [Request](#request-3)
-    - [Response](#response-3)
-    - [Specification](#specification-3)
   - [Update the methods of previous forks](#update-the-methods-of-previous-forks)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -59,44 +49,11 @@ The fields are encoded as follows:
 
 *Note:* The `amount` value is represented in Gwei.
 
-### ExecutionPayloadV4
-
-This structure has the syntax of [`ExecutionPayloadV3`](./cancun.md#executionpayloadv3) and appends the new fields: `depositRequests` and `withdrawalRequests`.
-
-- `parentHash`: `DATA`, 32 Bytes
-- `feeRecipient`:  `DATA`, 20 Bytes
-- `stateRoot`: `DATA`, 32 Bytes
-- `receiptsRoot`: `DATA`, 32 Bytes
-- `logsBloom`: `DATA`, 256 Bytes
-- `prevRandao`: `DATA`, 32 Bytes
-- `blockNumber`: `QUANTITY`, 64 Bits
-- `gasLimit`: `QUANTITY`, 64 Bits
-- `gasUsed`: `QUANTITY`, 64 Bits
-- `timestamp`: `QUANTITY`, 64 Bits
-- `extraData`: `DATA`, 0 to 32 Bytes
-- `baseFeePerGas`: `QUANTITY`, 256 Bits
-- `blockHash`: `DATA`, 32 Bytes
-- `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
-- `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
-- `blobGasUsed`: `QUANTITY`, 64 Bits
-- `excessBlobGas`: `QUANTITY`, 64 Bits
-- `depositRequests`: `Array of DepositRequestV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositRequestV1` structure.
-- `withdrawalRequests`: `Array of WithdrawalRequestV1` - Array of withdrawal requests, each object is an `OBJECT` containing the fields of a `WithdrawalRequestV1` structure.
-
-### ExecutionPayloadBodyV2
-
-This structure has the syntax of [`ExecutionPayloadBodyV1`](./shanghai.md#executionpayloadv1) and appends the new fields: `depositRequests` and `withdrawalRequests`.
-
-- `transactions`: `Array of DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `TransactionType || TransactionPayload` or `LegacyTransaction` as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
-- `withdrawals`: `Array of WithdrawalV1` - Array of withdrawals, each object is an `OBJECT` containing the fields of a `WithdrawalV1` structure.
-- `depositRequests`: `Array of DepositRequestV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositRequestV1` structure.
-- `withdrawalRequests`: `Array of WithdrawalRequestV1` - Array of withdrawal requests, each object is an `OBJECT` containing the fields of a `WithdrawalRequestV1` structure.
-
 ## Methods
 
 ### engine_newPayloadV4
 
-The request of this method is updated with [`ExecutionPayloadV4`](#ExecutionPayloadV4).
+The request of this method is updated with [`ExecutionPayloadV3`](./cancun.md#ExecutionPayloadV4).
 
 #### Request
 
@@ -105,6 +62,8 @@ The request of this method is updated with [`ExecutionPayloadV4`](#ExecutionPayl
   1. `executionPayload`: [`ExecutionPayloadV4`](#ExecutionPayloadV4).
   2. `expectedBlobVersionedHashes`: `Array of DATA`, 32 Bytes - Array of expected blob versioned hashes to validate.
   3. `parentBeaconBlockRoot`: `DATA`, 32 Bytes - Root of the parent beacon block.
+  4. `expectedDepositRequests`: `Array of DepositRequestV1` - Array of expected deposit requests to validate.
+  5. `expectedWithdrawalRequests`: `Array of WithdrawalRequestV1` - Array of expected withdrawal requests to validate.
 
 #### Response
 
@@ -115,6 +74,14 @@ Refer to the response for [`engine_newPayloadV3`](./cancun.md#engine_newpayloadv
 This method follows the same specification as [`engine_newPayloadV3`](./cancun.md#engine_newpayloadv3) with the following changes:
 
 1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the payload does not fall within the time frame of the Prague fork.
+
+2. Given the expected array of deposit requests, client software **MUST** run its validation by taking the following steps:
+    1. Obtain the actual deposit requests array as it is specified by the [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110).
+    2. Return `{status: INVALID, latestValidHash: validHash, validationError: errorMessage | null}` if the expected and the actual arrays don't match.
+
+3. Given the expected array of withdrawal requests, client software **MUST** run its validation by taking the following steps:
+    1. Obtain the actual withdrawal requests array as it is specified by the [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002).
+    2. Return `{status: INVALID, latestValidHash: validHash, validationError: errorMessage | null}` if the expected and the actual arrays don't match.
 
 ### engine_getPayloadV4
 
@@ -132,8 +99,10 @@ The response of this method is updated with [`ExecutionPayloadV4`](#ExecutionPay
 * result: `object`
   - `executionPayload`: [`ExecutionPayloadV4`](#ExecutionPayloadV4)
   - `blockValue` : `QUANTITY`, 256 Bits - The expected value to be received by the `feeRecipient` in wei
-  - `blobsBundle`: [`BlobsBundleV1`](#BlobsBundleV1) - Bundle with data corresponding to blob transactions included into `executionPayload`
+  - `blobsBundle`: [`BlobsBundleV1`](./cancun.md#BlobsBundleV1) - Bundle with data corresponding to blob transactions included into `executionPayload`
   - `shouldOverrideBuilder` : `BOOLEAN` - Suggestion from the execution layer to use this `executionPayload` instead of an externally provided one
+  - `depositRequests`: `Array of DepositRequestV1` - Array of deposits, each object is an `OBJECT` containing the fields of a `DepositRequestV1` structure.
+  - `withdrawalRequests`: `Array of WithdrawalRequestV1` - Array of withdrawal requests, each object is an `OBJECT` containing the fields of a `WithdrawalRequestV1` structure.
 * error: code and message set in case an exception happens while getting the payload.
 
 #### Specification
@@ -142,50 +111,9 @@ This method follows the same specification as [`engine_getPayloadV3`](./cancun.m
 
 1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the built payload does not fall within the time frame of the Prague fork.
 
-### engine_getPayloadBodiesByHashV2
+2. Client software **MUST** return `depositRequests` array obtained from the block execution according to the [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) specification.
 
-The response of this method is updated with [`ExecutionPayloadBodyV2`](#executionpayloadbodyv2).
-
-#### Request
-
-* method: `engine_getPayloadBodiesByHashV2`
-* params:
-  1. `Array of DATA`, 32 Bytes - Array of `block_hash` field values of the `ExecutionPayload` structure
-* timeout: 10s
-
-#### Response
-
-* result: `Array of ExecutionPayloadBodyV2` - Array of [`ExecutionPayloadBodyV2`](#executionpayloadbodyv2) objects.
-* error: code and message set in case an exception happens while processing the method call.
-
-#### Specification
-
-This method follows the same specification as [`engine_getPayloadBodiesByHashV1`](./shanghai.md#engine_getpayloadbodiesbyhashv1) with the addition of the following:
-
-1. Client software **MUST** set `depositRequests` and `withdrawalRequests` fields to `null` for bodies of pre-Prague blocks.
-
-### engine_getPayloadBodiesByRangeV2
-
-The response of this method is updated with [`ExecutionPayloadBodyV2`](#executionpayloadbodyv2).
-
-#### Request
-
-* method: `engine_getPayloadBodiesByRangeV2`
-* params:
-  1. `start`: `QUANTITY`, 64 bits - Starting block number
-  1. `count`: `QUANITTY`, 64 bits - Number of blocks to return
-* timeout: 10s
-
-#### Response
-
-* result: `Array of ExecutionPayloadBodyV2` - Array of [`ExecutionPayloadBodyV2`](#executionpayloadbodyv2) objects.
-* error: code and message set in case an exception happens while processing the method call.
-
-#### Specification
-
-This method follows the same specification as [`engine_getPayloadBodiesByRangeV2`](./shanghai.md#engine_getpayloadbodiesbyrangev1) with the addition of the following:
-
-1. Client software **MUST** set `depositRequests` and `withdrawalRequests` fields to `null` for bodies of pre-Prague blocks.
+3. Client software **MUST** return `withdrawalRequests` array obtained from the block execution according to the [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) specification.
 
 ### Update the methods of previous forks
 


### PR DESCRIPTION
Drafts an idea by @fjl and @lightclient to surface EL triggered requests as a sidecar to the ExecutionPayload.

## Motivation

Simplify the EL part of the EL triggered requests design by avoiding requests inclusion into the ExecutionPayload structure.

## Consensus layer

CL obtains deposit, withdrawal and requests of any other type in the response to the `engine_getPayload` method call in a similar way as blobs are obtained. And then CL includes obtained requests into a `BeaconBlockBody` instead of the `ExecutionPayload`:

```python
class BeaconBlockBody(Container):
    randao_reveal: BLSSignature
    eth1_data: Eth1Data  # Eth1 data vote
    graffiti: Bytes32  # Arbitrary data
    # Operations
    proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
    attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS_ELECTRA]  # [Modified in Electra:EIP7549]
    attestations: List[Attestation, MAX_ATTESTATIONS_ELECTRA]  # [Modified in Electra:EIP7549]
    deposits: List[Deposit, MAX_DEPOSITS]
    voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
    sync_aggregate: SyncAggregate
    # Execution
    execution_payload: ExecutionPayload  # [Modified in Electra:EIP6110:EIP7002]
    bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
    # Execution layer requests
    deposit_requests: List[DepositRequest, MAX_DEPOSIT_REQUESTS]  # [New in Electra:EIP6110]
    withdrawal_requests: List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS]  # [New in Electra:EIP7002]
    consolidation_requests: List[ConsolidationRequests, MAX_CONSOLIDATION_REQUESTS]  # [New in Electra:EIP7251]
```

When a beacon block is being processed, CL applies the requests as it is done today and also sends them via separate parameters to the `engine_newPayload` call to get them verified by the EL.

## Execution layer

EL is responsible to surface each request type in a separate list in the response to the `engine_getPayload` and validate that  expected requests passed from the CL via `engine_newPayload` matches actual requests obtained from the block execution.

This design is an alternative to the [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685).

## Security and other considerations

Since EL triggered requests are a product of block execution they only can be validated when a block is being fully executed, thus this change doesn’t affect the security of neither syncing nor online nodes. For syncing nodes the validation will still be happening only when the state is fully available which is happening near to the head of the chain, for online nodes full validation will be happening on each block.

The shift takes place on the request data commitment and storage part. Instead of duplicating requests between both layers it is proposed to keep them only on the CL — the layer which this requests are targeted for.

This proposal affects mev-boost flow in a way that the requests should be sent to the CL alongside to the `ExecutionPayloadHeader`. But this would also be required if requests were a part of the `ExecutionPayload` as the CL would need to apply them to its state in order to build a blinded beacon block.

### Optimistic sync attack

There is an optimistic sync attack vector opened by this proposal.

Consider a fully synced node that has experienced an outage with the following impact on the block's availability:
A: (EL, CL) <- B: (CL) <- C: (new malicious block) <- D (new block)

The node starts up with the head `B` which wasn't stored by the EL and then attempts to import malicious block `C` (a child of `B`):
1. `newPayload(C)` is responded with `SYNCING` as the EL does not have the block `B`
2. Optimistic sync starts
3. CL optimistically applies `C` with the requests that were never triggered by the EL
4. CL applies `D` and `newPayload(D)` is responded with `VALID`

As a result of this attack the node would be tricked into following the chain containing malicious block.

It is important to say that after such an outage the EL of an already synced node will use *full block execution* (instead of the state sync) to catch up with the head of the chain.
Thus, in the case when requests are a part of the EL block (the existing design) step (4) from the above sequence of events would instead be as follows:
* CL applies `D` and `newPayload(D)` is responded with `{status: INVALID, latestValidHash: B.block_hash}`

Which will make the CL to reject the malicious chain and revert to block `B`.

If an adversary finds a way to induce an outage on the majority nodes in the network, it can be leveraged to finalize a chain with invalid EL requests.

The mitigation of this attack is for EL to keep requests sent via `newPayload` around and validate them after each executed block. Potential problem with this mitigation is that CL clients may not send each block via `newPayload` during the optimistic sync thus the requests data may not always be available for the EL.

## Todo
* [ ] Update schema files
* [ ] Update CL specification
* [ ] Update EIPs