### PR TITLE
bump openrpc schema to 1.4.1

### DIFF
--- a/tools/cmd/speccheck/check.go
+++ b/tools/cmd/speccheck/check.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	openrpc "github.com/open-rpc/meta-schema"
+	openrpc "github.com/open-rpc/spec-types/generated/packages/go/v1_4"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 

--- a/tools/cmd/speccheck/spec.go
+++ b/tools/cmd/speccheck/spec.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	openrpc "github.com/open-rpc/meta-schema"
+	openrpc "github.com/open-rpc/spec-types/generated/packages/go/v1_4"
 )
 
 type ContentDescriptor struct {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ethereum/go-ethereum v1.17.4-0.20260609123946-08aaa7c5ff9d
 	github.com/holiman/uint256 v1.3.2
 	github.com/mattn/go-jsonpointer v0.0.1
-	github.com/open-rpc/meta-schema v0.0.0-20210416041958-626a15d0a618
+	github.com/open-rpc/spec-types/generated/packages/go v0.1.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3
@@ -93,7 +93,6 @@ require (
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 // indirect
 	github.com/open-rpc/openrpc-linter v0.0.16 // indirect
-	github.com/open-rpc/spec-types/generated/packages/go v0.1.1 // indirect
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 // indirect
 	github.com/pion/dtls/v3 v3.1.2 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -244,8 +244,6 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/open-rpc/meta-schema v0.0.0-20210416041958-626a15d0a618 h1:EoH8oqYGi6BElF3PnUr65GoPVTtaDlnYkrVZct1Q/Sg=
-github.com/open-rpc/meta-schema v0.0.0-20210416041958-626a15d0a618/go.mod h1:Ag6rSXkHIckQmjFBCweJEEt1mrTPBv8b9W4aU/NQWfI=
 github.com/open-rpc/openrpc-linter v0.0.16 h1:dkVWIuWGzV8hc09DPOicHb/OglJYBlyYD10C/Whjjys=
 github.com/open-rpc/openrpc-linter v0.0.16/go.mod h1:5TxXfVxjYVLK3sWXdK5Kp4+/xpIbsU17dF7e3w/PamI=
 github.com/open-rpc/spec-types/generated/packages/go v0.1.1 h1:eznQY3vMHCOy8ja79aUmBVhj2lEmpjqmLmscgMdVnBs=

--- a/tools/internal/metaschema/metaschema.go
+++ b/tools/internal/metaschema/metaschema.go
@@ -2,15 +2,22 @@ package metaschema
 
 import (
 	"encoding/json"
+	"strings"
 
-	openrpc "github.com/open-rpc/meta-schema"
+	openrpc "github.com/open-rpc/spec-types/generated/packages/go/v1_4"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
-var openrpcSchemaRaw = openrpc.RawOpenrpc_document
+var openrpcSchemaRaw = openrpc.RawOpenrpcDocument
 var openrpcSchema *jsonschema.Schema
 
 const OpenRpcSchemaURL = "https://meta.open-rpc.org/"
+const draft07SchemaURL = "http://json-schema.org/draft-07/schema#"
+
+var externalRefReplacements = map[string]string{
+	"https://meta.json-schema.tools":                                                draft07SchemaURL,
+	"https://meta.json-schema.tools/#/definitions/JSONSchemaObject/properties/$ref": draft07SchemaURL + "/properties/$ref",
+}
 
 func init() {
 	var openrpcSchemaJSON = map[string]any{}
@@ -23,15 +30,7 @@ func init() {
 	// Override it to a supported JSON Schema draft so compilation doesn't require that metaschema.
 	openrpcSchemaJSON["$schema"] = "http://json-schema.org/draft-07/schema"
 
-	// The upstream OpenRPC meta-schema embeds a copy of the json-schema-tools meta-schema under
-	// `definitions.JSONSchema` and gives it `$id: https://meta.json-schema.tools/`.
-	// Remove those identifiers so the embedded definition behaves like a normal local subschema.
-	if defs, ok := openrpcSchemaJSON["definitions"].(map[string]any); ok {
-		if js, ok := defs["JSONSchema"].(map[string]any); ok {
-			delete(js, "$id")
-			delete(js, "$schema")
-		}
-	}
+	replaceExternalSchemaRefs(openrpcSchemaJSON)
 
 	compiler := jsonschema.NewCompiler()
 	err = compiler.AddResource(OpenRpcSchemaURL, openrpcSchemaJSON)
@@ -44,4 +43,24 @@ func init() {
 
 func Validate(schema map[string]any) error {
 	return openrpcSchema.Validate(schema)
+}
+
+func replaceExternalSchemaRefs(v any) {
+	switch x := v.(type) {
+	case map[string]any:
+		if ref, ok := x["$ref"].(string); ok && strings.Contains(ref, "json-schema.tools") {
+			if repl, found := externalRefReplacements[ref]; found {
+				x["$ref"] = repl
+			} else {
+				x["$ref"] = draft07SchemaURL
+			}
+		}
+		for _, vv := range x {
+			replaceExternalSchemaRefs(vv)
+		}
+	case []any:
+		for _, vv := range x {
+			replaceExternalSchemaRefs(vv)
+		}
+	}
 }

--- a/tools/internal/specgen/base-doc.json
+++ b/tools/internal/specgen/base-doc.json
@@ -1,5 +1,5 @@
 {
-	"openrpc": "1.2.4",
+	"openrpc": "1.4.1",
 	"info": {
 		"title": "Ethereum JSON-RPC Specification",
 		"description": "A specification of the standard interface for Ethereum clients.",


### PR DESCRIPTION
Replaces this https://github.com/ethereum/execution-apis/pull/809