### PR TITLE
testgen: fix duplicate name for eth_simulateV1 state override test

### DIFF
--- a/tools/testgen/generators.go
+++ b/tools/testgen/generators.go
@@ -5480,7 +5480,7 @@ var EthSimulateV1 = MethodTests{
 			},
 		},
 		{
-			Name:  "ethSimulate-simple-state-diff",
+			Name:  "ethSimulate-simple-state",
 			About: "override one state variable with state",
 			Run: func(ctx context.Context, t *T) error {
 				stateChanges := make(map[common.Hash]common.Hash)


### PR DESCRIPTION
## Summary

Two `eth_simulateV1` test cases in `tools/testgen/generators.go` shared the name `ethSimulate-simple-state-diff`, causing a naming collision when generating fixtures.

This test uses a full `State` override (replacing all storage) rather than a `StateDiff` override (patching individual slots), so it is renamed to `ethSimulate-simple-state` to disambiguate the two cases and accurately reflect its behavior.

## Test plan

- [ ] Regenerate fixtures and confirm both `ethSimulate-simple-state` and `ethSimulate-simple-state-diff` are produced without collision