### PR TITLE
engine: add optional parentBlockHash to engine_getInclusionListV1

### DIFF
--- a/src/engine/bogota.md
+++ b/src/engine/bogota.md
@@ -112,7 +112,8 @@ This method follows the same specification as [`engine_newPayloadV5`](./amsterda
 #### Request
 
 * method: `engine_getInclusionListV1`
-* params: []
+* params:
+  1. `parentBlockHash`: `DATA|null`, 32 Bytes - hash of the block the inclusion list must be appendable to, or `null` to use the client's current head.
 * timeout: 1s
 
 #### Response
@@ -122,7 +123,7 @@ This method follows the same specification as [`engine_newPayloadV5`](./amsterda
 
 #### Specification
 
-1. Client software **MUST** provide, based on its local view of the mempool, a list of transactions for the inclusion list satisfying the following conditions:
+1. Client software **MUST** provide, based on its local view of the mempool, a list of transactions valid for inclusion in a block built on top of the block identified by `parentBlockHash` (or the current head, if `null`), satisfying the following conditions:
 
     1. Every transaction **MUST** have non-zero length (at least 1 byte).
 
@@ -131,6 +132,8 @@ This method follows the same specification as [`engine_newPayloadV5`](./amsterda
     3. The total byte length of the transaction list **MUST NOT** exceed `MAX_TRANSACTIONS_BYTES_PER_INCLUSION_LIST`.
 
 2. The strategy for selecting transactions is implementation dependent.
+
+3. If `parentBlockHash` is not `null` and does not identify a known block, client software **MUST** return `-32602: Invalid params`.
 
 ### engine_forkchoiceUpdatedV5
 

--- a/src/engine/openrpc/methods/inclusion_list.yaml
+++ b/src/engine/openrpc/methods/inclusion_list.yaml
@@ -3,10 +3,19 @@
   externalDocs:
     description: Method specification
     url: https://github.com/ethereum/execution-apis/blob/main/src/engine/bogota.md#engine_getinclusionlistv1
-  params: []
+  params:
+    - name: Parent block hash
+      required: false
+      schema:
+        oneOf:
+          - $ref: '#/components/schemas/hash32'
+          - type: 'null'
   result:
     name: Inclusion list transactions
     schema:
       type: array
       items:
         $ref: '#/components/schemas/bytes'
+  errors:
+    - code: -32602
+      message: Invalid params


### PR DESCRIPTION
## Summary

`engine_getInclusionListV1` currently specifies `params: []`. This adds an optional
`parentBlockHash` parameter: the hash of the block the returned list must be appendable
to, defaulting to the current head when omitted or `null`.

## Motivation

The candidate transactions for an inclusion list are only valid relative to a specific
parent — for example, filtering by the base fee of the block the list will be appended
after. The consensus layer decides which block it is building on, but that decision and
the `engine_getInclusionListV1` call are two separate round trips, during which the
execution layer's head can move. Without a way to name the intended parent, a list built
against the wrong one is silently unappendable, and the execution layer has no way to
detect this.

## Changes

- `src/engine/bogota.md`: document the optional `parentBlockHash` parameter and require
  `-32602: Invalid params` when it names an unknown block.
- `src/engine/openrpc/methods/inclusion_list.yaml`: add the parameter (optional, nullable
  `hash32`) and the corresponding error to the OpenRPC schema.

The parameter is optional and defaults to current behavior, so existing callers that send
no arguments are unaffected.

## Checks

- `make build` and `make test` (`speccheck`) pass.
- `make lint` shows no new warning categories beyond ones already present for comparable
  optional parameters (e.g. `engine_forkchoiceUpdatedV5`'s `custodyColumns`).
