### PR TITLE
schemas: `byte` and `uintDecimal` patterns fixed to match geth

### DIFF
--- a/src/schemas/base-types.yaml
+++ b/src/schemas/base-types.yaml
@@ -10,7 +10,7 @@ addresses:
 byte:
   title: hex encoded byte
   type: string
-  pattern: ^0x([0-9a-fA-F]?){1,2}$
+  pattern: ^0x[0-9a-f]{1,2}$
 bytes:
   title: hex encoded bytes
   type: string
@@ -75,7 +75,7 @@ uint256:
 uintDecimal:
   title: decimal unsigned integer string
   type: string
-  pattern: ^[1-9][0-9]*$
+  pattern: ^(0|[1-9][0-9]*)$
 hash32:
   title: 32 byte hex value
   type: string


### PR DESCRIPTION
two regex patterns in `src/schemas/base-types.yaml` diverge from what geth actually does:

* `byte`

```diff
- ^0x([0-9a-fA-F]?){1,2}$
+ ^0x[0-9a-f]{1,2}$
```

Old pattern allows `"0x"` but [geth](https://github.com/ethereum/go-ethereum/blob/970e3cd6f01331fab4888d4f185f7081c88e029d/common/hexutil/json.go#L285) would always append at least one hex digit (e.g. to make it `0x0` in the smallest case)

---

* `uintDecimal`
 
```diff
- ^[1-9][0-9]*$
+ ^(0|[1-9][0-9]*)$
```

old pattern rejects `"0"` but [geth](https://github.com/ethereum/go-ethereum/blob/970e3cd6f01331fab4888d4f185f7081c88e029d/internal/ethapi/api.go#L2160-L2162) allows plain 0 (here `api.networkVersion` is just `uint64` and there is no guarding or whatever against `0`). i used this example cuz it is the JSON-emitter for `net_version`

---

AFAIK all in-spec example values that resolve to these two types still validate without additional changes