### PR TITLE
Update View the spec link

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Examples of changes by version type:
 
 This repository is licensed under [CC0][license].
 
-[playground]: https://ethereum.github.io/execution-apis/api-documentation/
+[playground]: https://ethereum.github.io/execution-apis/
 [openrpc]: https://open-rpc.org
 [validator]: https://open-rpc.github.io/schema-utils-js/functions/validateOpenRPCDocument.html
 [graphql-schema]: http://graphql-schema.ethdevops.io/?url=https://raw.githubusercontent.com/ethereum/execution-apis/main/graphql.json


### PR DESCRIPTION
Uses https://ethereum.github.io/execution-apis/ as a link to the spec, https://ethereum.github.io/execution-apis/api-documentation/ page does not exist