### PR TITLE
Remove redundant specifications for forkchoiceUpdatedV3+

### DIFF
--- a/src/engine/amsterdam.md
+++ b/src/engine/amsterdam.md
@@ -226,10 +226,6 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV3`](./c
 
     2. `payloadAttributes.timestamp` does not fall within the time frame of the Amsterdam fork, return `-38005: Unsupported fork` on failure.
 
-    3. `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by `forkchoiceState.headBlockHash`, return `-38003: Invalid payload attributes` on failure.
-
-    4. If any of the above checks fails, the `forkchoiceState` update **MUST NOT** be rolled back.
-
 2. Client software **MUST** use the target gas limit supplied in `payloadAttributes.targetGasLimit` when constructing a payload.
 
 3. If `custodyColumns` is provided (non-null), the following rules apply:

--- a/src/engine/cancun.md
+++ b/src/engine/cancun.md
@@ -143,10 +143,6 @@ This method follows the same specification as [`engine_forkchoiceUpdatedV2`](./s
 
     2. `payloadAttributes.timestamp` does not fall within the time frame of the Cancun fork, return `-38005: Unsupported fork` on failure.
 
-    3. `payloadAttributes.timestamp` is greater than `timestamp` of a block referenced by `forkchoiceState.headBlockHash`, return `-38003: Invalid payload attributes` on failure.
-
-    4. If any of the above checks fails, the `forkchoiceState` update **MUST NOT** be rolled back.
-
 ### engine_getPayloadV3
 
 The response of this method is extended with [`BlobsBundleV1`](#blobsbundlev1) containing the blobs, their respective KZG commitments


### PR DESCRIPTION
This PR removes redundant specifications for forkchoiceUpdatedV3+. Since the changes _extend_ forkchoiceUpdatedV1's specifications, there is no need to have conditions equal to 8.2 and 8.3.