### PR TITLE
eth: add official revert error code for call methods

### DIFF
--- a/src/eth/execute.yaml
+++ b/src/eth/execute.yaml
@@ -13,6 +13,12 @@
     name: Return data
     schema:
       $ref: '#/components/schemas/bytes'
+  errors:
+    - code: 3
+      message: "execution reverted"
+      data:
+        title: "raw EVM revert data"
+        $ref: "#/components/schemas/bytes"
   examples:
     - name: eth_call example
       params:
@@ -25,6 +31,7 @@
       result:
         name: Return data
         value: '0x'
+
 - name: eth_estimateGas
   summary: Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
   params:
@@ -40,6 +47,12 @@
     name: Gas used
     schema:
       $ref: '#/components/schemas/uint'
+  errors:
+    - code: 3
+      message: "execution reverted"
+      data:
+        title: "raw EVM revert data"
+        $ref: "#/components/schemas/bytes"
   examples:
     - name: eth_estimateGas example
       params:
@@ -51,6 +64,7 @@
       result:
         name: Gas used
         value: '0x5208'
+
 - name: eth_createAccessList
   summary: Generates an access list for a transaction.
   params:
@@ -78,6 +92,12 @@
         gasUsed:
           title: Gas used
           $ref: '#/components/schemas/uint'
+  errors:
+    - code: 3
+      message: "execution reverted"
+      data:
+        title: "raw EVM revert data"
+        $ref: "#/components/schemas/bytes"
   examples:
     - name: eth_createAccessList example
       params:


### PR DESCRIPTION
Here I am trying to add an official way of getting the revert data of a contract call. This is often requested by users:

- https://github.com/ethereum/execution-apis/issues/232
- https://github.com/ethereum/execution-apis/issues/463
- https://github.com/ethereum/execution-apis/issues/523

The spec I'm adding here is what geth has been doing since 2022. It seems best to assign a separate error code because it's an unambiguous way of telling the error.