### PR TITLE
schemas: clarify feeRecipient is not COINBASE

### DIFF
--- a/src/schemas/execute.yaml
+++ b/src/schemas/execute.yaml
@@ -133,7 +133,8 @@ BlockOverrides:
       title: Gas limit
       $ref: '#/components/schemas/uint64'
     feeRecipient:
-      title: Fee Recipient (also known as coinbase)
+      title: Fee recipient
+      description: Address set by the proposer/builder to receive priority fees. Often matches the block header `feeRecipient` field but is not the COINBASE EVM opcode.
       $ref: '#/components/schemas/address'
     baseFeePerGas:
       title: Base fee per unit of gas


### PR DESCRIPTION
Closes #644

`BlockOverrides.feeRecipient` was titled "Fee Recipient (also known as coinbase)". Fee recipient is the proposer/builder payment target; COINBASE is the EVM opcode. They often match when the validator builds the block, but they are not the same concept.

## Changes

- Retitle `feeRecipient` and add a short description separating fee recipient from the COINBASE opcode.

## Verification

- `make build` passes.