### PR TITLE
use uint256 for keys to disallow 0x empty

### DIFF
--- a/src/eth/state.yaml
+++ b/src/eth/state.yaml
@@ -33,9 +33,8 @@
     - name: Storage slot
       required: true
       schema:
-        # this used to require strict uint256, but usage of leading zero is commonplace,
-        # so we can't disallow it.
-        $ref: '#/components/schemas/bytesMax32'
+        # usage of leading zero is commonplace, so we allow it.
+        $ref: '#/components/schemas/uint256'
     - name: Block
       required: true
       schema:

--- a/src/schemas/state.yaml
+++ b/src/schemas/state.yaml
@@ -47,7 +47,7 @@ StorageProof:
   properties:
     key:
       title: key
-      $ref: '#/components/schemas/bytesMax32'
+      $ref: '#/components/schemas/uint256'
     value:
       title: value
       $ref: '#/components/schemas/uint256'


### PR DESCRIPTION
the type currently used for storage slot key and storage proof key `bytesMax32` allows 0x empty values. `uint256` seems a better option for keys since the empty 0x value should never be used.

Added some clarification to make this less confusing -

The current type used for storage slot key from the schema is:

https://github.com/ethereum/execution-apis/blob/40088597b8b4f48c45184da002e27ffc3c37641f/src/schemas/base-types.yaml#L18
```
bytesMax32:
  title: 32 hex encoded bytes
  type: string
  pattern: ^0x[0-9a-f]{0,64}$
```

From the existing types, this seemed like the one that matches the desired behaviour -

https://github.com/ethereum/execution-apis/blob/40088597b8b4f48c45184da002e27ffc3c37641f/src/schemas/base-types.yaml#L59
```
uint256:
  title: hex encoded 256 bit unsigned integer
  type: string
  pattern: ^0x(0|[1-9a-f][0-9a-f]{0,63})$
```