### PR TITLE
Add the EIP-8141 frame transaction fields to the receipt

### DIFF
--- a/src/schemas/receipt.yaml
+++ b/src/schemas/receipt.yaml
@@ -37,6 +37,29 @@ Log:
       type: array
       items:
         $ref: '#/components/schemas/bytes32'
+FrameReceipt:
+  title: frame receipt
+  description: The result of a single frame of a frame transaction as defined by EIP-8141.
+  type: object
+  required:
+    - status
+    - gasUsed
+    - logs
+  additionalProperties: false
+  properties:
+    status:
+      title: status
+      description: 1 on success, 0 on failure, and 2 when the frame was skipped because its atomic batch failed.
+      $ref: '#/components/schemas/uint'
+    gasUsed:
+      title: gas used
+      description: The amount of gas used by this frame, before refunds.
+      $ref: '#/components/schemas/uint'
+    logs:
+      title: logs
+      type: array
+      items:
+        $ref: '#/components/schemas/Log'
 ReceiptInfo:
   type: object
   title: Receipt information
@@ -112,8 +135,18 @@ ReceiptInfo:
       $ref: '#/components/schemas/hash32'
     status:
       title: status
-      description: Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade.
+      description: Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade. A frame transaction as defined by EIP-8141 has no status of its own, so this is 1 if every entry of frameReceipts has status 1, and 0 otherwise.
       $ref: '#/components/schemas/uint'
+    payer:
+      title: payer
+      description: The account charged for the transaction. Only specified for frame transactions as defined by EIP-8141, where it need not be the sender.
+      $ref: '#/components/schemas/address'
+    frameReceipts:
+      title: frame receipts
+      description: The per-frame results, in frame order. Only specified for frame transactions as defined by EIP-8141.
+      type: array
+      items:
+        $ref: '#/components/schemas/FrameReceipt'
     effectiveGasPrice:
       title: effective gas price
       description: The actual value per gas deducted from the sender's account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas).


### PR DESCRIPTION
EIP-8141 replaces the single transaction-level status with a list of per-frame receipts, so a receipt returned over JSON-RPC has to say three things the schema cannot express today: who paid, what each frame did, and what the transaction's `status` means when the transaction itself has none.

This adds `payer` and `frameReceipts` to `ReceiptInfo`, both only present for frame transactions, and pins `status` for them: 1 if every frame receipt has status 1, and 0 otherwise. Deriving it from the frame receipts rather than from execution state keeps a node that executed the block and a node that only received the receipt in agreement.

Frame status 2 is the EIP-8141 code for a frame skipped because its atomic batch failed.

The transaction object side of EIP-8141 is not covered here.
