### PR TITLE
chore: fixed dead link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ npm run graphql:validate
 This repository is licensed under [CC0](LICENSE).
 
 
-[playground]: https://ethereum.github.io/execution-apis/docs/reference/json-rpc-api
+[playground]: https://ethereum.github.io/execution-apis/api-documentation/
 [openrpc]: https://open-rpc.org
 [validator]: https://open-rpc.github.io/schema-utils-js/functions/validateOpenRPCDocument.html
 [graphql-schema]: http://graphql-schema.ethdevops.io/?url=https://raw.githubusercontent.com/ethereum/execution-apis/main/graphql.json

--- a/docs/reference/quickstart.md
+++ b/docs/reference/quickstart.md
@@ -107,7 +107,7 @@ $ npm run graphql:validate
 This repository is licensed under [CC0](LICENSE).
 
 
-[playground]: https://ethereum.github.io/execution-apis/docs/reference/json-rpc-api
+[playground]: https://ethereum.github.io/execution-apis/api-documentation/
 [openrpc]: https://open-rpc.org
 [validator]: https://open-rpc.github.io/schema-utils-js/functions/validateOpenRPCDocument.html
 [graphql-schema]: http://graphql-schema.ethdevops.io/?url=https://raw.githubusercontent.com/ethereum/execution-apis/main/graphql.json


### PR DESCRIPTION
Hi! I found broken links in docs and fixed their.
Old: https://ethereum.github.io/execution-apis/docs/reference/json-rpc-api
New: https://ethereum.github.io/execution-apis/api-documentation/