### PR TITLE
engine: Modify fcuV3 to handle payload building in Prague

### DIFF
--- a/src/engine/prague.md
+++ b/src/engine/prague.md
@@ -83,7 +83,7 @@ This method follows the same specification as [`engine_getPayloadV3`](./cancun.m
 
 ### Update the methods of previous forks
 
-This document defines how Prague payload should be handled by the [`Cancun API`](./cancun.md).
+This section defines how Prague payload should be handled by the [`Cancun API`](./cancun.md).
 
 For the following methods:
 
@@ -92,4 +92,7 @@ For the following methods:
 
 a validation **MUST** be added:
 
-1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of payload or payloadAttributes greater or equal to the Prague activation timestamp.
+1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of payload greater or equal to the Prague activation timestamp.
+
+For the [`engine_forkchoiceUpdatedV3`](./cancun.md#engine_forkchoiceupdatedv3) the following modification **MUST** be made:
+1. Return `-38005: Unsupported fork` if `payloadAttributes.timestamp` doesn't fall within the time frame of the Cancun *or Prague* forks.


### PR DESCRIPTION
Extends `engine_forkchoiceUpdatedV3` usage for Prague

Credits to @siladu