### PR TITLE
engine: bound engine_getInclusionListV1 result by the consensus-layer transaction byte measure

### DIFF
--- a/src/engine/bogota.md
+++ b/src/engine/bogota.md
@@ -124,7 +124,7 @@ This method follows the same specification as [`engine_newPayloadV5`](./amsterda
 
 1. Client software **MUST** provide a list of transactions for the inclusion list based on the local view of the mempool. The strategy for selecting which transactions to include is implementation dependent.
 
-2. Client software **MUST** ensure the byte length of the RLP encoding of the returned transaction list does not exceed `MAX_BYTES_PER_INCLUSION_LIST`.
+2. Client software **MUST** ensure the sum of the byte lengths of the returned transactions does not exceed `MAX_BYTES_PER_INCLUSION_LIST`, and **MUST NOT** return an empty transaction. This is the measure the consensus layer applies to `InclusionList.transactions` (`MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`, every transaction non-empty), so a list satisfying it is always valid to broadcast.
 
 3. Client software **MUST NOT** include any [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction) in the returned transaction list.
  


### PR DESCRIPTION
`engine_getInclusionListV1` currently requires the *RLP encoding* of the returned list to fit `MAX_BYTES_PER_INCLUSION_LIST` (8192), while the consensus layer (ethereum/consensus-specs#5576, issue #5575) bounds the **sum of the transaction byte lengths** (`MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`) and rejects empty transactions. The RLP list framing adds a per-item prefix and a list header, so the two measures differ per transaction.

This aligns the engine rule with the consensus-layer measure: `sum(len(tx)) ≤ MAX_BYTES_PER_INCLUSION_LIST`, no empty transactions. A list that satisfies the engine bound is then always valid to broadcast. (The RLP measure was strictly larger, so lists were already CL-valid; this is a clarification that removes the second ruler.)

https://claude.ai/code/session_01YHCg1Q6QaZn8rPjB7za3UB