### PR TITLE
`engine_getBlobsV2`: add `partialResponse` flag to enable partial hits

### DIFF
--- a/src/engine/openrpc/methods/blob.yaml
+++ b/src/engine/openrpc/methods/blob.yaml
@@ -45,6 +45,11 @@
         type: array
         items:
           $ref: '#/components/schemas/hash32'
+    - name: Partial response requested
+      required: true
+      schema:
+        title: partialResponse
+        type: boolean
   result:
     name: List of blobs and corresponding cell proofs
     schema:
@@ -60,6 +65,8 @@
         - name: Blob versioned hashes
           value:
             - '0x000657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014'
+        - name: Partial response requested
+          value: true
       result:
         name: List of blobs and corresponding cell proofs
         value:


### PR DESCRIPTION
Add optional `partialResponse` boolean flag to reinstate `engine_getBlobsV1`'s partial hit behavior, needed for optimization work.

## Background
- `engine_getBlobsV1` currently achieves a 70-80% hit rate, expected to remain high even as blob volume increases.
- EIP-4844 introduced full blob sidecar broadcasts at the CL layer; with PeerDAS, the CL now gossips column sidecars.
- Because columns sidecars require all cells to be present, support for partial hits was previously dropped in [this commit][cad419].

## Motivation
- The P2P networking team is actively working on backwards-compatible optimizations that can be deployed in-between forks.
- For instance, we're prototyping cell-level deltas to facilitate column reconciliation based on local availability.
- This would reduce redundant full-column transmissions and reclaim useful bandwith to further scale blobs.

## Remarks
- We're aware this change might be procedurally late, but its ease of implementation and its ability to unlock an entire class of interim improvements makes it worthwhile to consider (and we only noticed this opportunity in Berlin).
- We'll happily submit PRs to implement this in EL and CL clients if needed. Just let us know!
- We gated partial responses behind a flag to avoid unnecessary overhead while unused.

[cad419]: https://github.com/ethereum/execution-apis/pull/630/commits/cad4194e3fa37359a1be95e4aad2752d69691077