### PR TITLE
debug: specify callTracer output and add EIP-8037 two-dimensional gas to tracing

### DIFF
--- a/src/debug/trace.yaml
+++ b/src/debug/trace.yaml
@@ -14,8 +14,7 @@
 
     When a named tracer is specified via the tracer field in TraceConfig (e.g.
     "callTracer", "prestateTracer"), the result field of each entry contains
-    tracer-specific output. Defining the output schemas of named tracers is
-    outside the scope of this specification.
+    tracer-specific output. The callTracer output is defined by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
 
     The response is an array ordered by transaction index within the block.
     Each entry includes the transaction hash paired with its trace result.
@@ -50,10 +49,20 @@
           - title: Opcode tracer entry
             description: Returned when no named tracer is specified.
             $ref: '#/components/schemas/OpcodeBlockTransactionTrace'
+          - title: callTracer entry
+            description: Returned when the tracer field is "callTracer".
+            type: object
+            required:
+              - txHash
+              - result
+            properties:
+              txHash:
+                $ref: '#/components/schemas/hash32'
+              result:
+                $ref: '#/components/schemas/CallFrame'
           - title: Named tracer entry
             description: >-
-              Returned when a named tracer is specified. The result field
-              contains tracer-specific output not defined by this specification.
+              Returned when a named tracer other than "callTracer" is specified. The result field contains that tracer output, which is not defined by this specification.
             type: object
             required:
               - txHash
@@ -63,8 +72,7 @@
                 $ref: '#/components/schemas/hash32'
               result:
                 description: >-
-                  Named tracer output. The schema is unspecified and may be
-                  any valid JSON value.
+                  Output of a named tracer other than "callTracer". The schema is unspecified and may be any valid JSON value.
   examples:
     - name: debug_traceBlockByNumber example (opcode tracer)
       params:
@@ -123,8 +131,7 @@
 
     When a named tracer is specified via the tracer field in TraceConfig (e.g.
     "callTracer", "prestateTracer"), the result field of each entry contains
-    tracer-specific output. Defining the output schemas of named tracers is
-    outside the scope of this specification.
+    tracer-specific output. The callTracer output is defined by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
 
     The response is an array ordered by transaction index within the block.
     Each entry includes the transaction hash paired with its trace result.
@@ -161,10 +168,20 @@
           - title: Opcode tracer entry
             description: Returned when no named tracer is specified.
             $ref: '#/components/schemas/OpcodeBlockTransactionTrace'
+          - title: callTracer entry
+            description: Returned when the tracer field is "callTracer".
+            type: object
+            required:
+              - txHash
+              - result
+            properties:
+              txHash:
+                $ref: '#/components/schemas/hash32'
+              result:
+                $ref: '#/components/schemas/CallFrame'
           - title: Named tracer entry
             description: >-
-              Returned when a named tracer is specified. The result field
-              contains tracer-specific output not defined by this specification.
+              Returned when a named tracer other than "callTracer" is specified. The result field contains that tracer output, which is not defined by this specification.
             type: object
             required:
               - txHash
@@ -174,8 +191,7 @@
                 $ref: '#/components/schemas/hash32'
               result:
                 description: >-
-                  Named tracer output. The schema is unspecified and may be
-                  any valid JSON value.
+                  Output of a named tracer other than "callTracer". The schema is unspecified and may be any valid JSON value.
   examples:
     - name: debug_traceBlockByHash example (opcode tracer)
       params:
@@ -230,8 +246,7 @@
 
     When a named tracer is specified via the tracer field in TraceConfig (e.g.
     "callTracer", "prestateTracer"), the result contains tracer-specific output.
-    Defining the output schemas of named tracers is outside the scope of this
-    specification.
+    The callTracer output is defined by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
   params:
     - name: Transaction hash
       required: true
@@ -252,11 +267,12 @@
         - title: Opcode tracer result
           description: Returned when no named tracer is specified.
           $ref: '#/components/schemas/OpcodeTransactionTrace'
+        - title: callTracer result
+          description: Returned when the tracer field is "callTracer".
+          $ref: '#/components/schemas/CallFrame'
         - title: Named tracer result
           description: >-
-            Returned when a named tracer is specified via the tracer field.
-            The format is tracer-specific and not defined by this specification.
-            Named tracers may return any JSON value (object, array, integer, etc.).
+            Returned when a named tracer other than "callTracer" is specified. The format is tracer-specific and not defined by this specification.
   examples:
     - name: debug_traceTransaction example (opcode tracer)
       params:
@@ -316,4 +332,46 @@
           gas: '0x1a49e'
           gasUsed: '0x1a49e'
           input: '0x'
