### PR TITLE
chore: fix dead link to contributors-guide

### DIFF
--- a/docs/reference/intro.md
+++ b/docs/reference/intro.md
@@ -36,4 +36,4 @@ Each category serves specific purposes and provides different functionalities fo
 
 ## Contributing
 
-We welcome contributions to improve this documentation. Please see our [Contributors Guide](/reference/contributors-guide) guide for more information on how to contribute. 
+We welcome contributions to improve this documentation. Please see our [Contributors Guide](/contributors-guide) guide for more information on how to contribute. 


### PR DESCRIPTION
hi! i was reading docs i found non-working link. non-working link is placed [here](https://ethereum.github.io/execution-apis/intro/)