### PR TITLE
fix: add slotNumber and targetGasLimit to testing_buildBlockV1

### DIFF
--- a/src/testing/testing_buildBlockV1.yaml
+++ b/src/testing/testing_buildBlockV1.yaml
@@ -23,7 +23,7 @@
     - name: Payload attributes
       required: true
       schema:
-        title: PayloadAttributesV3
+        title: PayloadAttributesV4
         type: object
         properties:
           timestamp:
@@ -39,6 +39,10 @@
               $ref: '#/components/schemas/Withdrawal'
           parentBeaconBlockRoot:
             $ref: '#/components/schemas/hash32'
+          slotNumber:
+            $ref: '#/components/schemas/uint'
+          targetGasLimit:
+            $ref: '#/components/schemas/uint'
     - name: Transactions
       required: true
       description: |
@@ -106,6 +110,8 @@
             suggestedFeeRecipient: '0x0000000000000000000000000000000000000000'
             withdrawals: []
             parentBeaconBlockRoot: '0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884365149a42212e8822'
+            slotNumber: '0x0'
+            targetGasLimit: '0x1c9c380'
         - name: Transactions
           value: []
         - name: Extra data

--- a/tools/testgen/generators.go
+++ b/tools/testgen/generators.go
@@ -2732,6 +2732,11 @@ var TestingBuildBlockV1 = MethodTests{
 					payloadAttrs["parentBeaconBlockRoot"] = beaconRoot.Hex()
 				}
 
+				if t.chain.Config().IsAmsterdam(parentBlock.Number(), parentBlock.Time()) {
+					payloadAttrs["slotNumber"] = hexutil.Uint64(0)
+					payloadAttrs["targetGasLimit"] = hexutil.Uint64(parentBlock.GasLimit())
+				}
+
 				// Use sender index 2 so nonce matches geth state: index 0 (and 3) are used by
 				// eth_sendRawTransaction tests which call IncNonce, so they diverge from geth when run in full suite.
 				sender, nonce := t.chain.GetSender(2)
@@ -2821,6 +2826,11 @@ var TestingBuildBlockV1 = MethodTests{
 					payloadAttrs["parentBeaconBlockRoot"] = beaconRoot.Hex()
 				}
 
+				if t.chain.Config().IsAmsterdam(parentBlock.Number(), parentBlock.Time()) {
+					payloadAttrs["slotNumber"] = hexutil.Uint64(0)
+					payloadAttrs["targetGasLimit"] = hexutil.Uint64(parentBlock.GasLimit())
+				}
+
 				extraData := hexutil.Encode([]byte{})
 				var result map[string]interface{}
 				err := t.rpc.CallContext(ctx, &result, "testing_buildBlockV1",
@@ -2873,6 +2883,11 @@ var TestingBuildBlockV1 = MethodTests{
 				if t.chain.Config().IsCancun(parentBlock.Number(), parentBlock.Time()) {
 					beaconRoot := common.Hash{0xcf, 0x8e, 0x0d, 0x4e, 0x95, 0x87, 0x36, 0x9b, 0x23, 0x01, 0xd0, 0x79, 0x03, 0x47, 0x32, 0x03, 0x02, 0xcc, 0x09, 0x43, 0xd5, 0xa1, 0x88, 0x43, 0x65, 0x14, 0x9a, 0x42, 0x21, 0x2e, 0x88, 0x22}
 					payloadAttrs["parentBeaconBlockRoot"] = beaconRoot.Hex()
+				}
+
+				if t.chain.Config().IsAmsterdam(parentBlock.Number(), parentBlock.Time()) {
+					payloadAttrs["slotNumber"] = hexutil.Uint64(0)
+					payloadAttrs["targetGasLimit"] = hexutil.Uint64(parentBlock.GasLimit())
 				}
 
 				// Add a transaction to the mempool first
@@ -2955,6 +2970,11 @@ var TestingBuildBlockV1 = MethodTests{
 				if t.chain.Config().IsCancun(parentBlock.Number(), parentBlock.Time()) {
 					beaconRoot := common.Hash{0xcf, 0x8e, 0x0d, 0x4e, 0x95, 0x87, 0x36, 0x9b, 0x23, 0x01, 0xd0, 0x79, 0x03, 0x47, 0x32, 0x03, 0x02, 0xcc, 0x09, 0x43, 0xd5, 0xa1, 0x88, 0x43, 0x65, 0x14, 0x9a, 0x42, 0x21, 0x2e, 0x88, 0x22}
 					payloadAttrs["parentBeaconBlockRoot"] = beaconRoot.Hex()
+				}
+
+				if t.chain.Config().IsAmsterdam(parentBlock.Number(), parentBlock.Time()) {
+					payloadAttrs["slotNumber"] = hexutil.Uint64(0)
+					payloadAttrs["targetGasLimit"] = hexutil.Uint64(parentBlock.GasLimit())
 				}
 
 				// Use an invalid nonce (e.g. 999) so the tx cannot be applied; client MUST fail.


### PR DESCRIPTION
Closes #857

`testing_buildBlockV1` described its payload attributes as `PayloadAttributesV3`, but Amsterdam requires `PayloadAttributesV4` with `slotNumber` and `targetGasLimit`. As reported in #857, this makes clients disagree — Erigon rejects with `-32602 targetGasLimit required for Glamsterdam and later forks`.

## Changes

- Retitle the payload attributes schema to `PayloadAttributesV4` and add the two `uint` fields, plus the inline example.
- Add both fields to the four `testing_buildBlockV1` generators, gated on `IsAmsterdam` (mirroring the existing Cancun gating), so fixtures carry them when filled against an Amsterdam-capable chain.

## Verification

- `make build`, `make test` (speccheck), `make lint`, and `go test ./...` pass; `make fill` stays idempotent on the pre-Amsterdam test chain.

## Note

The committed fixtures can't be regenerated in-repo to include `targetGasLimit` (the bundled geth and test chain are pre-Amsterdam, and geth's `PayloadAttributes` has no such field); filling them is a follow-up against an Amsterdam-capable client.