### PR TITLE
Correct example value type for `terminalTotalDifficulty`

### DIFF
--- a/src/engine/openrpc/methods/transition_configuration.yaml
+++ b/src/engine/openrpc/methods/transition_configuration.yaml
@@ -17,12 +17,12 @@
       params:
         - name: Consensus client configuration
           value:
-            terminalTotalDifficulty: 0
+            terminalTotalDifficulty: "0x0"
             terminalBlockHash: '0x0000000000000000000000000000000000000000000000000000000000000000'
             terminalBlockNumber: '0x1'
       result:
         name: Execution client configuration
         value:
-          terminalTotalDifficulty: 0
+          terminalTotalDifficulty: "0x0"
           terminalBlockHash: '0x0000000000000000000000000000000000000000000000000000000000000000'
           terminalBlockNumber: '0x1'


### PR DESCRIPTION
#### Overview
This fix the example value type of `terminalTotalDifficulty` in the `engine_exchangeTransitionConfigurationV1` definition .

According to the schemas in `schemas/uint256`, `terminalTotalDifficulty` should be a `uint256`, represented as a hex string with `0x` prefix. 

```yaml
uint256:
  title: hex encoded 256 bit unsigned integer
  type: string
  pattern: ^0x(0|[1-9a-f][0-9a-f]{0,63})$
```

However, the current example value of  `terminalTotalDifficulty`  is the numeric `0`. This PR updates the example value from `0` to `0x0`.

If we use the existing example value, the request will fail in geth due to a type mismatch.

```json
{"jsonrpc":"2.0","id":0,"error":{"code":-32602,"message":"invalid argument 0: json: cannot unmarshal hex string without 0x prefix into Go struct field TransitionConfigurationV1.terminalTotalDifficulty of type *hexutil.Big"}}
```

By changing the format of the value to a hex string, geth can successfully parse the parameter.

```json
{"jsonrpc":"2.0","id":0,"error":{"code":-32000,"message":"invalid ttd: execution 58750000000000000000000 consensus 0x0"}}
```

#### Reproduce

```py
import jwt
import time
import requests
import json

with open("your/path/to/jwt.hex", "r") as f:
    secret_hex = f.read().strip()
secret = bytes.fromhex(secret_hex)

payload = {
    "iat": int(time.time()),
    "exp": int(time.time()) + 60, 
    "iss": "engine-api"
}

token = jwt.encode(payload, secret, algorithm="HS256").decode("utf-8")

headers = {
    "Content-Type": "application/json",
    "Authorization": f"Bearer {token}"
}

data = {
    "jsonrpc": "2.0",
    "method": "engine_exchangeTransitionConfigurationV1",
    "params": [
        {
            "terminalTotalDifficulty": "0x0", # 0 
            "terminalBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
            "terminalBlockNumber": "0x1",
        }
    ],
    "id": 0,
}


response = requests.post("http://localhost:8551", headers=headers, data=json.dumps(data))

print(f"Status Code: {response.status_code}")

print(f"Response:{response.text}")

```
Simply changing `"terminalTotalDifficulty": 0` leads to the aforementioned error.
