### PR TITLE
Register `CN` for Caplin

### DIFF
--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -30,6 +30,7 @@ To facilitate a more accurate measurement of execution layer client diversity st
 This enum defines a standard for specifying a client with just two letters. Clients teams which have a code reserved in this list **MUST** use this code when identifying themselves. The code is specified here only to facilitate standardization and NOT to imply that these are the only supported Ethereum clients. Any clients not listed here are free to use any two letters which don't collide with an existing client code. They are encouraged to make a PR to this repo to reserve their own code. Existing codes are as follows:
 
  - `BU`: besu
+ - `CN`: caplin
  - `EJ`: ethereumJS
  - `EG`: erigon
  - `EX`: ethrex


### PR DESCRIPTION
Register `CN` for Caplin, Erigon's embedded consensus layer client.

Caplin integrates the consensus layer directly into the Erigon node, removing the need for a separate CL process and its own disk storage, which reduces operational complexity and resource usage. It is a distinct consensus client and needs its own two-letter code so that blocks proposed by an Erigon + Caplin setup are correctly attributable.

`EG` is already reserved for erigon (execution layer), so it cannot be reused for the consensus layer: the graffiti client-version format (`<EL code><EL commit><CL code><CL commit>`) requires distinct codes to tell the two layers apart. With `CN`, an Erigon + Caplin block encodes as e.g. `EGa53eCNa53e`, letting client-diversity tooling measure Caplin adoption independently.