### PR TITLE
make engine_getBlobsV1 non-optional as of Pectra

### DIFF
--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -187,7 +187,7 @@ Refer to the specification for [`engine_getPayloadV2`](./shanghai.md#engine_getp
 
 Consensus layer clients **MAY** use this method to fetch blobs from the execution layer blob pool.
 
-*Note*: This is a new optional method introduced after Cancun. It is defined here because it is backwards-compatible with Cancun.
+*Note*: This is a new method introduced after Cancun. It is defined here because it is backwards-compatible with Cancun.
 
 #### Request
 

--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -187,7 +187,7 @@ Refer to the specification for [`engine_getPayloadV2`](./shanghai.md#engine_getp
 
 Consensus layer clients **MAY** use this method to fetch blobs from the execution layer blob pool.
 
-*Note*: This is a new optional method introduced after Cancun. It is defined here because it is backwards-compatible with Cancun. Starting with Osaka, it will become non-optional.
+*Note*: This is a new method introduced after Cancun. It is defined here because it is backwards-compatible with Cancun.
 
 #### Request
 

--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -187,7 +187,7 @@ Refer to the specification for [`engine_getPayloadV2`](./shanghai.md#engine_getp
 
 Consensus layer clients **MAY** use this method to fetch blobs from the execution layer blob pool.
 
-*Note*: This is a new method introduced after Cancun. It is defined here because it is backwards-compatible with Cancun.
+*Note*: This is a new optional method introduced after Cancun. It is defined here because it is backwards-compatible with Cancun. Starting with Osaka, it will become non-optional.
 
 #### Request
 


### PR DESCRIPTION
All the EL clients from the [Pectra Testnet announcement](https://blog.ethereum.org/2025/02/14/pectra-testnet-announcements), [except Erigon](https://github.com/erigontech/erigon/issues/12284) which seems to have indicated support for doing so, support `engine_getBlobsV1` already, so this PR recognizes and ratifies this status quo.

`engine_exchangeCapabilities` in general doesn't suffice because of [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) concerns around swapping out of ELs at specified endpoints at arbitrary times, plus nuanced and unpredictable interactions with EL/JSON-RPC multiplexers, mean that at best, such capability-probing is still a best-effort gamble.

Various advocacy for increased blob count explicitly assumes `engine_getBlobsV1` will exist to mitigate increased bandwidth requirement/usage concerns, and asserts that it's fine, so ensure it does, and Ethereum can continue to help L2's scale.