### PR TITLE
fix incorrect regular expressions for uint base types

### DIFF
--- a/src/eth/state.yaml
+++ b/src/eth/state.yaml
@@ -33,7 +33,9 @@
     - name: Storage slot
       required: true
       schema:
-        $ref: '#/components/schemas/uint256'
+        # this used to require strict uint256, but usage of leading zero is commonplace,
+        # so we can't disallow it.
+        $ref: '#/components/schemas/bytesMax32'
     - name: Block
       required: true
       schema:

--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -51,15 +51,15 @@ ratio:
 uint:
   title: hex encoded unsigned integer
   type: string
-  pattern: ^0x([1-9a-f]+[0-9a-f]*|0)$
+  pattern: ^0x(0|[1-9a-f][0-9a-f]*)$
 uint64:
   title: hex encoded 64 bit unsigned integer
   type: string
-  pattern: ^0x([1-9a-f]+[0-9a-f]{0,15})|0$
+  pattern: ^0x(0|[1-9a-f][0-9a-f]{0,15})$
 uint256:
   title: hex encoded 256 bit unsigned integer
   type: string
-  pattern: ^0x(([1-9a-f][0-9a-f]{0,63})|0{1,64})$
+  pattern: ^0x(0|[1-9a-f][0-9a-f]{0,63})$
 hash32:
   title: 32 byte hex value
   type: string

--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -59,7 +59,7 @@ uint64:
 uint256:
   title: hex encoded 256 bit unsigned integer
   type: string
-  pattern: ^0x(([1-9a-f][0-9a-f]{0,63})|0{0,64})$
+  pattern: ^0x(([1-9a-f][0-9a-f]{0,63})|0{1,64})$
 hash32:
   title: 32 byte hex value
   type: string

--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -59,7 +59,7 @@ uint64:
 uint256:
   title: hex encoded 256 bit unsigned integer
   type: string
-  pattern: ^0x([1-9a-f]+[0-9a-f]{0,31})|0$
+  pattern: ^0x(([1-9a-f][0-9a-f]{0,63})|0{0,64})$
 hash32:
   title: 32 byte hex value
   type: string


### PR DESCRIPTION
Closes #556.


The issue with the suggested update to the regex `^0x([1-9a-f][0-9a-f]{0,63})|0$` was that it allowed `0xanything0` to be valid. This issue also exists in the current implementation, which is why the test "works fine," as @fvictorio mentioned. My updated regex addresses all the problems mentioned in the issue and fixes the `|0` edge case.

**My proposed regex:**
```
^0x(([1-9a-f][0-9a-f]{0,63})|0{1,64})$
```