### PR TITLE
engine: specify Trin Execution ClientCode

### DIFF
--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -38,6 +38,7 @@ This enum defines a standard for specifying a client with just two letters. Clie
  - `LS`: lodestar
  - `NM`: nethermind
  - `NB`: nimbus
+ - `TE`: trin-execution
  - `TK`: teku
  - `PM`: prysm
  - `RH`: reth


### PR DESCRIPTION
Hi all :wave: https://github.com/ethereum/trin/tree/master/trin-execution

We are building an execution client with the initial goal of bridging data into the Portal Networks, without devp2p. So I thought I would make a PR to reserve our own code (which is mentioned in the `identification.md` document.

For context about the `without devp2p` part, a longer term goal would be to build it out so it rely's on the Portal Network instead, for transaction gossip and access to old history/state. Currently we can get everything we need to sync to latest from `.era`/`.era1` files and the consensus client itself. Which bypasses the use of devp2p for now, but of course we still need access to the consensus layer through the engine api.