### PR TITLE
Added code for Nimbus EL identification

### DIFF
--- a/src/engine/identification.md
+++ b/src/engine/identification.md
@@ -39,7 +39,8 @@ This enum defines a standard for specifying a client with just two letters. Clie
  - `LH`: lighthouse
  - `LS`: lodestar
  - `NM`: nethermind
- - `NB`: nimbus
+ - `NB`: nimbus CL
+ - `NE`: nimbus EL
  - `TE`: trin-execution
  - `TK`: teku
  - `PM`: prysm


### PR DESCRIPTION
While I was looking at watermarks, I noticed that Nimbus-EL was using the pre-existing NB code which is for Nimbus CL client.

NE seems like a good code, updated names so that it's clear which is EL and which is CL.

Will raise a PR for Nimbus-EL to update it's code as well, so that we can avoid the collision.