### PR TITLE
Minor cleanup to EthSimulateResult

### DIFF
--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -168,9 +168,6 @@ Withdrawal:
       $ref: '#/components/schemas/uint64'
 EthSimulateResult:
   title: Full results of eth_simulate
-  $ref: '#/components/schemas/EthSimulateBlockResultSuccess'
-EthSimulateBlockResultSuccess:
-  title: Full results of eth_simulate
   type: array
   items:
     $ref: '#/components/schemas/EthSimulateBlockResultSingleSuccess'


### PR DESCRIPTION
Just removes an unnecessary layer of indirection.  Related to https://github.com/ethereum/execution-apis/pull/675#discussion_r2223742207