### PR TITLE
Revert "engine_getBlobsV2: Don't prohibit partial responses (#671)"

### DIFF
--- a/src/engine/osaka.md
+++ b/src/engine/osaka.md
@@ -108,8 +108,9 @@ Consensus layer clients **MAY** use this method to fetch blobs from the executio
 Refer to the specification for [`engine_getBlobsV1`](./cancun.md#engine_getblobsv1) with changes of the following:
 
 1. Given an array of blob versioned hashes client software **MUST** respond with an array of `BlobAndProofV2` objects with matching versioned hashes, respecting the order of versioned hashes in the input array.
-1. Given an array of blob versioned hashes, if client software has every one of the requested blobs, it **MUST** return an array of `BlobAndProofV2` objects whose order exactly matches the input array. For instance, if the request is `[A_versioned_hash, B_versioned_hash, C_versioned_hash]` and client software has `A`, `B` and `C` available, the response **MUST** be `[A, B, C]`.
-2. If one or more of the requested blobs are unavailable, the client **MUST** return either `null` or an array of the same length and order, inserting `null` only at the positions of the missing blobs. For instance, if the request is `[A_versioned_hash, B_versioned_hash, C_versioned_hash]` and client software has data for blobs `A` and `C`, but doesn't have data for `B`, the response **MUST** be either `null` or `[A, null, C]`.
+2. Client software **MUST** return `null` in case of any missing or older version blobs. For instance, 
+   1. if the request is `[A_versioned_hash, B_versioned_hash, C_versioned_hash]` and client software has data for blobs `A` and `C`, but doesn't have data for `B`, the response **MUST** be `null`.
+   2. if the request is `[A_versioned_hash_for_blob_with_blob_proof]`, the response **MUST** be `null` as well.
 3. Client software **MUST** support request sizes of at least 128 blob versioned hashes. The client **MUST** return `-38004: Too large request` error if the number of requested blobs is too large.
 4. Client software **MUST** return `null` if syncing or otherwise unable to serve blob pool data.
 5. Callers **MUST** consider that execution layer clients may prune old blobs from their pool, and will respond with `null` if a blob has been pruned.


### PR DESCRIPTION
This reverts commit d41fdf10fabbb73c4d126fb41809785d830acace.

As agreed on [ACDT from July 21](https://github.com/ethereum/pm/issues/1624), the consensus was to:

- go back to V2 all-or-nothing behaviour, and
- introduce V3 in the future (as specified in https://github.com/ethereum/execution-apis/pull/674) as an off-cycle Engine API change instead of linking it to Fusaka