+          output: '0x'
+    - name: debug_traceTransaction example (callTracer, EIP-8037 two-dimensional gas)
+      params:
+        - name: Transaction hash
+          value: '0xa1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+        - name: TraceConfig
+          value:
+            tracer: callTracer
+      result:
+        name: Transaction trace (callTracer, Amsterdam)
+        value:
+          type: CALL
+          from: '0xdbfe1a7295a45d1e0e0f7d0e2f6f8b0a1c2d3e4f'
+          to: '0x1c6cde364c917a14a9ea47d12e700d605af11ca8'
+          value: '0x0'
+          gas: '0x493e0'
+          gasUsed: '0x34bfd'
+          regularGasUsed: '0x7ecd'
+          stateGasUsed: '0x2cd30'
+          gasRefund: '0x0'
+          input: '0x'
+          output: '0x'
+    - name: debug_traceTransaction example (callTracer, EIP-7976 calldata floor binding)
+      params:
+        - name: Transaction hash
+          value: '0xb2a1c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0c3d4'
+        - name: TraceConfig
+          value:
+            tracer: callTracer
+      result:
+        name: Transaction trace (callTracer, floor-bound)
+        value:
+          type: CALL
+          from: '0xfe3b557e8fb62b89f4916b721be55ceb828dbd73'
+          to: '0x0100000000000000000000000000000000000000'
+          value: '0x0'
+          gas: '0x30d40'
+          gasUsed: '0xc350'
+          regularGasUsed: '0x7530'
+          stateGasUsed: '0x0'
+          gasRefund: '0x0'
+          input: '0xff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00'
           output: '0x'

--- a/src/debug/trace.yaml
+++ b/src/debug/trace.yaml
@@ -13,8 +13,8 @@
     OpcodeTransactionTrace.
 
     When a named tracer is specified via the tracer field in TraceConfig (e.g.
-    "callTracer", "prestateTracer"), the result field of each entry contains
-    tracer-specific output. The callTracer output is defined by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
+    "callTracer", "stateGasTracer", "prestateTracer"), the result field of each entry contains
+    tracer-specific output. The stateGasTracer output is defined by the StateGasTrace schema and the gas-related portion of the callTracer output by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
 
     The response is an array ordered by transaction index within the block.
     Each entry includes the transaction hash paired with its trace result.
@@ -60,9 +60,12 @@
                 $ref: '#/components/schemas/hash32'
               result:
                 $ref: '#/components/schemas/CallFrame'
+          - title: stateGasTracer entry
+            description: Returned when the tracer field is "stateGasTracer".
+            $ref: '#/components/schemas/StateGasBlockTrace'
           - title: Named tracer entry
             description: >-
-              Returned when a named tracer other than "callTracer" is specified. The result field contains that tracer output, which is not defined by this specification.
+              Returned when a named tracer other than "callTracer" or "stateGasTracer" is specified. The result field contains that tracer output, which is not defined by this specification.
             type: object
             required:
               - txHash
@@ -130,8 +133,8 @@
     OpcodeTransactionTrace.
 
     When a named tracer is specified via the tracer field in TraceConfig (e.g.
-    "callTracer", "prestateTracer"), the result field of each entry contains
-    tracer-specific output. The callTracer output is defined by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
+    "callTracer", "stateGasTracer", "prestateTracer"), the result field of each entry contains
+    tracer-specific output. The stateGasTracer output is defined by the StateGasTrace schema and the gas-related portion of the callTracer output by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
 
     The response is an array ordered by transaction index within the block.
     Each entry includes the transaction hash paired with its trace result.
@@ -179,9 +182,12 @@
                 $ref: '#/components/schemas/hash32'
               result:
                 $ref: '#/components/schemas/CallFrame'
+          - title: stateGasTracer entry
+            description: Returned when the tracer field is "stateGasTracer".
+            $ref: '#/components/schemas/StateGasBlockTrace'
           - title: Named tracer entry
             description: >-
-              Returned when a named tracer other than "callTracer" is specified. The result field contains that tracer output, which is not defined by this specification.
+              Returned when a named tracer other than "callTracer" or "stateGasTracer" is specified. The result field contains that tracer output, which is not defined by this specification.
             type: object
             required:
               - txHash
@@ -245,8 +251,8 @@
     (struct) logger is used and the result conforms to OpcodeTransactionTrace.
 
     When a named tracer is specified via the tracer field in TraceConfig (e.g.
-    "callTracer", "prestateTracer"), the result contains tracer-specific output.
-    The callTracer output is defined by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
+    "callTracer", "stateGasTracer", "prestateTracer"), the result contains tracer-specific output.
+    The stateGasTracer output is defined by the StateGasTrace schema and the gas-related portion of the callTracer output by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
   params:
     - name: Transaction hash
       required: true
