### PR TITLE
Default Block param to 'latest' on eth_* state methods

### DIFF
--- a/src/eth/state.yaml
+++ b/src/eth/state.yaml
@@ -6,7 +6,8 @@
       schema:
         $ref: '#/components/schemas/address'
     - name: Block
-      required: true
+      required: false
+      description: "default: 'latest'"
       schema:
         $ref: '#/components/schemas/BlockNumberOrTagOrHash'
   result:
@@ -37,7 +38,8 @@
         # so we can't disallow it.
         $ref: '#/components/schemas/bytesMax32'
     - name: Block
-      required: true
+      required: false
+      description: "default: 'latest'"
       schema:
         $ref: '#/components/schemas/BlockNumberOrTagOrHash'
   result:
@@ -70,7 +72,8 @@
           items:
             $ref: '#/components/schemas/bytesMax32'
     - name: Block
-      required: true
+      required: false
+      description: "default: 'latest'"
       schema:
         $ref: '#/components/schemas/BlockNumberOrTagOrHash'
   result:
@@ -111,7 +114,8 @@
       schema:
         $ref: '#/components/schemas/address'
     - name: Block
-      required: true
+      required: false
+      description: "default: 'latest'"
       schema:
         $ref: '#/components/schemas/BlockNumberOrTagOrHash'
   result:
@@ -136,7 +140,8 @@
       schema:
         $ref: '#/components/schemas/address'
     - name: Block
-      required: true
+      required: false
+      description: "default: 'latest'"
       schema:
         $ref: '#/components/schemas/BlockNumberOrTagOrHash'
   result:
@@ -168,7 +173,8 @@
         items:
           $ref: '#/components/schemas/bytesMax32'
     - name: Block
-      required: true
+      required: false
+      description: "default: 'latest'"
       schema:
         $ref: '#/components/schemas/BlockNumberOrTagOrHash'
   result:


### PR DESCRIPTION
Marks the `Block` parameter `required: false` (default `latest`) on the six state-reading methods in `state.yaml`: `eth_getBalance`, `eth_getStorageAt`, `eth_getStorageValues`, `eth_getTransactionCount`, `eth_getCode`, `eth_getProof`.

> Proposal for discussion — opening for visibility ahead of an [RPC Standards](https://github.com/ethereum/pm/issues/2075) discussion (ref: NethermindEth/nethermind#11764). Not expected to merge until client consensus + go-ethereum implementation.

### Why
The spec is internally inconsistent on this. `eth_call`, `eth_estimateGas` and `eth_createAccessList` already mark `Block` `required: false`, and `eth_simulateV1` documents `default: 'latest'` — yet the state-reading methods require it. 
This PR aligns them under one rule.

Client behaviour is also already split: **reth** and **Nethermind** default an omitted block param to `latest`, while **geth**, **erigon** and **besu** reject it. 
Standardising on default-to-latest matches existing behaviour in 2 of 5 clients and removes a client-diversity footgun, rather than leaving it implementation-defined.

### Changes
- `src/eth/state.yaml` — `Block` → `required: false` + `description: "default: 'latest'"` on all six methods (mirrors the `eth_simulateV1` idiom).

### TBD
- [ ] Reach consensus between all EL clients (only Nethermind/Reth rn implement this default-to-latest behaviour)
- [ ] Enforce compliance via hive tests with a test case that explicitly omits the block tag (asserting default-to-latest behaviour)
