### PR TITLE
Expose EIP-7843 slot number via JSON-RPC

### DIFF
--- a/src/schemas/block.yaml
+++ b/src/schemas/block.yaml
@@ -113,6 +113,9 @@ Block:
     blockAccessListHash:
       title: EIP-7928 block access list hash
       $ref: '#/components/schemas/hash32'
+    slotNumber:
+      title: Slot number
+      $ref: '#/components/schemas/uint'
 BlockTag:
   title: Block tag
   type: string

--- a/src/schemas/block.yaml
+++ b/src/schemas/block.yaml
@@ -114,7 +114,7 @@ Block:
       title: EIP-7928 block access list hash
       $ref: '#/components/schemas/hash32'
     slotNumber:
-      title: Slot number
+      title: EIP-7843 slot number
       $ref: '#/components/schemas/uint'
 BlockTag:
   title: Block tag


### PR DESCRIPTION
The slot number should be exposed via JSON-RPC so that it is possible to validate eth_getBlockByHash response against the block hash.