### PR TITLE
fix: add -32602 error code to engine_getPayloadBodiesByRangeV1 and V2

### DIFF
--- a/src/engine/openrpc/methods/payload.yaml
+++ b/src/engine/openrpc/methods/payload.yaml
@@ -854,6 +854,8 @@
       items:
         $ref: '#/components/schemas/ExecutionPayloadBodyV1'
   errors:
+    - code: -32602
+      message: Invalid params
     - code: -38004
       message: Too large request
   examples:
@@ -958,6 +960,8 @@
       items:
         $ref: '#/components/schemas/ExecutionPayloadBodyV2'
   errors:
+    - code: -32602
+      message: Invalid params
     - code: -38004
       message: Too large request
   examples:


### PR DESCRIPTION
Closes #775

## Problem

`engine_getPayloadBodiesByRangeV1` and `V2` were missing the `-32602: Invalid params` error required by the Shanghai and Amsterdam specs (i.e. the OpenRPC yaml disagreed with the markdown spec).

## Changes

Adds `-32602` to both methods' `errors` lists in `payload.yaml`, matching the other methods.

## Verification

- `make build` / `make test` (speccheck) pass
- `make lint`: no new warnings