### PR TITLE
fix: keep el internal rules outside engine api block access list

### DIFF
--- a/src/engine/amsterdam.md
+++ b/src/engine/amsterdam.md
@@ -125,9 +125,6 @@ This method follows the same specification as [`engine_newPayloadV4`](./prague.m
 
 2. Client software **MUST** return `-32602: Invalid params` error if the `blockAccessList` field is missing.
 
-3. Client software **MUST** validate the `blockAccessList` field by executing the payload's transactions and verifying that the computed access list matches the provided one.
-If this validation fails, the call **MUST** return `{status: INVALID, latestValidHash: null, validationError: errorMessage | null}`.
-
 ### engine_getPayloadV6
 
 This method is updated to return the new `ExecutionPayloadV4` structure.
@@ -154,8 +151,6 @@ This method is updated to return the new `ExecutionPayloadV4` structure.
 This method follows the same specification as [`engine_getPayloadV5`](./osaka.md#engine_getpayloadv5) with the following changes:
 
 1. Client software **MUST** return `-38005: Unsupported fork` error if the `timestamp` of the built payload does not fall within the time frame of the Amsterdam fork.
-
-2. When building the block, client software **MUST** collect all account accesses and state changes during transaction execution and populate the `blockAccessList` field in the returned `ExecutionPayloadV4` with the RLP-encoded access list.
 
 ### engine_getPayloadBodiesByHashV2
 


### PR DESCRIPTION
Engine API should not repeat/spec EL-internal block validity rules already defined by the EIP.

This is based on feedback by @mkalinin [here](https://discord.com/channels/595666850260713488/1364000387195076608/1508467130788741261).