@@ -270,9 +276,12 @@
         - title: callTracer result
           description: Returned when the tracer field is "callTracer".
           $ref: '#/components/schemas/CallFrame'
+        - title: stateGasTracer result
+          description: Returned when the tracer field is "stateGasTracer".
+          $ref: '#/components/schemas/StateGasTrace'
         - title: Named tracer result
           description: >-
-            Returned when a named tracer other than "callTracer" is specified. The format is tracer-specific and not defined by this specification.
+            Returned when a named tracer other than "callTracer" or "stateGasTracer" is specified. The format is tracer-specific and not defined by this specification.
   examples:
     - name: debug_traceTransaction example (opcode tracer)
       params:
@@ -375,3 +384,17 @@
           gasRefund: '0x0'
           input: '0xff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00'
           output: '0x'
+    - name: debug_traceTransaction example (stateGasTracer)
+      params:
+        - name: Transaction hash
+          value: '0xa1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2'
+        - name: TraceConfig
+          value:
+            tracer: stateGasTracer
+      result:
+        name: Transaction trace (stateGasTracer)
+        value:
+          gasUsed: '0x34bfd'
+          regularGasUsed: '0x7ecd'
+          stateGasUsed: '0x2cd30'
+          gasRefund: '0x0'

--- a/src/schemas/call-tracer.yaml
+++ b/src/schemas/call-tracer.yaml
@@ -1,0 +1,166 @@
+CallFrame:
+  title: Call frame
+  description: >-
+    Output of the "callTracer" named tracer: the tree of EVM call frames
+    executed by a transaction. Amsterdam (EIP-8037) adds the two-dimensional
+    gas breakdown - regularGasUsed and stateGasUsed - together with the
+    EIP-3529 refund (gasRefund) on the top frame. Only transactions contribute
+    to the block gas counters (system-contract calls and withdrawals are
+    unmetered), so summing the top-frame values across a block's transactions
+    reconstructs block_regular_gas_used and block_state_gas_used exactly.
+  type: object
+  required:
+    - type
+    - from
+    - gas
+    - gasUsed
+    - input
+  properties:
+    type:
+      title: call type
+      description: The operation that opened this frame.
+      type: string
+      enum:
+        - CALL
+        - CALLCODE
+        - DELEGATECALL
+        - STATICCALL
+        - CREATE
+        - CREATE2
+        - SELFDESTRUCT
+    from:
+      title: sender
+      description: The address that initiated this frame.
+      $ref: '#/components/schemas/address'
+    to:
+      title: recipient
+      description: >-
+        The call recipient, or for CREATE and CREATE2 the address of the
+        created contract. MUST be absent when a contract-creation frame failed.
+      $ref: '#/components/schemas/address'
+    value:
+      title: value
+      description: >-
+        The value transferred by this frame, in wei. Absent for call types that
+        cannot carry value (DELEGATECALL, STATICCALL); present ("0x0" when zero)
+        otherwise.
+      $ref: '#/components/schemas/uint'
+    gas:
+      title: gas provided
+      description: The amount of gas provided to this frame.
+      $ref: '#/components/schemas/uint'
+    gasUsed:
+      title: gas used
+      description: >-
+        The gas used by this frame after refunds. For the top frame this equals
+        the transaction receipt gasUsed (post-refund and after the EIP-7976 calldata floor is applied).
+      $ref: '#/components/schemas/uint'
+    regularGasUsed:
+      title: regular gas used
+      description: >-
+        EIP-8037: the gross (pre-refund) regular-gas used by this frame and its
+        children. On the top frame this is the transaction contribution to
+        block_regular_gas_used (EIP-7778) and, together with stateGasUsed,
+        satisfies regularGasUsed + stateGasUsed == gasUsed + gasRefund unless the EIP-7976 calldata floor binds. MUST be present on the top frame for
+        blocks at or after the Amsterdam fork and MUST be absent before it.
+      $ref: '#/components/schemas/uint'
+    stateGasUsed:
+      title: state gas used
+      description: >-
+        EIP-8037: the gross (pre-refund) state-gas used by this frame and its
+        children - gas charged for state creation (a new storage slot, account
+        creation, code deposit, or an EIP-7702 authorization to a new account).
+        On the top frame this is the transaction contribution to
+        block_state_gas_used. MUST be present on the top frame for Amsterdam+
+        blocks and MUST be absent before it.
+      $ref: '#/components/schemas/uint'
+    gasRefund:
+      title: gas refund
+      description: >-
+        The EIP-3529 gas refund applied to this transaction (capped at one fifth
+        of the pre-refund gas). Under EIP-7778 the refund lowers the receipt gas
+        but not the block gas counters. MUST be present on the top frame for
+        Amsterdam+ blocks, MUST be absent before the Amsterdam fork, and MUST
+        be absent on subcalls (refunds resolve at the transaction boundary).
+      $ref: '#/components/schemas/uint'
+    stateGasRefund:
+      title: state gas refund
+      description: >-
+        The total state-gas refunded within this transaction (for example the
+        account-creation charge returned when a CREATE reverts or halts, or an
+        EIP-7702 authorization refund), already netted out of stateGasUsed.
+        Clients MAY include this field on the top frame for Amsterdam+ blocks;
+        it makes state-gas refund handling directly observable when diagnosing
+        cross-client attribution differences.
+      $ref: '#/components/schemas/uint'
+    input:
+      title: input
+      description: The call data supplied to this frame.
+      $ref: '#/components/schemas/bytes'
+    output:
+      title: output
+      description: The data returned by this frame. Absent when the frame returned no data.
+      $ref: '#/components/schemas/bytes'
+    error:
+      title: error
+      description: >-
+        The execution error for this frame, if any. MUST be absent when the
+        frame did not error.
+      type: string
+    revertReason:
+      title: revert reason
+      description: >-
+        The decoded reason string when the frame reverted with a standard
+        Solidity Error(string). Absent otherwise.
+      type: string
+    logs:
+      title: logs
+      description: >-
+        The event logs emitted directly by this frame, in emission order.
+        Present only when the callTracer withLog option is enabled and MUST be
+        absent otherwise.
+      type: array
+      items:
+        $ref: '#/components/schemas/CallLog'
+    calls:
+      title: subcalls
+      description: >-
+        The child call frames invoked by this frame, in execution order. Each
+        element has the same shape as this schema (CallFrame), nested recursively
+        to arbitrary depth. Absent when the frame made no subcalls.
+      type: array
+      items:
+        title: Nested call frame
+        description: A child call frame with the same shape as CallFrame.
+        type: object
+CallLog:
+  title: Call log
+  description: An event log captured by the callTracer when the withLog option is enabled.
+  type: object
+  required:
+    - address
+    - topics
+    - data
+  properties:
+    address:
+      title: emitter
+      description: The address of the contract that emitted the log.
+      $ref: '#/components/schemas/address'
+    topics:
+      title: topics
+      description: The indexed log topics, from zero to four entries.
+      type: array
+      items:
+        $ref: '#/components/schemas/hash32'
+    data:
+      title: data
+      description: The non-indexed log data.
+      $ref: '#/components/schemas/bytes'
+    index:
+      title: log index
+      description: The index of this log among all logs in the block.
+      $ref: '#/components/schemas/uint'
+    position:
+      title: position
+      description: The position of this log relative to the subcalls within the same frame.
+      $ref: '#/components/schemas/uint'

