### PR TITLE
Update eip7928.md

### DIFF
--- a/src/engine/eip7928.md
+++ b/src/engine/eip7928.md
@@ -75,9 +75,11 @@ This method follows the same specification as [`engine_newPayloadV4`](./prague.m
 
 1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the payload does not fall within the time frame of the EIP-7928 activation.
 
-2. Client software **MUST** validate the `blockAccessList` field by executing the payload's transactions and verifying that the computed access list matches the provided one.
+2. Client software **MUST** return `-32602: Invalid params` error if the `blockAccessList` field is missing.
 
-3. If the `blockAccessList` field is missing, malformed, or doesn't match the computed access list, the call **MUST** return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}`.
+3. Client software **MUST** validate the `blockAccessList` field by executing the payload's transactions and verifying that the computed access list matches the provided one.
+
+4. If the `blockAccessList` field is malformed or doesn't match the computed access list, the call **MUST** return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}`.
 
 ### engine_getPayloadV6
 


### PR DESCRIPTION
I have added one specification for the `engine_newPayloadV5` method.

According to the Amsterdam upgrade, when the `blockAccessList` field is missing in `engine_newPayloadV5`, the error message: `-32602: Invalid params` should be returned. However, without specifying which error code should be returned, the `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}` may be wrongly returned according to the previous description, which may lead to inconsistencies among clients. Therefore, I think it is necessary to clearly specify the should-be-returned error code.