### PR TITLE
eth_createAccessList: clarify gas-fee affordability when fee fields omitted

### DIFF
--- a/src/eth/execute.yaml
+++ b/src/eth/execute.yaml
@@ -67,6 +67,13 @@
 
 - name: eth_createAccessList
   summary: Generates an access list for a transaction.
+  description: |
+    Generates an access list for a transaction.
+
+    When the gas fee fields (`gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`) are omitted, the
+    client may select implementation-defined fee values for the simulation. The request MUST NOT
+    fail solely because the sender cannot afford the gas fees implied by those client-selected
+    defaults. This does not waive balance requirements for a non-zero transaction `value`.
   params:
     - name: Transaction
       required: true

--- a/tests/eth_createAccessList/create-al-unfunded-sender.io
+++ b/tests/eth_createAccessList/create-al-unfunded-sender.io
@@ -1,0 +1,5 @@
+// Creates an access list for a zero-value transfer from an unfunded sender with all gas fee
+// fields omitted. The client selects implementation-defined fee defaults for simulation, and the
+// request must not fail merely because the sender cannot afford those defaults.
+>> {"jsonrpc":"2.0","id":1,"method":"eth_createAccessList","params":[{"from":"0xaa00000000000000000000000000000000000000","to":"0xbb00000000000000000000000000000000000000"},"latest"]}
+<< {"jsonrpc":"2.0","id":1,"result":{"accessList":[],"gasUsed":"0x5208"}}

--- a/tools/testgen/generators.go
+++ b/tools/testgen/generators.go
@@ -1022,6 +1022,32 @@ var EthCreateAccessList = MethodTests{
 			},
 		},
 		{
+			Name: "create-al-unfunded-sender",
+			About: `Creates an access list for a zero-value transfer from an unfunded sender with all gas fee
+fields omitted. The client selects implementation-defined fee defaults for simulation, and the
+request must not fail merely because the sender cannot afford those defaults.`,
+			Run: func(ctx context.Context, t *T) error {
+				msg := map[string]any{
+					"from": common.Address{0xaa},
+					"to":   common.Address{0xbb},
+				}
+				var result struct {
+					AccessList types.AccessList `json:"accessList"`
+					GasUsed    hexutil.Uint64   `json:"gasUsed"`
+				}
+				if err := t.rpc.CallContext(ctx, &result, "eth_createAccessList", msg, "latest"); err != nil {
+					return err
+				}
+				if len(result.AccessList) != 0 {
+					return fmt.Errorf("expected empty access list, got %d entries", len(result.AccessList))
+				}
+				if result.GasUsed != 21000 {
+					return fmt.Errorf("unexpected gasUsed (got %d want 21000)", uint64(result.GasUsed))
+				}
+				return nil
+			},
+		},
+		{
 			Name:     "create-al-contract",
 			About:    "creates an access list for a contract invocation that accesses storage",
 			SpecOnly: true,

--- a/tools/testgen/generators.go
+++ b/tools/testgen/generators.go
@@ -1031,6 +1031,32 @@ var EthCreateAccessList = MethodTests{
 			},
 		},
 		{
+			Name: "create-al-unfunded-sender",
+			About: `Creates an access list for a zero-value transfer from an unfunded sender with all gas fee
+fields omitted. The client selects implementation-defined fee defaults for simulation, and the
+request must not fail merely because the sender cannot afford those defaults.`,
+			Run: func(ctx context.Context, t *T) error {
+				msg := map[string]any{
+					"from": common.Address{0xaa},
+					"to":   common.Address{0xbb},
+				}
+				var result struct {
+					AccessList types.AccessList `json:"accessList"`
+					GasUsed    hexutil.Uint64   `json:"gasUsed"`
+				}
+				if err := t.rpc.CallContext(ctx, &result, "eth_createAccessList", msg, "latest"); err != nil {
+					return err
+				}
+				if len(result.AccessList) != 0 {
+					return fmt.Errorf("expected empty access list, got %d entries", len(result.AccessList))
+				}
+				if result.GasUsed != 21000 {
+					return fmt.Errorf("unexpected gasUsed (got %d want 21000)", uint64(result.GasUsed))
+				}
+				return nil
+			},
+		},
+		{
 			Name:     "create-al-contract",
 			About:    "creates an access list for a contract invocation that accesses storage",
 			SpecOnly: true,


### PR DESCRIPTION
> **Draft — depends on ethereum/go-ethereum#35397.** The conformance fixture expects success for an unfunded sender, which fails against current go-ethereum (the reference client used by rpc-compat CI). Merge after the go-ethereum fix lands and its commit is picked up here.

Fixes #853.

### Summary

Clarifies that when all gas fee fields (`gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`) are omitted, a client may pick implementation-defined fee values for the simulation, but the request MUST NOT fail solely because the sender cannot afford those client-selected defaults. Non-zero `value` still requires balance.

### Changes

- `src/eth/execute.yaml`: normative `description` on `eth_createAccessList`.
- `tools/testgen`: new `create-al-unfunded-sender` case — unfunded `from`, codeless `to`, zero value, no gas/fee fields.
- `tests/eth_createAccessList/create-al-unfunded-sender.io`: fixture expecting `{"accessList":[],"gasUsed":"0x5208"}`, generated from a patched go-ethereum. `speccheck` passes; sibling fixtures are unchanged.

### Cross-client status

Verified with a single shared fixture in hive `rpc-compat`. reth, nethermind, besu, erigon, and ethrex already return the expected result; go-ethereum is the sole divergence and is fixed by ethereum/go-ethereum#35397. With that fix built from source, all six clients pass.

### Discussion

The same affordability question applies to `eth_call` and `eth_estimateGas`. Reviewers may prefer wording this as shared simulation-method behavior rather than `createAccessList`-only.