--- a/src/schemas/call-tracer.yaml
+++ b/src/schemas/call-tracer.yaml
@@ -1,50 +1,22 @@
 CallFrame:
-  title: Call frame
+  title: Call frame (gas properties)
   description: >-
-    Output of the "callTracer" named tracer: the tree of EVM call frames
-    executed by a transaction. Amsterdam (EIP-8037) adds the two-dimensional
-    gas breakdown - regularGasUsed and stateGasUsed - together with the
-    EIP-3529 refund (gasRefund) on the top frame. Only transactions contribute
-    to the block gas counters (system-contract calls and withdrawals are
-    unmetered), so summing the top-frame values across a block's transactions
-    reconstructs block_regular_gas_used and block_state_gas_used exactly.
+    Partial schema for the output of the "callTracer" named tracer: the tree
+    of EVM call frames executed by a transaction. Only the gas-related
+    properties are defined here. The remaining callTracer properties (type,
+    from, to, value, input, output, error, revertReason, logs, calls) are
+    established client practice whose exact shapes differ between
+    implementations and are outside the scope of this specification; child
+    frames nested under calls repeat this same shape.
+
+    Amsterdam (EIP-8037) adds the two-dimensional gas breakdown -
+    regularGasUsed and stateGasUsed - together with the applied EIP-3529
+    refund (gasRefund) on the top-level frame. These are the same three
+    values returned by the stateGasTracer, which clients not implementing
+    the callTracer can support instead.
   type: object
-  required:
-    - type
-    - from
-    - gas
-    - gasUsed
-    - input
+  additionalProperties: true
   properties:
-    type:
-      title: call type
-      description: The operation that opened this frame.
-      type: string
-      enum:
-        - CALL
-        - CALLCODE
-        - DELEGATECALL
-        - STATICCALL
-        - CREATE
-        - CREATE2
-        - SELFDESTRUCT
-    from:
-      title: sender
-      description: The address that initiated this frame.
-      $ref: '#/components/schemas/address'
-    to:
-      title: recipient
-      description: >-
-        The call recipient, or for CREATE and CREATE2 the address of the
-        created contract. MUST be absent when a contract-creation frame failed.
-      $ref: '#/components/schemas/address'
-    value:
-      title: value
-      description: >-
-        The value transferred by this frame, in wei. Absent for call types that
-        cannot carry value (DELEGATECALL, STATICCALL); present ("0x0" when zero)
-        otherwise.
-      $ref: '#/components/schemas/uint'
     gas:
       title: gas provided
       description: The amount of gas provided to this frame.
