### PR TITLE
eth: EIP-7702-compatible summary for eth_getTransactionCount.

### DIFF
--- a/src/eth/state.yaml
+++ b/src/eth/state.yaml
@@ -33,7 +33,7 @@
     schema:
       $ref: '#/components/schemas/bytes'
 - name: eth_getTransactionCount
-  summary: Returns the number of transactions sent from an address.
+  summary: Returns the nonce of an address.  NOTE: The name eth_getTransactionCount reflects the historical fact that before EIP-7702 was introduced in Pectra an account's nonce and sent transaction count were the same.
   params:
     - name: Address
       required: true
@@ -44,7 +44,7 @@
       schema:
         $ref: '#/components/schemas/BlockNumberOrTagOrHash'
   result:
-    name: Transaction count
+    name: Account nonce
     schema:
       $ref: '#/components/schemas/uint'
 - name: eth_getCode


### PR DESCRIPTION
With EIP-7702 the nonce of an account can be bumped w/o the account sending a transaction.  However most (all?) handle this RPC by returning the account's nonce, which is probably the desired behavior post-7702 anyways.