### PR TITLE
feat: add support for semver prereleases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "remark-gfm": "~4.0.1",
+        "semver": "^7.8.1",
         "typescript": "~5.6.2"
       }
     },
@@ -15605,7 +15606,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "remark-gfm": "~4.0.1",
+    "semver": "7.8.1",
     "typescript": "~5.6.2"
   }
 }

--- a/scripts/assemble-versions.js
+++ b/scripts/assemble-versions.js
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { exit } from "node:process";
+import semver from "semver";
 
 const MAX_VERSIONS = 10;
 
@@ -14,20 +15,9 @@ function sh(cmd, args, opts = {}) {
   });
 }
 
-function semverDesc(a, b) {
-  const pa = String(a)
-    .replace(/^v/, "")
-    .split(".")
-    .map((n) => parseInt(n, 10) || 0);
-  const pb = String(b)
-    .replace(/^v/, "")
-    .split(".")
-    .map((n) => parseInt(n, 10) || 0);
-  for (let i = 0; i < 3; i++) {
-    if ((pb[i] || 0) !== (pa[i] || 0)) return (pb[i] || 0) - (pa[i] || 0);
-  }
-  return 0;
-}
+// Descending precedence: higher versions first. semver.rcompare strips a
+// leading "v" itself and applies full spec precedence (incl. prereleases).
+const semverDesc = (a, b) => semver.rcompare(a, b);
 
 function listReleases() {
   try {
@@ -75,7 +65,12 @@ function downloadAndExtract(tag) {
 
 const releases = listReleases()
   .filter((r) => !r.isDraft && !r.isPrerelease)
-  .map((r) => r.tagName);
+  .map((r) => r.tagName)
+  .filter((tag) => {
+    if (semver.valid(tag)) return true;
+    console.warn(`assemble-versions: skipping non-semver tag "${tag}"`);
+    return false;
+  });
 
 if (releases.length === 0) {
   console.log("assemble-versions: no published releases found; nothing to assemble");


### PR DESCRIPTION
This adds support for prerelease additions to semver. The changes here track the previous v prefix as well as common -alpha,-beta,-rc2 tags as supported by npmjs