@@ -52,115 +24,54 @@ CallFrame:
     gasUsed:
       title: gas used
       description: >-
-        The gas used by this frame after refunds. For the top frame this equals
-        the transaction receipt gasUsed (post-refund and after the EIP-7976 calldata floor is applied).
+        The gas used by this frame. For the top-level frame this equals the
+        transaction receipt gasUsed (post-refund, and post-floor when the
+        EIP-7976 calldata floor binds). Sub-frame attribution is not defined
+        by this specification.
       $ref: '#/components/schemas/uint'
     regularGasUsed:
-      title: regular gas used
+      title: regular gas used (gross)
       description: >-
-        EIP-8037: the gross (pre-refund) regular-gas used by this frame and its
-        children. On the top frame this is the transaction contribution to
-        block_regular_gas_used (EIP-7778) and, together with stateGasUsed,
-        satisfies regularGasUsed + stateGasUsed == gasUsed + gasRefund unless the EIP-7976 calldata floor binds. MUST be present on the top frame for
-        blocks at or after the Amsterdam fork and MUST be absent before it.
+        EIP-8037: the gross (pre-refund) regular gas used by the transaction -
+        its contribution to block_regular_gas_used (EIP-7778). Together with
+        stateGasUsed it satisfies regularGasUsed + stateGasUsed == gasUsed +
+        gasRefund unless the EIP-7976 calldata floor binds. Clients that
+        implement the callTracer SHOULD include this field on the top-level
+        frame for blocks at or after the Amsterdam fork and MUST NOT include
+        it before the fork. Sub-frame attribution is not defined by this
+        specification; clients SHOULD omit this field on sub-frames.
       $ref: '#/components/schemas/uint'
     stateGasUsed:
-      title: state gas used
+      title: state gas used (gross)
       description: >-
-        EIP-8037: the gross (pre-refund) state-gas used by this frame and its
-        children - gas charged for state creation (a new storage slot, account
-        creation, code deposit, or an EIP-7702 authorization to a new account).
-        On the top frame this is the transaction contribution to
-        block_state_gas_used. MUST be present on the top frame for Amsterdam+
-        blocks and MUST be absent before it.
+        EIP-8037: the gross (pre-refund) state gas used by the transaction -
+        gas charged for state creation (an SSTORE into a new slot, account
+        creation, code deposit, or an EIP-7702 authorization to a new
+        account), net of source-based state-gas refunds - its contribution to
+        block_state_gas_used. Clients that implement the callTracer SHOULD
+        include this field on the top-level frame for Amsterdam+ blocks and
+        MUST NOT include it before the fork. Sub-frame attribution is not
+        defined by this specification; clients SHOULD omit this field on
+        sub-frames.
       $ref: '#/components/schemas/uint'
     gasRefund:
       title: gas refund
       description: >-
-        The EIP-3529 gas refund applied to this transaction (capped at one fifth
-        of the pre-refund gas). Under EIP-7778 the refund lowers the receipt gas
-        but not the block gas counters. MUST be present on the top frame for
-        Amsterdam+ blocks, MUST be absent before the Amsterdam fork, and MUST
-        be absent on subcalls (refunds resolve at the transaction boundary).
+        The EIP-3529 gas refund applied to this transaction (capped at one
+        fifth of the pre-refund gas). Under EIP-7778 the refund lowers the
+        receipt gas but not the block gas counters. Clients that implement
+        the callTracer SHOULD include this field on the top-level frame for
+        Amsterdam+ blocks, MUST NOT include it before the fork, and MUST NOT
+        include it on sub-frames (refunds resolve at the transaction
+        boundary).
       $ref: '#/components/schemas/uint'
     stateGasRefund:
       title: state gas refund
       description: >-
