### PR TITLE
schemas: add data as alias of input on GenericTransaction

### DIFF
--- a/src/schemas/transaction.yaml
+++ b/src/schemas/transaction.yaml
@@ -546,6 +546,10 @@ GenericTransaction:
     input:
       title: input data
       $ref: '#/components/schemas/bytes'
+    data:
+      title: data
+      description: Alias of `input`. Prefer `input`. If both are present and differ, clients should reject.
+      $ref: '#/components/schemas/bytes'
     gasPrice:
       title: gas price
       description: The gas price willing to be paid by the sender in wei


### PR DESCRIPTION
Closes #663

`GenericTransaction` had `additionalProperties: false` with only `input`, but the `eth_createAccessList` example and client call paths already send `data`. Requests using `data` were schema-invalid despite being accepted in practice.

## Changes

- Add `data` to `GenericTransaction` as an alias of `input`, with the same `bytes` schema.
- Document that `input` is preferred and clients should reject when both are present and differ.

## Verification

- `make build` and `make lint` pass.