### PR TITLE
Add net_listening and net_peerCount

### DIFF
--- a/src/eth/client.yaml
+++ b/src/eth/client.yaml
@@ -133,3 +133,30 @@
       result:
         name: Network ID
         value: '1'
+- name: net_listening
+  summary: Returns true if the client is actively listening for network connections.
+  params: []
+  result:
+    name: Listening
+    schema:
+      title: Listening
+      type: boolean
+  examples:
+    - name: net_listening example
+      params: []
+      result:
+        name: Listening
+        value: true
+- name: net_peerCount
+  summary: Returns the number of peers currently connected to the client.
+  params: []
+  result:
+    name: Peer count
+    schema:
+      $ref: '#/components/schemas/uint'
+  examples:
+    - name: net_peerCount example
+      params: []
+      result:
+        name: Peer count
+        value: '0x2'

--- a/tests/net_listening/get-listening.io
+++ b/tests/net_listening/get-listening.io
@@ -1,0 +1,3 @@
+// Calls net_listening to check whether the client is listening for network connections.
+>> {"jsonrpc":"2.0","id":1,"method":"net_listening"}
+<< {"jsonrpc":"2.0","id":1,"result":true}

--- a/tests/net_peerCount/get-peer-count.io
+++ b/tests/net_peerCount/get-peer-count.io
@@ -1,0 +1,3 @@
+// Calls net_peerCount to retrieve the number of connected peers. The test client runs without peers, so the expected value is zero.
+>> {"jsonrpc":"2.0","id":1,"method":"net_peerCount"}
+<< {"jsonrpc":"2.0","id":1,"result":"0x0"}

--- a/tools/testgen/generators.go
+++ b/tools/testgen/generators.go
@@ -98,6 +98,8 @@ var AllMethods = []MethodTests{
 	EthConfig,
 	EthCapabilities,
 	NetVersion,
+	NetListening,
+	NetPeerCount,
 	TestingBuildBlockV1,
 	TxpoolStatus,
 	TxpoolContent,
@@ -2445,6 +2447,46 @@ var NetVersion = MethodTests{
 				}
 				if id.Cmp(t.chain.genesis.Config.ChainID) != 0 {
 					return fmt.Errorf("wrong networkID %v returned", id)
+				}
+				return nil
+			},
+		},
+	},
+}
+
+var NetListening = MethodTests{
+	"net_listening",
+	[]Test{
+		{
+			Name:  "get-listening",
+			About: "Calls net_listening to check whether the client is listening for network connections.",
+			Run: func(ctx context.Context, t *T) error {
+				var got bool
+				if err := t.rpc.CallContext(ctx, &got, "net_listening"); err != nil {
+					return err
+				}
+				if !got {
+					return fmt.Errorf("net_listening returned false, want true")
+				}
+				return nil
+			},
+		},
+	},
+}
+
+var NetPeerCount = MethodTests{
+	"net_peerCount",
+	[]Test{
+		{
+			Name:  "get-peer-count",
+			About: "Calls net_peerCount to retrieve the number of connected peers. The test client runs without peers, so the expected value is zero.",
+			Run: func(ctx context.Context, t *T) error {
+				var got hexutil.Uint
+				if err := t.rpc.CallContext(ctx, &got, "net_peerCount"); err != nil {
+					return err
+				}
+				if got != 0 {
+					return fmt.Errorf("unexpected peer count (got: %d, want: 0)", got)
 				}
 				return nil
 			},


### PR DESCRIPTION
Add net_listening and net_peerCount into the spec, Please note that the testgen asserts peer count is exactly zero, which holds for the isolated geth rig today if rpctestgen ever boots with peers, that check will need loosening.