-        The total state-gas refunded within this transaction (for example the
-        account-creation charge returned when a CREATE reverts or halts, or an
-        EIP-7702 authorization refund), already netted out of stateGasUsed.
-        Clients MAY include this field on the top frame for Amsterdam+ blocks;
-        it makes state-gas refund handling directly observable when diagnosing
-        cross-client attribution differences.
-      $ref: '#/components/schemas/uint'
-    input:
-      title: input
-      description: The call data supplied to this frame.
-      $ref: '#/components/schemas/bytes'
-    output:
-      title: output
-      description: The data returned by this frame. Absent when the frame returned no data.
-      $ref: '#/components/schemas/bytes'
-    error:
-      title: error
-      description: >-
-        The execution error for this frame, if any. MUST be absent when the
-        frame did not error.
-      type: string
-    revertReason:
-      title: revert reason
-      description: >-
-        The decoded reason string when the frame reverted with a standard
-        Solidity Error(string). Absent otherwise.
-      type: string
-    logs:
-      title: logs
-      description: >-
-        The event logs emitted directly by this frame, in emission order.
-        Present only when the callTracer withLog option is enabled and MUST be
-        absent otherwise.
-      type: array
-      items:
-        $ref: '#/components/schemas/CallLog'
-    calls:
-      title: subcalls
-      description: >-
-        The child call frames invoked by this frame, in execution order. Each
-        element has the same shape as this schema (CallFrame), nested recursively
-        to arbitrary depth. Absent when the frame made no subcalls.
-      type: array
-      items:
-        title: Nested call frame
-        description: A child call frame with the same shape as CallFrame.
-        type: object
-CallLog:
-  title: Call log
-  description: An event log captured by the callTracer when the withLog option is enabled.
-  type: object
-  required:
-    - address
-    - topics
-    - data
-  properties:
-    address:
-      title: emitter
-      description: The address of the contract that emitted the log.
-      $ref: '#/components/schemas/address'
-    topics:
-      title: topics
-      description: The indexed log topics, from zero to four entries.
-      type: array
-      items:
-        $ref: '#/components/schemas/hash32'
-    data:
-      title: data
-      description: The non-indexed log data.
-      $ref: '#/components/schemas/bytes'
-    index:
-      title: log index
-      description: The index of this log among all logs in the block.
-      $ref: '#/components/schemas/uint'
-    position:
-      title: position
-      description: The position of this log relative to the subcalls within the same frame.
+        The total state gas refunded within this transaction (for example the
+        account-creation charge returned when a CREATE reverts or halts, or
+        an EIP-7702 authorization refund), already netted out of
+        stateGasUsed. Clients MAY include this field on the top-level frame
+        for Amsterdam+ blocks; it makes state-gas refund handling directly
+        observable when diagnosing cross-client attribution differences.
       $ref: '#/components/schemas/uint'

--- a/src/schemas/opcode-tracer.yaml
+++ b/src/schemas/opcode-tracer.yaml
@@ -10,7 +10,7 @@ TraceConfig:
     only apply to the opcode logger and are ignored when a named tracer is set.
 
     When the tracer field is set to a named tracer (e.g. "callTracer",
-    "prestateTracer"), the result format is tracer-specific. The callTracer output is defined by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
+    "stateGasTracer", "prestateTracer"), the result format is tracer-specific. The stateGasTracer output is defined by the StateGasTrace schema and the gas-related portion of the callTracer output by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
   type: object
   properties:
     tracer:
@@ -125,21 +125,29 @@ StructLog:
         The gas cost computed for this opcode step — the amount that will be
         deducted from the remaining gas assuming successful execution. Includes
         dynamic costs such as memory expansion and storage access charges
-        (e.g. cold vs. warm SLOAD/SSTORE).
+        (e.g. cold vs. warm SLOAD/SSTORE). Under EIP-8037 (Amsterdam+) this is
+        the charge to the regular gas dimension, including any state gas paid
+        from regular gas after the state-gas reservoir is exhausted;
+        reservoir-funded state gas appears only in stateGasCost.
       type: integer
       minimum: 0
     stateGasCost:
       title: state-gas cost
       description: >-
-        EIP-8037 (Amsterdam+) only. The state-gas portion of gasCost for this
-        step - the amount charged to the state-gas dimension, nonzero only for
-        state-creating operations (an SSTORE into a new slot, account creation,
-        code deposit, or an EIP-7702 authorization to a new account). gasCost
-        minus stateGasCost is the regular-gas portion. Clients MUST include this
-        field at every step when it is non-zero and SHOULD include it at every
-        step even when zero. Absent before the Amsterdam fork.
+        EIP-8037 (Amsterdam+) only. The net change to the transaction's state
+        gas used caused by this step, regardless of whether the charge was
+        funded from the state-gas reservoir or spilled over into regular gas.
+        Nonzero only for steps that create state (for example an SSTORE into
+        a new slot, or a call that creates a new account), and MAY be
+        negative when a source-based state-gas refund is applied (for example
+        a reverting CREATE returning its account-creation charge). Some state
+        gas is charged outside opcode steps entirely (intrinsic state gas,
+        code deposit at contract-creation completion, EIP-7702 authorization
+        processing), so the sum of stateGasCost over all steps does not in
+        general equal the transaction's stateGasUsed. Clients MAY include
+        this field; when included it SHOULD be present at every step where it
+        is non-zero. Absent before the Amsterdam fork.
       type: integer
