### PR TITLE
schemas: treat unresolvable safe and finalized tags as unknown blocks

### DIFF
--- a/src/schemas/block.yaml
+++ b/src/schemas/block.yaml
@@ -122,7 +122,7 @@ BlockTag:
     - safe
     - latest
     - pending
-  description: '`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error'
+  description: '`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions; `pending`: A sample next block built by the client on top of `latest` and containing the set of transactions usually taken from local mempool. If the `safe` or `finalized` tag cannot be resolved to a block, the method responds as it does for an unknown block.'
 BlockNumberOrTag:
   title: Block number or tag
   oneOf:
@@ -138,7 +138,7 @@ BlockTagForRange:
     - finalized
     - safe
     - latest
-  description: '`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions. Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error'
+  description: '`earliest`: The lowest numbered block the client has available; `finalized`: The most recent crypto-economically secure block, cannot be re-orged outside of manual intervention driven by community coordination; `safe`: The most recent block that is safe from re-orgs under honest majority and certain synchronicity assumptions; `latest`: The most recent block in the canonical chain observed by the client, this block may be re-orged out of the canonical chain even under healthy/normal conditions. If the `safe` or `finalized` tag cannot be resolved to a block, the method responds as it does for an unknown block.'
 BlockNumberOrTagForRange:
   title: Block number or tag
   oneOf:


### PR DESCRIPTION
The `BlockTag` and `BlockTagForRange` descriptions end with a rule from the merge era:

> Before the merge transition is finalized, any call querying for `finalized` or `safe` block MUST be responded to with `-39001: Unknown block` error

This PR replaces that sentence with:

> If the `safe` or `finalized` tag cannot be resolved to a block, the method responds as it does for an unknown block.

No numeric code. Each method keeps its own unknown-block behavior.

## Why

The rule was written for pre-merge nodes. #200 added it in May 2022. The author noted that no unified error list existed and that any code risked a conflict, and picked `-39001` after `-31100`. #785 copied the sentence into `BlockTagForRange` in June 2026 without discussion. Nothing tests it. The rpc-compat chain applies a forkchoice update at startup, so both tags always resolve.

Clients did not converge on it. Behavior today on a node that has not received a forkchoice update:

| Client | `eth_getBlockByNumber("safe")` | `eth_getBalance` and other state reads |
|---|---|---|
| go-ethereum | `-32000` "safe block not found" | `-32000` |
| Nethermind | `null` (NethermindEth/nethermind#8702) | `-32000` |
| Besu | `-39001` "Unknown block" | `-39001` |
| Erigon | `-39001` | `-39001` |
| reth | `null` | `-32001` |
| ethrex | `null` | `-32603` |

Two of six return `-39001` from the block getter. All six return `null` for an unknown block number. go-ethereum has never emitted `-39001`.

The code also collides. ethrex uses `-39001` for an EIP-8025 proof-format error. The OP stack `op-service` uses `-39001` for "out of events". `-39001` is not in `src/error-groups/`, and no method lists it in `errors[]`.

The spec already splits this case by result type. `eth_getBlockAccessList` returns `null` for an unknown block. `debug_getRawBlockAccessList` cannot return `null` and returns `-32001: Resource not found`. The new sentence makes an unresolved tag follow the same per-method rule.

## Out of scope

Methods that cannot return `null` (`eth_getBalance`, `eth_call`, and others) have no specified error for an unknown block. That stays unspecified here. It belongs to the error-code work in #650, #784, and #817.

## Effect on clients

Besu and Erigon return `-39001` from getters that the spec says return `null`. go-ethereum returns `-32000` from the same getters. Each change is a few lines in the getter path. Nethermind, reth, and ethrex already return `null`.

Related: #874, #877.
