### PR TITLE
fix link to tests documentation

### DIFF
--- a/docs/reference/contributors-guide.md
+++ b/docs/reference/contributors-guide.md
@@ -115,4 +115,4 @@ others don't.
 
 [exec-apis]: https://github.com/ethereum/execution-apis
 [pm]: https://github.com/ethereum/pm
-[test-gen]: https://github.com/ethereum/execution-apis/blob/main/tests/README.md
+[test-gen]: https://github.com/ethereum/execution-apis/blob/main/docs/reference/tests.md


### PR DESCRIPTION

Fixed broken and outdated link throughout the project documentation.

- `docs/reference/contributors-guide.md` - Fixed test documentation link
