### PR TITLE
tests: add eth_gasPrice and eth_maxPriorityFeePerGas fixtures

### DIFF
--- a/tests/eth_gasPrice/get-current-gas-price.io
+++ b/tests/eth_gasPrice/get-current-gas-price.io
@@ -1,0 +1,4 @@
+// gets the current gas price in wei
+// speconly: client response is only checked for schema validity.
+>> {"jsonrpc":"2.0","id":1,"method":"eth_gasPrice"}
+<< {"jsonrpc":"2.0","id":1,"result":"0x1047435"}

--- a/tests/eth_maxPriorityFeePerGas/get-current-tip.io
+++ b/tests/eth_maxPriorityFeePerGas/get-current-tip.io
@@ -1,0 +1,4 @@
+// gets the current maxPriorityFeePerGas in wei
+// speconly: client response is only checked for schema validity.
+>> {"jsonrpc":"2.0","id":1,"method":"eth_maxPriorityFeePerGas"}
+<< {"jsonrpc":"2.0","id":1,"result":"0xf4240"}

--- a/tools/testgen/generators.go
+++ b/tools/testgen/generators.go
@@ -112,9 +112,8 @@ var AllMethods = []MethodTests{
 	TxpoolContent,
 	TxpoolContentFrom,
 
-	// -- gas price tests are disabled because of non-determinism
-	// EthGasPrice,
-	// EthMaxPriorityFeePerGas,
+	EthGasPrice,
+	EthMaxPriorityFeePerGas,
 
 	// -- uncle APIs are not required anymore after the merge
 	// EthGetUncleByBlockNumberAndIndex,
@@ -1920,8 +1919,9 @@ var EthGasPrice = MethodTests{
 	"eth_gasPrice",
 	[]Test{
 		{
-			Name:  "get-current-gas-price",
-			About: "gets the current gas price in wei",
+			Name:     "get-current-gas-price",
+			About:    "gets the current gas price in wei",
+			SpecOnly: true, // Gas price suggestions are not required to be identical across clients.
 			Run: func(ctx context.Context, t *T) error {
 				if _, err := t.eth.SuggestGasPrice(ctx); err != nil {
 					return err
@@ -1937,8 +1937,9 @@ var EthMaxPriorityFeePerGas = MethodTests{
 	"eth_maxPriorityFeePerGas",
 	[]Test{
 		{
-			Name:  "get-current-tip",
-			About: "gets the current maxPriorityFeePerGas in wei",
+			Name:     "get-current-tip",
+			About:    "gets the current maxPriorityFeePerGas in wei",
+			SpecOnly: true, // Priority fee suggestions are not required to be identical across clients.
 			Run: func(ctx context.Context, t *T) error {
 				if _, err := t.eth.SuggestGasTipCap(ctx); err != nil {
 					return err


### PR DESCRIPTION
## Summary

- enable the existing `eth_gasPrice` and `eth_maxPriorityFeePerGas` rpctestgen cases
- mark both cases as `SpecOnly` because suggested fee values are implementation-specific
- add the generated RPC fixtures

For `SpecOnly` fixtures, Hive validates a successful response result against the OpenRPC schema instead of requiring byte-identical values. This checks that each client implements the method and returns a valid quantity while allowing fee suggestion algorithms to differ.

Partially addresses #737.

## Testing

- `make fill` (repeated full regeneration produced no changes)
- `make build && make test`
- `make -C tools test`
- `make lint`