### PR TITLE
engine: add payload witness endpoint to REST + SSZ proposal

### DIFF
--- a/src/engine/refactor-ssz.md
+++ b/src/engine/refactor-ssz.md
@@ -279,8 +279,7 @@ source of the divergence.
 ### `ExecutionWitness`
 
 Used by `PayloadStatusWithWitness`, the response of
-[`POST /payloads/witness`](#post-payloadswitness). It carries
-the raw state required to statelessly re-execute and verify the block.
+[`POST /payloads/witness`](#post-payloadswitness).
 The container is **fork-invariant in shape** (like `PayloadStatus`);
 only the endpoint that returns it is fork-scoped.
 
@@ -292,18 +291,11 @@ ExecutionWitness {
 }
 ```
 
-| Field | Contents |
-| - | - |
-| `state` | Merkle trie nodes (account + storage) accessed during execution |
-| `codes` | contract bytecodes touched during execution |
-| `headers` | block headers needed to resolve `BLOCKHASH` |
-
 Each item is opaque bytes; the EL does **not** re-encode them as
 structured SSZ — they travel as `ByteList`s, the same way `transactions`
-and `block_access_list` do. An empty list (`[]`) for any field means no
-data of that category was accessed. Field semantics and the exact bytes
-of each item follow the
-[execution-specs stateless witness](https://github.com/ethereum/execution-specs/blob/master/src/ethereum/forks/amsterdam/stateless.py).
+and `block_access_list` do. Field contents and completeness requirements
+are defined in
+[refactor.md § Payload submission with witness](./refactor.md#payload-submission-with-witness).
 
 ---
 
@@ -720,33 +712,25 @@ from `payload.transactions`).
 
 ### `POST /payloads/witness`
 
-Optional, Amsterdam+. Same request as
-[`POST /payloads`](#post-payloads); the response is a
-superset of `PayloadStatus` that also carries the stateless
-[`ExecutionWitness`](#executionwitness). See
+See
 [refactor.md § Payload submission with witness](./refactor.md#payload-submission-with-witness)
-for the endpoint semantics.
+for endpoint availability and witness requirements.
 
 #### Request (Amsterdam)
 
-Identical to `POST /payloads` — `ExecutionPayloadEnvelopeAmsterdam`
-(and the matching `ExecutionPayloadEnvelope{Fork}` for every Amsterdam+
-fork, selected by the `Eth-Execution-Version` header).
+`ExecutionPayloadEnvelopeAmsterdam`, as defined for
+[`POST /payloads`](#post-payloads).
 
 #### Response
 
 ```
 PayloadStatusWithWitness {
-    payload_status: PayloadStatus               # same container, full enum 0/1/2/3
-    witness:        Optional[ExecutionWitness]  # present iff payload_status.status == VALID
+    payload_status: PayloadStatus
+    witness:        Optional[ExecutionWitness]
 }
 ```
 
-`witness` resolves to `List[ExecutionWitness, 1]`: a length-1 list
-holding the witness when `payload_status.status == VALID`, and the empty
-list (`[]`) for `INVALID` / `SYNCING` / `ACCEPTED` or when no witness was
-produced. The endpoint never returns a witness alongside a non-`VALID`
-status. Because `PayloadStatus` and `ExecutionWitness` are both
+Because `PayloadStatus` and `ExecutionWitness` are both
 variable-size, `PayloadStatusWithWitness` is a two-offset container
 (`payload_status`, then `witness`).
 

--- a/src/engine/refactor-ssz.md
+++ b/src/engine/refactor-ssz.md
@@ -714,7 +714,7 @@ from `payload.transactions`).
 
 See
 [refactor.md § Payload submission with witness](./refactor.md#payload-submission-with-witness)
-for endpoint availability and witness requirements.
+for endpoint availability, witness requirements, and public-key semantics.
 
 #### Request (Amsterdam)
 
@@ -727,12 +727,14 @@ for endpoint availability and witness requirements.
 PayloadStatusWithWitness {
     payload_status: PayloadStatus
     witness:        Optional[ExecutionWitness]
+    public_keys:    List[ByteVector[65], MAX_TXS_PER_PAYLOAD]
 }
 ```
 
-Because `PayloadStatus` and `ExecutionWitness` are both
-variable-size, `PayloadStatusWithWitness` is a two-offset container
-(`payload_status`, then `witness`).
+All three fields are variable-size, so `PayloadStatusWithWitness` is a
+three-offset container (`payload_status`, then `witness`, then
+`public_keys`). Each public key is a fixed-size 65-byte vector, so the
+list encodes as concatenated keys with no per-key offsets.
 
 ### `POST /forkchoice`
 

--- a/src/engine/refactor-ssz.md
+++ b/src/engine/refactor-ssz.md
@@ -27,6 +27,7 @@
   - [`PayloadAttributes` (Amsterdam)](#payloadattributes-amsterdam)
   - [`ForkchoiceState`](#forkchoicestate)
   - [`PayloadStatus`](#payloadstatus)
+  - [`ExecutionWitness`](#executionwitness)
 - [Per-fork container catalogue](#per-fork-container-catalogue)
   - [`ExecutionPayload` per fork](#executionpayload-per-fork)
   - [`PayloadAttributes` per fork](#payloadattributes-per-fork)
@@ -39,6 +40,7 @@
   - [Identification & capabilities](#identification--capabilities)
 - [Endpoint containers](#endpoint-containers)
   - [`POST /payloads`](#post-payloads)
+  - [`POST /payloads/witness`](#post-payloadswitness)
   - [`POST /forkchoice`](#post-forkchoice)
   - [`GET /payloads/{payloadId}`](#get-payloadspayloadid)
   - [`POST /bodies/hash` and `GET /bodies?...`](#post-bodieshash-and-get-bodies)
@@ -89,6 +91,8 @@
 | `MAX_BLOBS_REQUEST` | `MAX_VERSIONED_HASHES_PER_REQUEST` (128) | derived |
 | `MAX_BODIES_REQUEST` | `2**5` (32) | [Shanghai](./shanghai.md#engine_getpayloadbodiesbyhashv1) |
 | `MAX_REQUEST_BODY_SIZE` | `2**26` (67,108,864) | this spec (64 MiB; advertised as `limits.payload.max_bytes`) |
+| `MAX_WITNESS_ITEMS` | `2**20` (1,048,576) | this spec (max items per `ExecutionWitness` field) |
+| `MAX_WITNESS_ITEM_BYTES` | `2**20` (1,048,576) | this spec (max byte length of a single witness item) |
 | `MAX_ERROR_BYTES` | `1024` | this spec |
 | `MAX_CLIENT_CODE_LENGTH` | `2` | this spec |
 | `MAX_CLIENT_NAME_LENGTH` | `64` | this spec |
@@ -271,6 +275,35 @@ emitted) pointing at the start of the 14-byte text. Total =
 precedes the text whenever the error is present — this is exactly the
 byte that a plain `List[byte, 1024]` implementation omits, and the
 source of the divergence.
+
+### `ExecutionWitness`
+
+Used by `PayloadStatusWithWitness`, the response of
+[`POST /payloads/witness`](#post-payloadswitness). It carries
+the raw state required to statelessly re-execute and verify the block.
+The container is **fork-invariant in shape** (like `PayloadStatus`);
+only the endpoint that returns it is fork-scoped.
+
+```
+ExecutionWitness {
+    state:   List[ByteList[MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]
+    codes:   List[ByteList[MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]
+    headers: List[ByteList[MAX_WITNESS_ITEM_BYTES], MAX_WITNESS_ITEMS]
+}
+```
+
+| Field | Contents |
+| - | - |
+| `state` | Merkle trie nodes (account + storage) accessed during execution |
+| `codes` | contract bytecodes touched during execution |
+| `headers` | block headers needed to resolve `BLOCKHASH` |
+
+Each item is opaque bytes; the EL does **not** re-encode them as
+structured SSZ — they travel as `ByteList`s, the same way `transactions`
+and `block_access_list` do. An empty list (`[]`) for any field means no
+data of that category was accessed. Field semantics and the exact bytes
+of each item follow the
+[execution-specs stateless witness](https://github.com/ethereum/execution-specs/blob/master/src/ethereum/forks/amsterdam/stateless.py).
 
 ---
 
@@ -684,6 +717,38 @@ from `payload.transactions`).
 #### Response
 
 `PayloadStatus` (full enum, `0`/`1`/`2`/`3`).
+
+### `POST /payloads/witness`
+
+Optional, Amsterdam+. Same request as
+[`POST /payloads`](#post-payloads); the response is a
+superset of `PayloadStatus` that also carries the stateless
+[`ExecutionWitness`](#executionwitness). See
+[refactor.md § Payload submission with witness](./refactor.md#payload-submission-with-witness)
+for the endpoint semantics.
+
+#### Request (Amsterdam)
+
+Identical to `POST /payloads` — `ExecutionPayloadEnvelopeAmsterdam`
+(and the matching `ExecutionPayloadEnvelope{Fork}` for every Amsterdam+
+fork, selected by the `Eth-Execution-Version` header).
+
+#### Response
+
+```
+PayloadStatusWithWitness {
+    payload_status: PayloadStatus               # same container, full enum 0/1/2/3
+    witness:        Optional[ExecutionWitness]  # present iff payload_status.status == VALID
+}
+```
+
+`witness` resolves to `List[ExecutionWitness, 1]`: a length-1 list
+holding the witness when `payload_status.status == VALID`, and the empty
+list (`[]`) for `INVALID` / `SYNCING` / `ACCEPTED` or when no witness was
+produced. The endpoint never returns a witness alongside a non-`VALID`
+status. Because `PayloadStatus` and `ExecutionWitness` are both
+variable-size, `PayloadStatusWithWitness` is a two-offset container
+(`payload_status`, then `witness`).
 
 ### `POST /forkchoice`
 

--- a/src/engine/refactor.md
+++ b/src/engine/refactor.md
@@ -168,21 +168,36 @@ doesn't find it there falls back to the `/payloads` +
   `ExecutionPayloadEnvelope{Fork}`. The `Eth-Execution-Version` header
   selects the envelope shape exactly as for `/payloads`.
 
-- **Response body:** SSZ-encoded `PayloadStatusWithWitness`:
+- **Response body:** SSZ-encoded
+  [`PayloadStatusWithWitness`](./refactor-ssz.md#post-payloadswitness),
+  containing `payload_status` and `witness`. Every response with
+  `payload_status.status == VALID` MUST contain exactly one complete
+  `ExecutionWitness` for the submitted payload, including when the
+  payload was already known to be valid. For every other status
+  (`INVALID`, `SYNCING`, `ACCEPTED`), `witness` MUST be the empty list
+  (`[]`). The optional type represents absence for those statuses; it
+  does not make witness delivery optional for `VALID` responses.
 
-  ```
-  PayloadStatusWithWitness {
-      payload_status: PayloadStatus               # same container as /payloads
-      witness:        Optional[ExecutionWitness]  # present iff status == VALID
-  }
-  ```
+  | Field | Contents |
+  | - | - |
+  | `state` | RLP-encoded account and storage trie nodes needed during execution and state-root recomputation |
+  | `codes` | Contract bytecode fetched from the pre-state during execution |
+  | `headers` | RLP-encoded ancestor block headers needed to establish the pre-state and verify `BLOCKHASH` results |
 
-  `witness` is the SSZ `Optional` (`List[T, 1]`): it holds an
-  `ExecutionWitness` only when `payload_status.status == VALID`, and is
-  the empty list (`[]`) for every other status (`INVALID`, `SYNCING`,
-  `ACCEPTED`) or when the EL produced no witness. The witness contains
-  the raw trie nodes, contract bytecodes, and headers needed to
-  statelessly re-execute the block. See
+  `state` and `codes` may be empty only when no material of that category
+  is required for execution or state-root recomputation.
+
+  For Amsterdam, `headers` MUST contain between 1 and 256 headers in
+  oldest-to-newest order, forming a contiguous chain that ends at the
+  payload's parent. Each header after the first MUST reference the hash
+  of the preceding header through its `parent_hash`. The parent header
+  supplies the pre-state root and MUST be included even for an empty
+  block or when execution makes no `BLOCKHASH` queries. Older headers
+  extend that chain as needed to verify `BLOCKHASH` results.
+
+  Field semantics and the exact bytes of each item follow the
+  [execution-specs stateless witness at tests-zkevm@v0.8.4](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.4/src/ethereum/forks/amsterdam/stateless.py).
+  See
   [refactor-ssz.md § `ExecutionWitness`](./refactor-ssz.md#executionwitness)
   for the container and its `MAX_*` bounds.
 

--- a/src/engine/refactor.md
+++ b/src/engine/refactor.md
@@ -20,6 +20,7 @@
 - [Resource model (overview)](#resource-model-overview)
 - [Endpoints](#endpoints)
   - [Payload submission](#payload-submission)
+  - [Payload submission with witness](#payload-submission-with-witness)
   - [Forkchoice update](#forkchoice-update)
   - [Payload retrieval](#payload-retrieval)
   - [Historical bodies](#historical-bodies)
@@ -62,6 +63,7 @@ All hot-path endpoints select the fork via the
 | Old method | New endpoint | Notes |
 | - | - | - |
 | `engine_newPayloadV{1..5}` | `POST /payloads` | `parentBeaconBlockRoot` and `executionRequests` folded into the SSZ envelope; `expectedBlobVersionedHashes` removed; `INVALID_BLOCK_HASH` removed from the status enum |
+| `engine_newPayloadV{1..5}` + `debug_executionWitness` (two calls) | `POST /payloads/witness` | **optional**, Amsterdam+; same request as `/payloads`, response also carries the stateless `ExecutionWitness` so provers / stateless validators get the witness in one round-trip |
 | `engine_forkchoiceUpdatedV{1..4}` | `POST /forkchoice` | one atomic call; carries forkchoice state, optional `payload_attributes`, and (Amsterdam+) optional `custody_columns` |
 | `engine_getPayloadV{1..6}` | `GET /payloads/{id}` | poll-style, same semantics as today |
 | `engine_getPayloadBodiesByHashV{1,2}` | `POST /bodies/hash` | header selects both the response schema and the era of returned blocks; `POST` because hash lists are too large for URLs |
@@ -85,6 +87,7 @@ endpoints ignore it.
 | Resource | Endpoint | Purpose |
 | - | - | - |
 | Payload | `POST /engine/v1/payloads` | Submit a payload received from the CL gossip network for the EL to validate / import. Replaces `engine_newPayload`. Fork-scoped via `Eth-Execution-Version`. |
+| Payload | `POST /engine/v1/payloads/witness` | **Optional (Amsterdam+).** Same as `POST /payloads`, but the response also returns the stateless execution witness. Folds the legacy `engine_newPayload` + `debug_executionWitness` two-call flow into one. Fork-scoped via `Eth-Execution-Version`. |
 | Payload | `GET /engine/v1/payloads/{payloadId}` | Retrieve a built payload by id. Replaces `engine_getPayload`. Fork-scoped via `Eth-Execution-Version`. CL polls when it wants a fresher snapshot. |
 | Forkchoice | `POST /engine/v1/forkchoice` | Atomic forkchoice update: update head/safe/finalized, optionally start a payload build, optionally update custody set. Replaces `engine_forkchoiceUpdated`. Fork-scoped via `Eth-Execution-Version`. |
 | Bodies | `POST /engine/v1/bodies/hash` | Replaces `engine_getPayloadBodiesByHash`. `Eth-Execution-Version` selects both the response schema *and* the era of returned blocks; out-of-era blocks come back as `available=false`. |
@@ -135,6 +138,58 @@ Replaces `engine_newPayloadV{1..5}`.
 
 - **HTTP status:** `200 OK` for any of the four validation outcomes.
   Validation results are not transport errors.
+
+### Payload submission with witness
+
+#### `POST /engine/v1/payloads/witness`
+
+**Optional.** Same request as `POST /payloads`; the response is a
+superset of `PayloadStatus` that additionally carries the **stateless
+execution witness** gathered while validating the block. It folds the
+legacy two-call flow (`engine_newPayload`, then `debug_executionWitness`)
+into a single round-trip.
+
+The motivation is latency for zkVM provers and stateless validators.
+Today they submit the payload, wait for `newPayload`, then issue a
+second JSON-RPC call for the witness and decode a ~500 MB hex-JSON
+blob — which forces them to follow the chain one block behind.
+Returning the witness SSZ-encoded over the same connection, in the same
+call, removes both the extra round-trip and the hex re-encode.
+
+This endpoint is **available from Amsterdam onward** (the fork at which
+stateless witnesses are specified); an `Eth-Execution-Version` below
+Amsterdam returns `400 /engine-api/errors/unsupported-fork`. It is
+optional: ELs that implement it advertise `payloads/witness` in the
+`fork_scoped_endpoints` list of `GET /capabilities`, and a CL that
+doesn't find it there falls back to the `/payloads` +
+`debug_executionWitness` flow.
+
+- **Request body:** identical to `POST /payloads` — SSZ-encoded
+  `ExecutionPayloadEnvelope{Fork}`. The `Eth-Execution-Version` header
+  selects the envelope shape exactly as for `/payloads`.
+
+- **Response body:** SSZ-encoded `PayloadStatusWithWitness`:
+
+  ```
+  PayloadStatusWithWitness {
+      payload_status: PayloadStatus               # same container as /payloads
+      witness:        Optional[ExecutionWitness]  # present iff status == VALID
+  }
+  ```
+
+  `witness` is the SSZ `Optional` (`List[T, 1]`): it holds an
+  `ExecutionWitness` only when `payload_status.status == VALID`, and is
+  the empty list (`[]`) for every other status (`INVALID`, `SYNCING`,
+  `ACCEPTED`) or when the EL produced no witness. The witness contains
+  the raw trie nodes, contract bytecodes, and headers needed to
+  statelessly re-execute the block. See
+  [refactor-ssz.md § `ExecutionWitness`](./refactor-ssz.md#executionwitness)
+  for the container and its `MAX_*` bounds.
+
+- **HTTP status:** `200 OK` for all validation outcomes, exactly as
+  `/payloads`. Validation results are response data, not transport
+  errors; the [error model](#error-model) is otherwise identical to
+  `/payloads`.
 
 ### Forkchoice update
 

--- a/src/engine/refactor.md
+++ b/src/engine/refactor.md
@@ -63,7 +63,7 @@ All hot-path endpoints select the fork via the
 | Old method | New endpoint | Notes |
 | - | - | - |
 | `engine_newPayloadV{1..5}` | `POST /payloads` | `parentBeaconBlockRoot` and `executionRequests` folded into the SSZ envelope; `expectedBlobVersionedHashes` removed; `INVALID_BLOCK_HASH` removed from the status enum |
-| `engine_newPayloadV{1..5}` + `debug_executionWitness` (two calls) | `POST /payloads/witness` | **optional**, Amsterdam+; same request as `/payloads`, response also carries the stateless `ExecutionWitness` so provers / stateless validators get the witness in one round-trip |
+| `engine_newPayloadV{1..5}` + `debug_executionWitness` (two calls) | `POST /payloads/witness` | **optional**, Amsterdam+; same request as `/payloads`, response also carries the stateless `ExecutionWitness` and transaction public keys so provers / stateless validators get both in one round-trip |
 | `engine_forkchoiceUpdatedV{1..4}` | `POST /forkchoice` | one atomic call; carries forkchoice state, optional `payload_attributes`, and (Amsterdam+) optional `custody_columns` |
 | `engine_getPayloadV{1..6}` | `GET /payloads/{id}` | poll-style, same semantics as today |
 | `engine_getPayloadBodiesByHashV{1,2}` | `POST /bodies/hash` | header selects both the response schema and the era of returned blocks; `POST` because hash lists are too large for URLs |
@@ -87,7 +87,7 @@ endpoints ignore it.
 | Resource | Endpoint | Purpose |
 | - | - | - |
 | Payload | `POST /engine/v1/payloads` | Submit a payload received from the CL gossip network for the EL to validate / import. Replaces `engine_newPayload`. Fork-scoped via `Eth-Execution-Version`. |
-| Payload | `POST /engine/v1/payloads/witness` | **Optional (Amsterdam+).** Same as `POST /payloads`, but the response also returns the stateless execution witness. Folds the legacy `engine_newPayload` + `debug_executionWitness` two-call flow into one. Fork-scoped via `Eth-Execution-Version`. |
+| Payload | `POST /engine/v1/payloads/witness` | **Optional (Amsterdam+).** Same as `POST /payloads`, but the response also returns the stateless execution witness and transaction public keys. Folds the legacy `engine_newPayload` + `debug_executionWitness` two-call flow into one. Fork-scoped via `Eth-Execution-Version`. |
 | Payload | `GET /engine/v1/payloads/{payloadId}` | Retrieve a built payload by id. Replaces `engine_getPayload`. Fork-scoped via `Eth-Execution-Version`. CL polls when it wants a fresher snapshot. |
 | Forkchoice | `POST /engine/v1/forkchoice` | Atomic forkchoice update: update head/safe/finalized, optionally start a payload build, optionally update custody set. Replaces `engine_forkchoiceUpdated`. Fork-scoped via `Eth-Execution-Version`. |
 | Bodies | `POST /engine/v1/bodies/hash` | Replaces `engine_getPayloadBodiesByHash`. `Eth-Execution-Version` selects both the response schema *and* the era of returned blocks; out-of-era blocks come back as `available=false`. |
@@ -145,9 +145,10 @@ Replaces `engine_newPayloadV{1..5}`.
 
 **Optional.** Same request as `POST /payloads`; the response is a
 superset of `PayloadStatus` that additionally carries the **stateless
-execution witness** gathered while validating the block. It folds the
-legacy two-call flow (`engine_newPayload`, then `debug_executionWitness`)
-into a single round-trip.
+execution witness** and **transaction public keys** gathered while
+validating the block. It folds the legacy two-call flow
+(`engine_newPayload`, then `debug_executionWitness`) into a single
+round-trip.
 
 The motivation is latency for zkVM provers and stateless validators.
 Today they submit the payload, wait for `newPayload`, then issue a
@@ -155,6 +156,8 @@ second JSON-RPC call for the witness and decode a ~500 MB hex-JSON
 blob — which forces them to follow the chain one block behind.
 Returning the witness SSZ-encoded over the same connection, in the same
 call, removes both the extra round-trip and the hex re-encode.
+Returning transaction public keys also lets proving hosts populate
+`StatelessInput.public_keys` without recovering the keys themselves.
 
 This endpoint is **available from Amsterdam onward** (the fork at which
 stateless witnesses are specified); an `Eth-Execution-Version` below
@@ -170,13 +173,16 @@ doesn't find it there falls back to the `/payloads` +
 
 - **Response body:** SSZ-encoded
   [`PayloadStatusWithWitness`](./refactor-ssz.md#post-payloadswitness),
-  containing `payload_status` and `witness`. Every response with
-  `payload_status.status == VALID` MUST contain exactly one complete
+  containing `payload_status`, `witness`, and `public_keys`. Every
+  response with `payload_status.status == VALID` MUST contain exactly one complete
   `ExecutionWitness` for the submitted payload, including when the
   payload was already known to be valid. For every other status
-  (`INVALID`, `SYNCING`, `ACCEPTED`), `witness` MUST be the empty list
-  (`[]`). The optional type represents absence for those statuses; it
-  does not make witness delivery optional for `VALID` responses.
+  (`INVALID`, `SYNCING`, `ACCEPTED`), both `witness` and `public_keys`
+  MUST be the empty list (`[]`). The optional type represents absence
+  for those statuses; it does not make witness delivery optional for
+  `VALID` responses.
+
+  The `witness` fields are:
 
   | Field | Contents |
   | - | - |
@@ -200,6 +206,29 @@ doesn't find it there falls back to the `/payloads` +
   See
   [refactor-ssz.md § `ExecutionWitness`](./refactor-ssz.md#executionwitness)
   for the container and its `MAX_*` bounds.
+
+  `public_keys` is a sibling of `witness`, matching the separation in
+  `StatelessInput`. For every `VALID` response, it MUST contain exactly
+  one transaction sender public key per entry in `payload.transactions`,
+  in the same order, including when the payload was already known to be
+  valid. Duplicate keys MUST be preserved. An empty transaction list
+  therefore requires an empty `public_keys` list. Each key MUST be the
+  canonical 65-byte uncompressed SEC1 secp256k1 encoding
+  (`0x04 || x || y`, with each coordinate encoded as 32 big-endian bytes)
+  recovered from the corresponding transaction's signature. The list
+  does not include keys for authorization tuples or EVM `ECRECOVER` calls.
+
+  Supplied keys are untrusted inputs to stateless validation. The guest
+  MUST verify that each key validates the corresponding transaction's
+  signature and is consistent with its recovery ID / y-parity, retaining
+  all transaction signature validity checks. Signature verification alone
+  is insufficient because another recovery candidate may derive a
+  different sender. See the
+  [execution-specs public-key verification semantics at tests-zkevm@v0.8.4](https://github.com/ethereum/execution-specs/blob/tests-zkevm%40v0.8.4/src/ethereum/forks/amsterdam/transactions.py#L895).
+
+  EL implementations may retain public keys during sender recovery or
+  recover them when serving this endpoint; a cached sender address alone
+  is insufficient to construct this field.
 
 - **HTTP status:** `200 OK` for all validation outcomes, exactly as
   `/payloads`. Validation results are response data, not transport


### PR DESCRIPTION
_Note: this PR is based on previous work from @developeruche, plus some extra refinements_

This PR adds `POST /engine/v1/payloads/witness` to the REST + SSZ proposal. It lets zkVM provers and stateless validators submit a payload and receive its validation result, execution witness, and transaction sender public keys in one call, avoiding a separate witness request and hex-JSON encoding.

The endpoint is optional from Amsterdam onward and advertised through capabilities. It accepts the same request as `/payloads`. Every `VALID` response must include a complete witness, including for already-known payloads; other statuses must omit it.

Responses also include `public_keys`, allowing proving hosts to populate `StatelessInput.public_keys` without recovering keys themselves. For `VALID` payloads, including already-known payloads, the list contains one 65-byte uncompressed sender public key per transaction, in transaction order; for other statuses, it is empty. Stateless validators must still verify the supplied keys against transaction signatures and recovery IDs.

The proposal defines witness contents, public-key semantics, SSZ containers, and size bounds. Behavioral requirements live in `refactor.md`; encoding definitions live in `refactor-ssz.md`.
