### PR TITLE
Add error when accessing pruned chain data

### DIFF
--- a/src/eth/block.yaml
+++ b/src/eth/block.yaml
@@ -16,6 +16,9 @@
       oneOf:
         - $ref: '#/components/schemas/notFound'
         - $ref: '#/components/schemas/Block'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getBlockByHash example
       params:
@@ -76,6 +79,9 @@
       oneOf:
         - $ref: '#/components/schemas/notFound'
         - $ref: '#/components/schemas/Block'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getBlockByNumber example
       params:
@@ -131,6 +137,9 @@
         - $ref: '#/components/schemas/notFound'
         - title: Transaction count
           $ref: '#/components/schemas/uint'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getBlockTransactionCountByHash example
       params:
@@ -152,6 +161,9 @@
         - $ref: '#/components/schemas/notFound'
         - title: Transaction count
           $ref: '#/components/schemas/uint'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getBlockTransactionCountByNumber example
       params:
@@ -173,6 +185,9 @@
         - $ref: '#/components/schemas/notFound'
         - title: Uncle count
           $ref: '#/components/schemas/uint'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getUncleCountByBlockHash example
       params:
@@ -194,6 +209,9 @@
         - $ref: '#/components/schemas/notFound'
         - title: Uncle count
           $ref: '#/components/schemas/uint'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getUncleCountByBlockNumber example
       params:
@@ -218,6 +236,9 @@
           type: array
           items:
             $ref: '#/components/schemas/ReceiptInfo'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getBlockReceipts example
       params:

--- a/src/eth/transaction.yaml
+++ b/src/eth/transaction.yaml
@@ -51,6 +51,9 @@
       oneOf:
         - $ref: '#/components/schemas/notFound'
         - $ref: '#/components/schemas/TransactionInfo'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getTransactionByBlockHashAndIndex example
       params:
@@ -93,6 +96,9 @@
       oneOf:
         - $ref: '#/components/schemas/notFound'
         - $ref: '#/components/schemas/TransactionInfo'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getTransactionByBlockNumberAndIndex example
       params:
@@ -131,6 +137,9 @@
       oneOf:
         - $ref: '#/components/schemas/notFound'
         - $ref: '#/components/schemas/ReceiptInfo'
+  errors:
+    - code: 4444
+      message: Pruned history unavailable
   examples:
     - name: eth_getTransactionReceipt example
       params:


### PR DESCRIPTION
This adds an error in the RPC when a users requests data that has been pruned.

Affected RPC:
* eth_getBlockByHash
* eth_getBlockByNumber
* eth_getBlockTransactionCountByHash
* eth_getBlockTransactionCountByNumber
* eth_getUncleCountByBlockHash
* eth_getUncleCountByBlockNumber
* eth_getBlockReceipts
* eth_getTransactionByBlockHashAndIndex
* eth_getTransactionByBlockNumberAndIndex
* eth_getTransactionReceipt

It would be better to create a reusable error for this, but that will require reorganzing the project structure, updating the build pipeline, and resolving the site generation issues. I started working on this [here](https://github.com/ethereum/execution-apis/compare/main...lightclient:execution-apis:no-history-error?expand=1), but wasn't able to get the site generator working. We need to just move to docausauraus.