### PR TITLE
Introduction of REST based + SSZ serialized `new-payload-with-witness`

### DIFF
--- a/src/engine/README.md
+++ b/src/engine/README.md
@@ -3,7 +3,7 @@
 The Engine JSON-RPC API is a collection of methods that all execution clients implement.
 This interface allows the communication between consensus and execution layers of the two-component post-Merge Ethereum Client.
 
-This API is in *active development* and currently specified in markdown documents specified by fork scopes ([Paris](./paris.md), [Shanghai](./shanghai.md), [Cancun](./cancun.md), [Prague](./prague.md), [Osaka](./osaka.md), [Amsterdam](./amsterdam.md)).
+This API is in *active development* and currently specified in markdown documents specified by fork scopes ([Paris](./paris.md), [Shanghai](./shanghai.md), [Cancun](./cancun.md), [Prague](./prague.md), [Osaka](./osaka.md), [Amsterdam](./amsterdam.md)), with shared definitions in [Common](./common.md), [Authentication](./authentication.md), and optional [HTTP REST](./rest.md) bindings.
 
 ## References
 * [Engine API: A Visual Guide](https://hackmd.io/@danielrachi/engine_api)

--- a/src/engine/common.md
+++ b/src/engine/common.md
@@ -51,6 +51,10 @@ These methods are described in [Ethereum JSON-RPC Specification][json-rpc-spec].
 Engine API uses JWT authentication enabled by default.
 JWT authentication is specified in [Authentication](./authentication.md) document.
 
+## HTTP REST bindings (optional)
+
+Execution layer client software **MAY** expose additional `POST` routes on the same Engine HTTP server (same port and authentication rules) as specified in [Engine API -- REST](./rest.md). Those routes are not JSON-RPC; they use JSON request bodies and SSZ response bodies as defined in that document.
+
 ## Versioning
 
 The versioning of the Engine API is defined as follows:

--- a/src/engine/rest.md
+++ b/src/engine/rest.md
@@ -84,16 +84,15 @@ This type is an SSZ `Container` combining the payload validation result and the 
 | 0 | `status` | `uint8` |
 | 1 | `latest_valid_hash` | `Union[None, ByteVector[32]]` |
 | 2 | `validation_error` | `Union[None, List[uint8, VALIDATION_ERROR_MAX]]` |
-| 3 | `witness` | `List[uint8, MAX_WITNESS_BYTES]` |
+| 3 | `witness` | `Union[None, ExecutionWitnessV1]` |
 
 Constants:
 
 * `VALIDATION_ERROR_MAX`: as defined in [SSZ PayloadStatusV1](#ssz-payloadstatusv1).
-* `MAX_WITNESS_BYTES`: `1073741824` (1 GiB) — maximum byte length of the SSZ-encoded `ExecutionWitnessV1`.
 
 Fields `status`, `latest_valid_hash`, and `validation_error` carry the same semantics as [SSZ PayloadStatusV1](#ssz-payloadstatusv1).
 
-The `witness` field contains the SSZ serialization of an [`ExecutionWitnessV1`](#ssz-executionwitnessv1). When the `status` is not `VALID` or no witness was produced, the `witness` field **MUST** be an empty list (`[]`).
+The `witness` field is a `Union` type: the `None` variant **MUST** be used when the `status` is not `VALID` or no witness was produced; the `ExecutionWitnessV1` variant **MUST** be used when the `status` is `VALID` and a witness was generated.
 
 Serialization of `Container`, `Union`, `List`, and `ByteVector` types **MUST** follow the Ethereum consensus [Simple Serialize (SSZ) specification][ssz].
 

--- a/src/engine/rest.md
+++ b/src/engine/rest.md
@@ -1,0 +1,171 @@
+# Engine API -- HTTP REST bindings
+
+This document specifies optional **HTTP REST** endpoints for a subset of the Engine API. They are exposed on the same authenticated Engine HTTP server and port as JSON-RPC (see [Common Definitions](./common.md)).
+
+JSON-RPC methods remain the canonical specification for request parameters and processing rules. REST endpoints **MUST** behave identically to their JSON-RPC counterparts except for the HTTP request shape and response encoding described here.
+
+## Table of contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Structures](#structures)
+  - [SSZ PayloadStatusV1](#ssz-payloadstatusv1)
+  - [SSZ ExecutionWitnessV1](#ssz-executionwitnessv1)
+  - [SSZ NewPayloadWithWitnessResponseV1](#ssz-newpayloadwithwitnessresponsev1)
+- [Endpoints](#endpoints)
+  - [new-payload-with-witness](#new-payload-with-witness)
+    - [Request](#request)
+    - [Successful response](#successful-response)
+    - [Error responses](#error-responses)
+    - [Specification](#specification)
+- [Capabilities](#capabilities)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Structures
+
+### SSZ PayloadStatusV1
+
+This type is an SSZ `Container` encoding the same logical object as JSON-RPC [`PayloadStatusV1`](./paris.md#payloadstatusv1).
+
+| Index | Field name | SSZ type |
+| ----- | ---------- | -------- |
+| 0 | `status` | `uint8` |
+| 1 | `latest_valid_hash` | `Union[None, ByteVector[32]]` |
+| 2 | `validation_error` | `Union[None, List[uint8, VALIDATION_ERROR_MAX]]` |
+
+Constants:
+
+* `VALIDATION_ERROR_MAX`: `8192` (maximum number of `uint8` elements in the list when the `validation_error` union variant is present).
+
+`uint8` values for `status` **MUST** be:
+
+| Value | JSON-RPC `status` string |
+| ----- | ------------------------ |
+| `0` | `VALID` |
+| `1` | `INVALID` |
+| `2` | `SYNCING` |
+| `3` | `ACCEPTED` |
+| `4` | `INVALID_BLOCK_HASH` |
+
+Mapping from JSON-RPC field values to SSZ:
+
+* `latestValidHash: null` **MUST** be encoded as the `None` variant of `latest_valid_hash`.
+* `latestValidHash: <32-byte DATA>` **MUST** be encoded as the `ByteVector[32]` variant (raw bytes, **not** hex).
+* `validationError: null` **MUST** be encoded as the `None` variant of `validation_error`.
+* `validationError: <string>` **MUST** be encoded as UTF-8 bytes in the `List[uint8, VALIDATION_ERROR_MAX]` variant. If the UTF-8 encoding exceeds `VALIDATION_ERROR_MAX` bytes, client software **MUST** truncate to `VALIDATION_ERROR_MAX` bytes without splitting a multi-byte UTF-8 code point (i.e. truncate to the longest prefix that is valid UTF-8 and fits the limit).
+
+### SSZ ExecutionWitnessV1
+
+This type is an SSZ `Container` encoding the execution witness produced during block processing. It contains the raw Merkle trie nodes, preimage keys, contract bytecodes, and block headers required to statelessly verify the block's execution.
+
+| Index | Field name | SSZ type |
+| ----- | ---------- | -------- |
+| 0 | `state` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
+| 1 | `keys` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
+| 2 | `codes` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
+| 3 | `headers` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
+
+Constants:
+
+* `MAX_WITNESS_ITEMS`: `1048576` — maximum number of items per witness field.
+* `MAX_WITNESS_ITEM_BYTES`: `1048576` — maximum byte length of a single witness item.
+
+Field semantics:
+
+* `state` — serialized Merkle Patricia Trie nodes (account trie and storage tries) touched during execution.
+* `keys` — preimage keys (hashed keys → original keys) used to look up trie nodes.
+* `codes` — contract bytecodes accessed during execution.
+* `headers` — RLP-encoded block headers needed by the `BLOCKHASH` opcode.
+
+An empty list (`[]`) for any field indicates no data of that category was accessed during execution.
+
+### SSZ NewPayloadWithWitnessResponseV1
+
+This type is an SSZ `Container` combining the payload validation result and the execution witness.
+
+| Index | Field name | SSZ type |
+| ----- | ---------- | -------- |
+| 0 | `status` | `uint8` |
+| 1 | `latest_valid_hash` | `Union[None, ByteVector[32]]` |
+| 2 | `validation_error` | `Union[None, List[uint8, VALIDATION_ERROR_MAX]]` |
+| 3 | `witness` | `List[uint8, MAX_WITNESS_BYTES]` |
+
+Constants:
+
+* `VALIDATION_ERROR_MAX`: as defined in [SSZ PayloadStatusV1](#ssz-payloadstatusv1).
+* `MAX_WITNESS_BYTES`: `1073741824` (1 GiB) — maximum byte length of the SSZ-encoded `ExecutionWitnessV1`.
+
+Fields `status`, `latest_valid_hash`, and `validation_error` carry the same semantics as [SSZ PayloadStatusV1](#ssz-payloadstatusv1).
+
+The `witness` field contains the SSZ serialization of an [`ExecutionWitnessV1`](#ssz-executionwitnessv1). When the `status` is not `VALID` or no witness was produced, the `witness` field **MUST** be an empty list (`[]`).
+
+Serialization of `Container`, `Union`, `List`, and `ByteVector` types **MUST** follow the Ethereum consensus [Simple Serialize (SSZ) specification][ssz].
+
+[ssz]: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md
+
+## Endpoints
+
+### new-payload-with-witness
+
+This endpoint **MUST** implement the same payload validation and execution logic as JSON-RPC [`engine_newPayloadV5`](./amsterdam.md#engine_newpayloadv5). In addition, when execution succeeds with `VALID` status, the response **MUST** include the execution witness.
+
+#### Request
+
+* HTTP method: `POST`
+* Path: `/new-payload-with-witness`
+* Header `Content-Type` **MUST** be `application/json`.
+* Body: a JSON array of exactly **four** elements, in order:
+  1. `executionPayload`: [`ExecutionPayloadV4`](./amsterdam.md#executionpayloadv4)
+  2. `expectedBlobVersionedHashes`: `Array of DATA`, 32 Bytes each
+  3. `parentBeaconBlockRoot`: `DATA`, 32 Bytes
+  4. `executionRequests`: `Array of DATA` — as defined for [`engine_newPayloadV5`](./amsterdam.md#engine_newpayloadv5)
+* timeout: 8s
+
+#### Successful response
+
+* HTTP status: `200 OK`
+* Header `Content-Type` **MUST** be `application/octet-stream`
+* Body: the SSZ serialization of [`NewPayloadWithWitnessResponseV1`](#ssz-newpayloadwithwitnessresponsev1) as defined above.
+
+#### Error responses
+
+Unless otherwise specified, error bodies **MUST** use `Content-Type: application/json` and **MUST** be a JSON object with at least:
+
+* `code`: `integer` — same semantics as JSON-RPC `error.code` for Engine API errors (see [Errors](./common.md#errors)).
+* `message`: `string` — same semantics as JSON-RPC `error.message`.
+
+| Condition | HTTP status | Notes |
+| --------- | ----------- | ----- |
+| Missing or invalid JWT | `401` | Per [Authentication](./authentication.md). |
+| Malformed JSON body, or body is not a JSON array | `400` | e.g. `-32700` Parse error where applicable. |
+| Wrong number of parameters or invalid parameter shapes | `400` | `-32602` Invalid params |
+| Unsupported fork or other Engine errors that JSON-RPC surfaces as `error` | `400` or `500` as appropriate | Same `code` as JSON-RPC (e.g. `-38005` Unsupported fork). |
+| HTTP method other than `POST` | `405` | |
+
+When JSON-RPC would return a **result** `PayloadStatusV1` (including `INVALID`, `SYNCING`, etc.), this endpoint **MUST** respond with `200 OK` and an SSZ body — **not** an HTTP error — because those outcomes are part of normal payload processing.
+
+#### Specification
+
+This endpoint follows the same specification as [`engine_newPayloadV5`](./amsterdam.md#engine_newpayloadv5) with the following additions:
+
+1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the payload does not fall within the time frame of the Amsterdam activation.
+
+2. When the payload status is `VALID`, the EL **MUST** include the execution witness in the `witness` field of the response. The witness **MUST** be the SSZ serialization of an `ExecutionWitnessV1` containing all state data accessed during block execution.
+
+3. When the payload status is not `VALID` (e.g. `INVALID`, `SYNCING`, `ACCEPTED`), the `witness` field **MUST** be empty (`[]`).
+
+4. The execution witness **MUST** contain sufficient data for a stateless verifier to re-execute the block and arrive at the same post-state root. Specifically:
+   - `state` **MUST** contain every Merkle Patricia Trie node (from both the account trie and any storage tries) that was read or written during execution.
+   - `keys` **MUST** contain the preimage mappings for every hashed key used to traverse the tries.
+   - `codes` **MUST** contain every contract bytecode that was loaded during execution.
+   - `headers` **MUST** contain the RLP-encoded headers of any ancestor blocks accessed via the `BLOCKHASH` opcode.
+
+## Capabilities
+
+Execution layer client software that implements the endpoint in this document **SHOULD** include the following string in the response array of [`engine_exchangeCapabilities`](./common.md#engine_exchangecapabilities) when the corresponding route is supported:
+
+* `rest_engine_newPayloadWithWitness` — `POST /new-payload-with-witness` is available
+
+Consensus layer client software **MAY** use this to discover REST support. This capability name is **not** a JSON-RPC method name; it identifies an optional REST feature.

--- a/src/engine/rest.md
+++ b/src/engine/rest.md
@@ -2,7 +2,7 @@
 
 This document specifies optional **HTTP REST** endpoints for a subset of the Engine API. They are exposed on the same authenticated Engine HTTP server and port as JSON-RPC (see [Common Definitions](./common.md)).
 
-JSON-RPC methods remain the canonical specification for request parameters and processing rules. REST endpoints **MUST** behave identically to their JSON-RPC counterparts except for the HTTP request shape and response encoding described here.
+The Engine API's primary interface is JSON-RPC. This document introduces an **optional** REST endpoint, `POST /new-payload-with-witness`, that performs the same payload validation and execution as [`engine_newPayloadV5`](./amsterdam.md#engine_newpayloadv5) but additionally returns an execution witness. The endpoint accepts the same JSON parameters as `engine_newPayloadV5` and returns the response as SSZ-encoded bytes. All validation rules, processing logic, and error semantics are inherited from `engine_newPayloadV5` unless explicitly stated otherwise below.
 
 ## Table of contents
 
@@ -103,7 +103,7 @@ The `witness` field contains the SSZ serialization of an [`ExecutionWitnessV1`](
 
 Serialization of `Container`, `Union`, `List`, and `ByteVector` types **MUST** follow the Ethereum consensus [Simple Serialize (SSZ) specification][ssz].
 
-[ssz]: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md
+[ssz]: https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md
 
 ## Endpoints
 

--- a/src/engine/rest.md
+++ b/src/engine/rest.md
@@ -58,7 +58,7 @@ Mapping from JSON-RPC field values to SSZ:
 
 ### SSZ ExecutionWitnessV1
 
-This type is an SSZ `Container` encoding the execution witness produced during block processing. It contains the raw Merkle trie nodes, preimage keys, contract bytecodes, and block headers required to statelessly verify the block's execution.
+This type is an SSZ `Container` encoding the execution witness produced during block processing. It contains the raw Merkle trie nodes, contract bytecodes, and block headers required to statelessly verify the block's execution.
 
 | Index | Field name | SSZ type |
 | ----- | ---------- | -------- |

--- a/src/engine/rest.md
+++ b/src/engine/rest.md
@@ -63,21 +63,15 @@ This type is an SSZ `Container` encoding the execution witness produced during b
 | Index | Field name | SSZ type |
 | ----- | ---------- | -------- |
 | 0 | `state` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
-| 1 | `keys` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
-| 2 | `codes` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
-| 3 | `headers` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
+| 1 | `codes` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
+| 2 | `headers` | `List[List[uint8, MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]` |
 
 Constants:
 
 * `MAX_WITNESS_ITEMS`: `1048576` — maximum number of items per witness field.
 * `MAX_WITNESS_ITEM_BYTES`: `1048576` — maximum byte length of a single witness item.
 
-Field semantics:
-
-* `state` — serialized Merkle Patricia Trie nodes (account trie and storage tries) touched during execution.
-* `keys` — preimage keys (hashed keys → original keys) used to look up trie nodes.
-* `codes` — contract bytecodes accessed during execution.
-* `headers` — RLP-encoded block headers needed by the `BLOCKHASH` opcode.
+For detailed field semantics and specific encoding requirements, refer to the [Execution Witness specification](https://github.com/ethereum/execution-specs/blob/e2ff4cc00ca94cb5872090e0f813894e231f6be3/src/ethereum/forks/amsterdam/stateless.py#L27-L47).
 
 An empty list (`[]`) for any field indicates no data of that category was accessed during execution.
 
@@ -120,7 +114,9 @@ This endpoint **MUST** implement the same payload validation and execution logic
   1. `executionPayload`: [`ExecutionPayloadV4`](./amsterdam.md#executionpayloadv4)
   2. `expectedBlobVersionedHashes`: `Array of DATA`, 32 Bytes each
   3. `parentBeaconBlockRoot`: `DATA`, 32 Bytes
-  4. `executionRequests`: `Array of DATA` — as defined for [`engine_newPayloadV5`](./amsterdam.md#engine_newpayloadv5)
+  4. `executionRequests`: `Array of DATA`
+
+  These parameters are as defined for [`engine_newPayloadV5`](./amsterdam.md#engine_newpayloadv5).
 * timeout: 8s
 
 #### Successful response
@@ -156,11 +152,6 @@ This endpoint follows the same specification as [`engine_newPayloadV5`](./amster
 
 3. When the payload status is not `VALID` (e.g. `INVALID`, `SYNCING`, `ACCEPTED`), the `witness` field **MUST** be empty (`[]`).
 
-4. The execution witness **MUST** contain sufficient data for a stateless verifier to re-execute the block and arrive at the same post-state root. Specifically:
-   - `state` **MUST** contain every Merkle Patricia Trie node (from both the account trie and any storage tries) that was read or written during execution.
-   - `keys` **MUST** contain the preimage mappings for every hashed key used to traverse the tries.
-   - `codes` **MUST** contain every contract bytecode that was loaded during execution.
-   - `headers` **MUST** contain the RLP-encoded headers of any ancestor blocks accessed via the `BLOCKHASH` opcode.
 
 ## Capabilities
 


### PR DESCRIPTION

Currently, for a zkVM prover to statelessly validate a block, the Execution Witness (the primary input needed for this validation) can only be obtained by calling two separate Engine API methods sequentially: first `engine_newPayload`, then `debug_executionWitness`. This introduces two fundamental problems:

### 1. Impossible for zkAttestors to follow the exact head of the chain

A block must first be fully executed via `engine_newPayload` before `debug_executionWitness` can be called. This means in the very best case, attestation happens **one block behind** the chain's head — making true real-time attestation impossible.

### 2. Slow witness retrieval, especially for large witnesses

On an average Ethereum block, the Execution Witness is about **17 MB**. Using the current two-call method:

| Witness Size (Approx) | `debug_executionWitness` Retrieval (Geth) |
| :--- | :--- |
| **17 MB** (typical) | ~1.4 s |
| **100 MB** | ~3.9 s |
| **300 MB** | ~11 s |
| **500 MB** | ~23 s |

These numbers are from the Geth client.


## Approach

The key question was: **how do we cut this down enough for true real-time attestation?**

### Step 1: Combine the two calls

The first step was introducing `engine_newPayloadWithWitness`, a JSON-RPC method that combines `engine_newPayload` and `debug_executionWitness` into a single call. This gave roughly a **2× improvement** — but was still not enough. The timeout for `engine_newPayload` is **8 seconds**; we need the new method to be comfortably within this budget even for worst-case blocks (~500 MB witness).

### Step 2: Fix the transport and serialization bottlenecks

Profiling `engine_newPayloadWithWitness` over JSON-RPC revealed two dominant bottlenecks:

1. **Transport**: Sending hundreds of megabytes of witness data over JSON-RPC was extremely expensive — the 500 MB witness case spent **74%** of total time just on transport overhead.
2. **Serialization**: The witness is JSON-serialized with hex encoding, roughly doubling the on-the-wire size (a ~300 MB raw witness becomes ~500–600 MB in JSON hex).

To address both, this spec introduces `POST /new-payload-with-witness`:

- **Pure HTTP** for transport (no JSON-RPC framing overhead)
- **SSZ serialization** for the response (compact binary encoding, no hex doubling)

### Step 3: Optimize the EL pipeline

After eliminating serialization and transport bottlenecks, the dominant cost was the EL's "store" phase (3,791 ms, 98% of block time). Profiling revealed that this was **not CPU-bound by the Merkle trie update itself**, but rather by I/O contention and blocking synchronization:

1. **Trie worker optimization**: The trie update worker used a zero-buffered channel (`sync_channel(0)`), forcing block *N*'s in-memory trie update to wait until block *N−1*'s disk flush completed. Decoupling these into two threads with a buffered channel eliminated the blocking.
2. **Blocking witness persistence**: `store_witness` was on the critical path, serializing a ~300 MB witness and writing it to RocksDB before `store_block` could proceed. This was moved to a background thread since it's only needed for `debug_executionWitness` RPC lookups.
3. **Concurrent Merkle trie updates**: Storage trie updates for individual accounts are independent and can be parallelized. A 16-shard worker pool was introduced to process account and storage trie updates concurrently, with cross-worker communication for storage root aggregation.

These optimizations reduced the store phase from **3,791 ms to 726 ms** (~5.2× improvement).

## Benchmark Results

All benchmarks were performed using the [Ethrex](https://github.com/lambdaclass/ethrex) client running on a Kurtosis local testnet with Lighthouse as the CL. The test block contained **203 transactions** consuming **36 Mgas**, producing a **~302 MB** SSZ-encoded witness which is about 500mb if it were to be JSON encoded.

### `engine_newPayloadWithWitness` (JSON-RPC + JSON)

Implementation: [ethrex `engine_newPayloadWithWitness`](https://github.com/developeruche/witness-bench/tree/main/new-payload-with-witness/ethrex)

#### Latency by witness size

| Witness Size (Approx) | Total Round-Trip (ms) |
| :--- | :--- |
| **100 MB** | 1,117 ms |
| **300 MB** | 6,794 ms |
| **500 MB** | 8,131 ms |

#### Component breakdown (500 MB witness)

| Component | Duration (ms) | % of Total | Notes |
| :--- | :--- | :--- | :--- |
| Block Production | 60 ms | 0.7% | |
| Witness Generation | 528 ms | 6.5% | |
| Serialization (RLP + Hex) | **1,499 ms** | **18%** | |
| Transport / Overhead | **6,044 ms** | **74%** | **The bottleneck** |
| **TOTAL** | **8,131 ms** | **100%** | |


### `POST /new-payload-with-witness` (HTTP + SSZ) — Initial

Implementation: [ethrex `feat/zkengine-http`](https://github.com/developeruche/ethrex/tree/feat/zkengine-http) (before EL optimizations)

#### Component breakdown (500 MB witness → 306 MB SSZ)

| Component | Duration | % of Block Total |
| :--- | :--- | :--- |
| Validate | 0.01 ms | — |
| Execute | 95 ms | 2% |
| Merkle | 0.58 ms | — |
| Store | 3,791 ms | 98% |
| **Block total** | **3,887 ms** | |
| Execution + Witness | 3,889 ms | ≈ block total |
| SSZ Encoding | 71 ms | |
| **EL total** | **3,984 ms** | |

**CL side:**

| Metric | Value |
| :--- | :--- |
| Round-trip latency | 4,653 ms ✓ within 8s budget |
| Witness size received | 306 MB ✓ (500 MB shrunk to 306 MB) |


### `POST /new-payload-with-witness` (HTTP + SSZ) — Optimized

Implementation: [ethrex `feat/zkengine-http`](https://github.com/developeruche/ethrex/tree/feat/zkengine-http) (with EL pipeline optimizations)

#### Component breakdown (302 MB SSZ witness, 203 txs, 36 Mgas)

| Component | Duration | % of Block Total |
| :--- | :--- | :--- |
| Validate | 0.00 ms | — |
| Execute | 71 ms | 9% |
| Merkle | 0.35 ms | — |
| Store | 726 ms | 91% |
| **Block total** | **798 ms** | |
| Execution + Witness | 800 ms | ≈ block total |
| SSZ Encoding | 117 ms | |
| **EL total** | **932 ms** | |

#### Store breakdown (726 ms)

| Sub-step | Duration | % of Store |
| :--- | :--- | :--- |
| **Witness generation** | 574 ms | 79% |
| Witness persistence | ~149 ms | 20% |
| Store block (RocksDB writes + trie channel + commit) | 3.5 ms | 0.5% |

### Summary comparison

| Metric | JSON-RPC + JSON | HTTP + SSZ (initial) | HTTP + SSZ (optimized) |
| :--- | :--- | :--- | :--- |
| **EL total** | 8,131 ms | 3,984 ms | **932 ms** |
| **Wire size** | ~500 MB | 306 MB | **302 MB** |
| **Serialization** | 1,499 ms | 71 ms | **117 ms** |
| **Store phase** | — | 3,791 ms | **726 ms** |

> [!NOTE]
> With the EL pipeline optimizations, the dominant cost has shifted from the Merkle trie update (previously ~3,500 ms) to **witness generation** (574 ms, 79% of the store phase). Witness generation involves re-traversing the state and storage tries with logging enabled to capture the pre-state and post-update trie nodes required for stateless validation. This is the current irreducible floor.

**For more context on "Store"**

The "store" phase is the EL's **state commitment step**. It makes the executed block's state available for subsequent blocks. After EL pipeline optimizations, its sub-steps are:

| Sub-step | Duration | Description |
| :--- | :--- | :--- |
| **Witness generation** | ~574 ms | Re-traverses the state and storage tries to collect all accessed trie nodes, contract bytecodes, and block headers into the `ExecutionWitness`. This is the dominant cost — I/O-bound by MPT node reads. |
| **Witness persistence** | ~149 ms | Serializes the witness and writes it to the database for `debug_executionWitness` RPC lookups. Can be deferred to a background task. |
| **Trie channel + RocksDB writes** | ~3.5 ms | Sends the trie diff to the background worker (0.01 ms), writes block data to RocksDB (1.3 ms), waits for in-memory trie update (0.0 ms), and commits (2.2 ms). |

The witness generation cost scales with the number of state accesses in the block and is unaffected by the choice of transport or serialization format.

### Prototype Code

1. **`engine_newPayloadWithWitness`** (JSON-RPC method): In its Ethrex implementation [here](https://github.com/developeruche/witness-bench/tree/main/new-payload-with-witness/ethrex), a new JSON-RPC method was introduced. This method behaves exactly like `engine_newPayloadV5` but additionally returns the `ExecutionWitness` of the block in the response.

2. **`POST /new-payload-with-witness`** (HTTP + SSZ endpoint): In the Ethrex implementation [here](https://github.com/developeruche/ethrex/tree/feat/zkengine-http), the same logic is exposed as a REST endpoint on the Engine API server. The request accepts the same JSON parameters as `engine_newPayloadV5`. The response is SSZ-encoded bytes containing the `PayloadStatus` and the `ExecutionWitness`.
