### PR TITLE
ci: update actions to node24 releases and fix go module cache path

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,18 +19,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: ^1.26
+          cache-dependency-path: tools/go.sum
         id: go
 
       - name: Build the spec
         run: make build
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm
@@ -44,12 +45,12 @@ jobs:
         run: npm run build:docs:ci:deploy
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: build
 
       - name: Upload openrpc spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openrpc-spec
           path: |
@@ -65,7 +66,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   deploy-spec-main:
     runs-on: ubuntu-latest
@@ -73,9 +74,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download openrpc spec
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: openrpc-spec
       - name: setup git config

--- a/.github/workflows/publish-spec.yaml
+++ b/.github/workflows/publish-spec.yaml
@@ -15,7 +15,7 @@ jobs:
   publish-spec:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download stamped spec from release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,20 +21,21 @@ jobs:
       # (github.ref_name is a defensive fallback)
       TAG: ${{ github.event.inputs.tag || github.event.release.tag_name || github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag || github.event.release.tag_name || github.ref }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: ^1.26
+          cache-dependency-path: tools/go.sum
         id: go
 
       - name: Build the spec
         run: make build
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm
@@ -60,7 +61,7 @@ jobs:
             "api_versioned_sidebars/version-${VER}-sidebars.json"
 
       - name: Upload openrpc spec
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: openrpc-spec
           path: |
@@ -68,7 +69,7 @@ jobs:
             refs-openrpc.json
 
       - name: Upload docs snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-snapshot
           path: docs-snapshot-*.tar.gz
@@ -79,11 +80,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: openrpc-spec
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: docs-snapshot
 
@@ -111,9 +112,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download stamped spec artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: openrpc-spec
       - name: setup git config

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -6,6 +6,6 @@ jobs:
     name: Spellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v7
     - uses: rojopolis/spellcheck-github-actions@0.29.0
       name: Spellcheck

--- a/.github/workflows/sync-release-notes.yaml
+++ b/.github/workflows/sync-release-notes.yaml
@@ -18,11 +18,11 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -34,7 +34,7 @@ jobs:
         run: node scripts/sync-release-note.js
 
       - name: Open / update PR
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main

--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -11,16 +11,17 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: ^1.25
+          cache-dependency-path: tools/go.sum
         id: go
 
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,11 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Specification
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: ^1.26
+          cache-dependency-path: tools/go.sum
         id: go
 
       - name: Build the spec
@@ -47,10 +48,11 @@ jobs:
   lint-tools:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ^1.24
+          cache-dependency-path: tools/go.sum
         id: go
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
Our workflow runs show Node.js 20 deprecation warnings for actions/checkout@v4, setup-node@v4, upload-artifact@v4, download-artifact@v4, and deploy-pages@v4. GitHub forces these to run on Node 24 today and will remove Node 20 support later. This PR updates every action to its latest major release, which runs on Node 24 natively:

- actions/checkout v4/v6/master -> v7
- actions/setup-go v6 -> v7
- actions/setup-node v4 -> v7
- actions/upload-artifact v4 -> v7
- actions/download-artifact v4 -> v8
- actions/deploy-pages v4 -> v5
- actions/upload-pages-artifact v3 -> v5
- peter-evans/create-pull-request v6.1.0 -> v8.1.1 (pinned SHA)

The runs also warn "Restore cache failed: Dependencies file is not found". setup-go enables module caching by default and looks for go.mod at the repository root, but our module is in tools/. Each setup-go step now sets `cache-dependency-path: tools/go.sum`, so the cache works and the warning goes away.

I checked the release notes for each major version between old and new. The relevant breaking changes do not affect us:

- download-artifact v5 changed the extraction path only for single downloads by ID. We download by name.
- download-artifact v8 fails on digest mismatch by default. This is the safe behavior we want.
- upload-pages-artifact v4 stopped including hidden files. Our docs build output contains no dotfile the site needs (only `img/.gitkeep`).
- checkout v6 persists credentials to a separate file. The `git push` steps in deploy and publish-spec still work through the same mechanism.
- create-pull-request v7 renamed `git-token` to `branch-token` and removed the `PULL_REQUEST_NUMBER` env output. We use neither.

Tested locally: actionlint on all workflows, `make build`, `make test`, `make lint`, `make lint`/`make test` in tools/, and `npm ci` plus the full docs build. All pass. The test, test-deploy, and spellcheck workflows run on this PR and exercise the new checkout, setup-go, and setup-node versions plus the cache path. The deploy, release, and publish-spec workflows only run after merge or on release, so their artifact and pages action bumps are verified against the release notes above.