### PR TITLE
Use backticks for FCU

### DIFF
--- a/src/engine/paris.md
+++ b/src/engine/paris.md
@@ -190,7 +190,7 @@ The payload build process is specified as follows:
 
 #### Request
 
-* method: "engine_forkchoiceUpdatedV1"
+* method: `engine_forkchoiceUpdatedV1`
 * params:
   1. `forkchoiceState`: `Object` - instance of [`ForkchoiceStateV1`](#ForkchoiceStateV1)
   2. `payloadAttributes`: `Object|null` - instance of [`PayloadAttributesV1`](#PayloadAttributesV1) or `null`

--- a/src/engine/shanghai.md
+++ b/src/engine/shanghai.md
@@ -117,7 +117,7 @@ This method follows the same specification as [`engine_newPayloadV1`](./paris.md
 
 #### Request
 
-* method: "engine_forkchoiceUpdatedV2"
+* method: `engine_forkchoiceUpdatedV2`
 * params:
   1. `forkchoiceState`: `Object` - instance of [`ForkchoiceStateV1`](./paris.md#ForkchoiceStateV1)
   2. `payloadAttributes`: `Object|null` - instance of [`PayloadAttributesV1`](./paris.md#PayloadAttributesV1) | [`PayloadAttributesV2`](#PayloadAttributesV2) or `null`, where:


### PR DESCRIPTION
This PR uses backticks for FCU v1 and v2.