### PR TITLE
engine: specify bit ordering for the 16-byte custody and cell bitarrays

### DIFF
--- a/src/engine/amsterdam.md
+++ b/src/engine/amsterdam.md
@@ -210,7 +210,7 @@ This method follows the same specification as [`engine_getPayloadBodiesByRangeV1
 * params:
   1. `forkchoiceState`: [`ForkchoiceStateV1`](./paris.md#ForkchoiceStateV1).
   2. `payloadAttributes`: `Object|null` - Instance of [`PayloadAttributesV4`](#payloadattributesv4) or `null`.
-  3. `custodyColumns`: `DATA|null`, 16 Bytes - Interpreted as a bitarray of length `CELLS_PER_EXT_BLOB` indicating which column indices form the CL's custody set, or `null` if the CL does not provide custody services.
+  3. `custodyColumns`: `DATA|null`, 16 Bytes - Interpreted as a bitarray of length `CELLS_PER_EXT_BLOB` indicating which column indices form the CL's custody set, or `null` if the CL does not provide custody services. The value is the SSZ serialization of `BitVector[CELLS_PER_EXT_BLOB]`: column `i` is bit `i % 8` of byte `i / 8`.
 * timeout: 8s
 
 #### Response
@@ -253,7 +253,7 @@ Consensus layer clients **MAY** use this method to fetch blob cells from the exe
 * method: `engine_getBlobsV4`
 * params:
   1. `versioned_blob_hashes`: `Array of DATA`, 32 Bytes - an array of blob versioned hashes.
-  2. `indices_bitarray`: `DATA`, 16 Bytes - a bitarray denoting the indices of the cells to retrieve.
+  2. `indices_bitarray`: `DATA`, 16 Bytes - a bitarray denoting the indices of the cells to retrieve. The value is the SSZ serialization of `BitVector[CELLS_PER_EXT_BLOB]`: cell index `i` is bit `i % 8` of byte `i / 8`.
 * timeout: 1s
 
 #### Response


### PR DESCRIPTION
`engine_forkchoiceUpdatedV4`'s `custodyColumns` and `engine_getBlobsV4`'s `indices_bitarray` are both 16-byte bitarrays with no stated bit-to-byte mapping. The failure is silent: a reversed order still decodes to a well-formed 128-bit set, so the EL adopts the wrong custody set, or returns cells the CL did not ask for, instead of returning an error.

The ordering specified is the SSZ serialization of `BitVector[CELLS_PER_EXT_BLOB]` ([consensus specs](https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md#bitvectorn)), `array[i // 8] |= value[i] << (i % 8)`. The custody set is SSZ-native, so this introduces no new convention. It matches go-ethereum, where `core/types/custody_bitmap.go` sets `result[i/8] |= 1 << (i % 8)` and marshals the 16 bytes as plain hex. ethrex implements the same ordering.

Documentation only: the fields stay `DATA`, 16 bytes, nothing on the wire changes, and no OpenRPC change is needed since both are already typed `bytes16`. Confirmation from other client teams would be welcome, and if any client packs the bits the other way round that is worth surfacing before this merges.

EIP-8070 carries the same definitions and has the same gap: ethereum/EIPs#12054, wording kept identical so the documents cannot drift.