-      minimum: 0
     stateGasReservoir:
       title: state-gas reservoir remaining
       description: >-

--- a/src/schemas/opcode-tracer.yaml
+++ b/src/schemas/opcode-tracer.yaml
@@ -10,8 +10,7 @@ TraceConfig:
     only apply to the opcode logger and are ignored when a named tracer is set.
 
     When the tracer field is set to a named tracer (e.g. "callTracer",
-    "prestateTracer"), the result format is tracer-specific. Defining the
-    output schemas of named tracers is outside the scope of this specification.
+    "prestateTracer"), the result format is tracer-specific. The callTracer output is defined by the CallFrame schema; defining the output schemas of other named tracers is outside the scope of this specification.
   type: object
   properties:
     tracer:
@@ -129,6 +128,27 @@ StructLog:
         (e.g. cold vs. warm SLOAD/SSTORE).
       type: integer
       minimum: 0
+    stateGasCost:
+      title: state-gas cost
+      description: >-
+        EIP-8037 (Amsterdam+) only. The state-gas portion of gasCost for this
+        step - the amount charged to the state-gas dimension, nonzero only for
+        state-creating operations (an SSTORE into a new slot, account creation,
+        code deposit, or an EIP-7702 authorization to a new account). gasCost
+        minus stateGasCost is the regular-gas portion. Clients MUST include this
+        field at every step when it is non-zero and SHOULD include it at every
+        step even when zero. Absent before the Amsterdam fork.
+      type: integer
+      minimum: 0
+    stateGasReservoir:
+      title: state-gas reservoir remaining
+      description: >-
+        EIP-8037 (Amsterdam+) only. The remaining state-gas reservoir before
+        this opcode. The GAS opcode and the gas field report gas_left only
+        (excluding the reservoir); this field exposes the reservoir separately.
+        MAY be omitted.
+      type: integer
+      minimum: 0
     depth:
       title: call depth
       description: The call stack depth at this execution step. Starts at 1 for the outermost call.
@@ -205,6 +225,30 @@ OpcodeTransactionTrace:
     gas:
       title: gas used
       description: Total amount of gas consumed by the transaction.
+      type: integer
+      minimum: 0
+    regularGasUsed:
+      title: regular gas used (gross)
+      description: >-
+        EIP-8037 (Amsterdam+) only. The transaction gross (pre-refund)
+        regular-gas contribution to the block (summed into
+        block_regular_gas_used, EIP-7778). Absent before the Amsterdam fork.
+      type: integer
+      minimum: 0
+    stateGasUsed:
+      title: state gas used (gross)
+      description: >-
+        EIP-8037 (Amsterdam+) only. The transaction gross (pre-refund)
+        state-gas contribution to the block (summed into block_state_gas_used).
+        Absent before the Amsterdam fork.
+      type: integer
+      minimum: 0
+    gasRefund:
+      title: gas refund
+      description: >-
+        EIP-3529 refund for this transaction. Under EIP-7778 it reduces the
+        receipt gas but not the block counters, so
+        regularGasUsed + stateGasUsed == gas + gasRefund (except when the EIP-7976 calldata floor binds). Absent before the Amsterdam fork.
       type: integer
       minimum: 0
     failed:

