### PR TITLE
feat: add open-rpc linter to ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,11 @@ jobs:
         with:
           go-version: ^1.18
         id: go
+      - name: Install openrpc-linter
+        run: go install github.com/shanejonas/openrpc-linter@latest
+      - name: Run openrpc-linter
+        run: openrpc-linter lint refs-openrpc.json -r openrpc-lint.yml
+
       - name: Install speccheck
         run: go install github.com/lightclient/rpctestgen/cmd/speccheck@latest
       - name: Run speccheck

--- a/openrpc-lint.yml
+++ b/openrpc-lint.yml
@@ -1,0 +1,16 @@
+description: "OpenRPC validation rules"
+rules:
+  info-title:
+    description: "Info must have description. It supports markdown, and usually shows up as the index page of the documentation."
+    given: "$.info"
+    severity: "error" 
+    then:
+      field: "description"
+      function: "truthy"
+  method-summary:
+    description: "Method must have a summary."
+    given: "$.methods[*]"
+    severity: "error"
+    then:
+      field: "summary"
+      function: "truthy"


### PR DESCRIPTION
Adds initial passing linting for the openrpc document.

For now just checks if `info.title` exists as well as `method.summary`, we can expand support as we go.

I tried to add a lint rule for `examples` but `simulate` currently doesn't have any examples so I left it out for now.