### PR TITLE
engine: use -38003 for wrong payloadAttributes version in forkchoiceUpdatedV2

### DIFF
--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -123,7 +123,7 @@ This method follows the same specification as [`engine_newPayloadV1`](./paris.md
   2. `payloadAttributes`: `Object|null` - instance of [`PayloadAttributesV1`](./paris.md#PayloadAttributesV1) | [`PayloadAttributesV2`](#PayloadAttributesV2) or `null`, where:
       - `PayloadAttributesV1` **MUST** be used to build a payload with the `timestamp` value lower than the Shanghai timestamp,
       - `PayloadAttributesV2` **MUST** be used to build a payload with the `timestamp` value greater or equal to the Shanghai timestamp,
-      - Client software **MUST** return `-32602: Invalid params` error if the wrong version of the structure is used in the method call.
+      - Client software **MUST** return `-38003: Invalid payload attributes` error if the wrong version of the structure is used in the method call.
 * timeout: 8s
 
 #### Response


### PR DESCRIPTION
`engine_forkchoiceUpdatedV2` specified `-32602: Invalid params` when the wrong version of `payloadAttributes` is used, but V3 and V4 both return `-38003: Invalid payload attributes` for the same class of error. This aligns V2 with that behaviour.

Ref: https://github.com/ethereum/go-ethereum/pull/33918

-32602 ("Invalid params") is the standard JSON-RPC error for "wrong parameter type/shape, i.e. the call itself is malformed at the RPC level.

-38003 ("Invalid payload attributes") targets this case: attributes that are wrong for the given context.