### PR TITLE
eth: specify getLogs error for block ranges beyond head

### DIFF
--- a/src/eth/filter.yaml
+++ b/src/eth/filter.yaml
@@ -150,6 +150,14 @@
               - '0x04474795f5b996ff80cb47c148d4c5ccdbe09ef27551820caa9c2f8ed149cce3'
 - name: eth_getLogs
   summary: Returns an array of all logs matching the specified filter.
+  description: >-
+    Returns all logs that match the given filter. `fromBlock` and `toBlock`
+    bound an inclusive block range; block tags resolve against the current
+    head block. If either bound resolves to a block number
+    greater than the current head block, or if `fromBlock` resolves to a block
+    number greater than `toBlock`, clients MUST return the `-32602: Invalid
+    params` error. Clients MUST NOT clamp the range to the head block or
+    return a partial result.
   params:
     - name: Filter
       schema:

--- a/tests/eth_getLogs/filter-error-fully-future-block-range.io
+++ b/tests/eth_getLogs/filter-error-fully-future-block-range.io
@@ -1,0 +1,3 @@
+// checks that an error is returned if both `fromBlock` and `toBlock` are greater than the latest block
+>> {"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"fromBlock":"0x38","toBlock":"0x3a"}]}
+<< {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"block range extends beyond current head block"}}

--- a/tests/eth_getLogs/filter-error-future-block-to-latest.io
+++ b/tests/eth_getLogs/filter-error-future-block-to-latest.io
@@ -1,0 +1,3 @@
+// checks that an error is returned if `fromBlock` is greater than the latest block and `toBlock` is `latest`
+>> {"jsonrpc":"2.0","id":1,"method":"eth_getLogs","params":[{"fromBlock":"0x38","toBlock":"latest"}]}
+<< {"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"invalid block range params"}}

--- a/tools/testgen/generators.go
+++ b/tools/testgen/generators.go
@@ -2386,6 +2386,33 @@ var EthGetLogs = MethodTests{
 			},
 		},
 		{
+			Name:  "filter-error-fully-future-block-range",
+			About: "checks that an error is returned if both `fromBlock` and `toBlock` are greater than the latest block",
+			Run: func(ctx context.Context, t *T) error {
+				_, err := t.eth.FilterLogs(ctx, ethereum.FilterQuery{
+					FromBlock: big.NewInt(int64(len(t.chain.blocks) + 1)),
+					ToBlock:   big.NewInt(int64(len(t.chain.blocks) + 3)),
+				})
+				if err == nil {
+					return fmt.Errorf("expected error")
+				}
+				return nil
+			},
+		},
+		{
+			Name:  "filter-error-future-block-to-latest",
+			About: "checks that an error is returned if `fromBlock` is greater than the latest block and `toBlock` is `latest`",
+			Run: func(ctx context.Context, t *T) error {
+				_, err := t.eth.FilterLogs(ctx, ethereum.FilterQuery{
+					FromBlock: big.NewInt(int64(len(t.chain.blocks) + 1)),
+				})
+				if err == nil {
+					return fmt.Errorf("expected error")
+				}
+				return nil
+			},
+		},
+		{
 			Name:  "filter-error-reversed-block-range",
 			About: "checks that an error is returned if `fromBlock` is larger than `toBlock`",
 			Run: func(ctx context.Context, t *T) error {


### PR DESCRIPTION
Specify eth_getLogs behavior for block ranges past the head block, and add rpc-compat tests for it. Fixes #534.

Five of six clients already return an error for these ranges. I surveyed the current master builds of geth, Nethermind, Besu, Erigon, reth, and ethrex with hive rpc-compat:

- toBlock past the head: geth, Nethermind, Besu, Erigon, and reth return -32602. ethrex returns -32603.
- fromBlock past the head with toBlock "latest": reth returns an empty array. The other five return an error, ethrex with -32000.
- Reversed range (fromBlock above toBlock): all six return an error. All codes are -32602 except ethrex (-32000).

The spec change documents what most clients already do. Clients return -32602 when a bound resolves past the head, or when fromBlock resolves above toBlock. Clients do not clamp the range and do not return a partial result.

The two new test cases cover the shapes the existing filter-error-future-block-range fixture misses: a fully future range, and a future fromBlock with toBlock "latest".

Client fixes: paradigmxyz/reth#26891 (empty array case) and lambdaclass/ethrex#7236 (error codes).