### PR TITLE
Add non-zero requirements to getInclusionListV1's response

### DIFF
--- a/src/engine/bogota.md
+++ b/src/engine/bogota.md
@@ -122,12 +122,18 @@ This method follows the same specification as [`engine_newPayloadV5`](./amsterda
 
 #### Specification
 
-1. Client software **MUST** provide a list of transactions for the inclusion list based on the local view of the mempool. The strategy for selecting which transactions to include is implementation dependent.
+1. Client software **MUST** provide, based on its local view of the mempool, a list of transactions for the inclusion list satisfying the following conditions:
 
-2. Client software **MUST** ensure the byte length of the RLP encoding of the returned transaction list does not exceed `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`.
+    1. The transaction list **MUST** contain at least one transaction.
 
-3. Client software **MUST NOT** include any [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction) in the returned transaction list.
- 
+    2. Every transaction **MUST** have non-zero length (at least 1 byte).
+
+    3. The transaction list **MUST NOT** include any [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction).
+
+    4. The total byte length of the transaction list **MUST NOT** exceed `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`.
+
+2. The strategy for selecting transactions is implementation dependent.
+
 ### engine_forkchoiceUpdatedV5
 
 #### Request

--- a/src/engine/bogota.md
+++ b/src/engine/bogota.md
@@ -124,13 +124,11 @@ This method follows the same specification as [`engine_newPayloadV5`](./amsterda
 
 1. Client software **MUST** provide, based on its local view of the mempool, a list of transactions for the inclusion list satisfying the following conditions:
 
-    1. The transaction list **MUST** contain at least one transaction.
+    1. Every transaction **MUST** have non-zero length (at least 1 byte).
 
-    2. Every transaction **MUST** have non-zero length (at least 1 byte).
+    2. The transaction list **MUST NOT** include any [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction).
 
-    3. The transaction list **MUST NOT** include any [blob transaction](https://eips.ethereum.org/EIPS/eip-4844#blob-transaction).
-
-    4. The total byte length of the transaction list **MUST NOT** exceed `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`.
+    3. The total byte length of the transaction list **MUST NOT** exceed `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`.
 
 2. The strategy for selecting transactions is implementation dependent.
 


### PR DESCRIPTION
This PR elaborates `getInclusionListV1`'s response by adding more non-zero requirements for transaction count and size.

Relevant: #870