### PR TITLE
feat(schema): Update schema of `engine_getBlobsV2` as per `Osaka.md`

### DIFF
--- a/src/engine/openrpc/methods/blob.yaml
+++ b/src/engine/openrpc/methods/blob.yaml
@@ -48,9 +48,11 @@
   result:
     name: List of blobs and corresponding cell proofs
     schema:
-      type: array
-      items:
-        $ref: '#/components/schemas/BlobAndProofV2'
+      oneOf:
+        - type: array
+          items:
+            $ref: '#/components/schemas/BlobAndProofV2'
+        - type: 'null'
   errors:
     - code: -38004
       message: Too large request


### PR DESCRIPTION
Closes #777 

## Fix: Align `engine_getBlobsV2` result schema with Osaka spec

### Problem
The result schema for `engine_getBlobsV2` in `blob.yaml` only declares an array return type. As per `osaka.md`, the method must return `null` whenever **any** requested blob is missing, pruned, or unavailable — making `null` a primary return value, not an edge case.

The current schema does not permit `null`, creating a mismatch between the `machine-readable spec` and the `Markdown specification`.

### Change
Updated the result schema in `blob.yaml` to use `oneOf`, allowing eitheran array of `BlobAndProofV2` objects or `null`.

### Fix
```yaml
result:
  name: List of blobs and corresponding cell proofs
  schema:
    oneOf:
      - type: array
        items:
          $ref: '#/components/schemas/BlobAndProofV2'
      - type: 'null'
```

### References
- [`osaka.md` — engine_getBlobsV2](https://github.com/ethereum/execution-apis/blob/main/src/engine/osaka.md#engine_getblobsv2)
- [`blob.yaml#L50`](https://github.com/ethereum/execution-apis/blob/main/src/engine/openrpc/methods/blob.yaml#L50)

@MysticRyuujin  please review the issue and PR