--- a/src/schemas/state-gas-tracer.yaml
+++ b/src/schemas/state-gas-tracer.yaml
@@ -1,0 +1,77 @@
+StateGasTrace:
+  title: State gas trace
+  description: >-
+    Output of the "stateGasTracer" named tracer: the per-transaction
+    two-dimensional gas summary introduced by EIP-8037 (Amsterdam). The
+    reported values are the ones every client already computes for block-level
+    gas accounting; this tracer exposes them per transaction without
+    re-deriving anything from opcode-level data. Clients supporting the
+    Amsterdam fork SHOULD implement this tracer under the name
+    "stateGasTracer". It accepts no tracerConfig options.
+
+    regularGasUsed and stateGasUsed are the gross (pre-refund) block
+    contributions of EIP-7778: summing each over a block's transactions
+    reconstructs block_regular_gas_used and block_state_gas_used exactly, and
+    the block header gasUsed equals the maximum of the two sums. Only
+    transactions contribute to the block gas counters (system-contract calls
+    and withdrawals are unmetered).
+
+    The fields satisfy regularGasUsed + stateGasUsed == gasUsed + gasRefund,
+    except when the EIP-7976 calldata floor binds, in which case gasUsed ==
+    max(regularGasUsed + stateGasUsed - gasRefund, floor). The floor case is
+    why the dimensions are reported explicitly: a floor-bound gasUsed makes
+    regularGasUsed unrecoverable from the receipt alone.
+  type: object
+  required:
+    - gasUsed
+    - regularGasUsed
+    - stateGasUsed
+    - gasRefund
+  properties:
+    gasUsed:
+      title: gas used
+      description: >-
+        The gas used by the transaction as reported in its receipt
+        (post-refund, and post-floor when the EIP-7976 calldata floor binds).
+      $ref: '#/components/schemas/uint'
+    regularGasUsed:
+      title: regular gas used (gross)
+      description: >-
+        The gross (pre-refund) regular gas used by the transaction - its
+        contribution to block_regular_gas_used (EIP-7778). Before the
+        Amsterdam fork this equals the full pre-refund gas used.
+      $ref: '#/components/schemas/uint'
+    stateGasUsed:
+      title: state gas used (gross)
+      description: >-
+        The gross (pre-refund) state gas used by the transaction - gas charged
+        for state creation (an SSTORE into a new slot, account creation, code
+        deposit, or an EIP-7702 authorization to a new account), net of
+        EIP-8037 source-based state-gas refunds - its contribution to
+        block_state_gas_used. Zero before the Amsterdam fork.
+      $ref: '#/components/schemas/uint'
+    gasRefund:
+      title: gas refund
+      description: >-
+        The EIP-3529 gas refund applied to this transaction (capped at one
+        fifth of the pre-refund gas). Under EIP-7778 the refund lowers the
+        receipt gas but not the block gas counters.
+      $ref: '#/components/schemas/uint'
+StateGasBlockTrace:
+  title: State gas block trace entry
+  description: >-
+    A single transaction's stateGasTracer result within a
+    debug_traceBlockByNumber or debug_traceBlockByHash response.
+  type: object
+  required:
+    - txHash
+    - result
+  properties:
+    txHash:
+      title: transaction hash
+      description: The hash of the transaction this trace entry corresponds to.
+      $ref: '#/components/schemas/hash32'
+    result:
+      title: state gas trace
+      description: The state gas trace for this transaction.
+      $ref: '#/components/schemas/StateGasTrace'


### PR DESCRIPTION
Adds the EIP-8037 regular/state gas breakdown (and the EIP-3529 `gasRefund`) to the debug tracing schemas, specifies the previously-undefined `callTracer` output, and introduces a `stateGasTracer` as the normative core for EIP-8037 tracing.

## What's included

**`schemas/state-gas-tracer.yaml` (new)** — a named `stateGasTracer` returning the per-transaction `{gasUsed, regularGasUsed, stateGasUsed, gasRefund}`. A survey of all seven EL clients' tracer implementations on their glamsterdam-devnet-6 branches (geth, erigon, reth, besu, nethermind, ethrex, nimbus-eth1) showed every client already computes and carries these values on its transaction-result type for block-level accounting; exposure is 60–300 LOC per client, and for nimbus-eth1 (which has no `callTracer` at all) this is the only practical compliance path.

**`schemas/call-tracer.yaml` (new)** — `CallFrame`/`CallLog`, defining the `callTracer` result. `CallFrame` is deliberately a partial schema covering only the gas-related properties (`additionalProperties: true`): full call-frame shapes already diverge between clients (sub-frame gas semantics differ in erigon and besu), so enshrining one client's frame layout would make others non-compliant at birth. The new fields — `regularGasUsed` and `stateGasUsed` (gross, pre-refund, the EIP-7778 per-transaction block contributions) and `gasRefund` — are SHOULD on the top-level frame for clients that implement the `callTracer`.

Top-frame invariant (Amsterdam+): `regularGasUsed + stateGasUsed == gasUsed + gasRefund`, unless the EIP-7623 calldata floor binds.

**`schemas/opcode-tracer.yaml`** — per-step `stateGasCost`/`stateGasReservoir` and per-transaction `regularGasUsed`/`stateGasUsed`/`gasRefund`. Per-step `stateGasCost` is MAY and signed: three independent implementations (ethrex, reth, erigon) track per-step state gas as a signed value that can go negative under EIP-8037 source-based refunds, and intrinsic, code-deposit and EIP-7702 state gas is charged outside opcode steps in every surveyed client, so per-step sums cannot reconstruct the transaction total. The scalar `gasCost` is pinned as the regular-dimension charge including reservoir spillover.

**`debug/trace.yaml`** — wires the new result schemas into the result unions of the three trace methods, reconciles the now-outdated "named tracers are out of scope" prose, and adds a post-Amsterdam `callTracer` example.

## Notes

- `CallFrame.calls` is typed as a generic object because the reference tooling (`specgen -deref`) does not dereference recursive schemas; the recursion is documented in prose.
- Passes `make build`, `make test` (speccheck) and `make lint` (no new warnings).
